### PR TITLE
feat(inquisitor): FR-142 add worktree gate to suppress audit in enforce pipeline

### DIFF
--- a/.chaplain/inquisitor.sh
+++ b/.chaplain/inquisitor.sh
@@ -3,6 +3,7 @@
 # FR-076: Quotes the Scripture, audits recent work, writes diary entry
 # FR-118: --propose flag detects persistent violations and writes fix proposals to inbox
 # FR-131: Commit-delta gate aborts when no feat/fix commits since last audit
+# FR-142: Worktree gate suppresses audit in git worktrees (enforce pipeline)
 # Usage: .chaplain/inquisitor.sh [--force] [--propose]
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -16,6 +17,16 @@ while [[ $# -gt 0 ]]; do
         *) shift ;;
     esac
 done
+
+# --- Worktree gate (FR-142) ---
+# In a git worktree, .git is a file (gitdir pointer), not a directory.
+# Suppress audit during enforce pipeline — intermediate commits are WIP.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.git" && -z "$FORCE" ]]; then
+    echo "⏭️  Inquisitor: Running in a git worktree (enforce pipeline in progress). Skipping audit."
+    echo "   Audits run on main after the FR/PR is merged. Use --force to override."
+    exit 0
+fi
 
 # --- Commit-delta gate (FR-131, FR-134) ---
 # Extract HEAD SHA from the last audit's commit range in docs/diary/.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -315,6 +315,7 @@ YAMLGraph implements **19 capabilities** covering **68 requirements**. Each capa
 | 39 | Inquisitor Commit-Delta Gate | `.chaplain/inquisitor.sh` | REQ-YG-131 |
 | 40 | Enforce Pipeline Graph Delegation | `scripts/enforce_worktree.sh`, `examples/enforce/graph.yaml` | REQ-YG-128 |
 | 41 | Clean GIT_* Test Fixture | `tests/conftest.py` | REQ-YG-140 |
+| 42 | Inquisitor Worktree Gate | `.chaplain/inquisitor.sh` | REQ-YG-142 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -678,6 +679,14 @@ Session-scoped autouse pytest fixture strips `GIT_*` environment variables injec
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-140 | `_clean_git_env` session-scoped autouse fixture strips all `GIT_*` env vars at session start, restores on teardown; no-op when vars absent; prevents pre-commit `GIT_DIR`/`GIT_WORK_TREE` from leaking into subprocess git calls in `tmp_path`-based test repos | `tests/conftest.py`, `tests/unit/test_clean_git_env` |
+
+### 42. Inquisitor Worktree Gate (FR-142)
+
+`inquisitor.sh` worktree gate detects git worktree context (`-f "$REPO_ROOT/.git"`) and exits early, suppressing audit and propose phases during enforce pipeline. Placed before commit-delta gate (FR-131); `--force` bypasses.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-142 | `inquisitor.sh` worktree gate checks `-f "$REPO_ROOT/.git"` (file = worktree, directory = main), exits 0 with message when in worktree; `--force` bypasses gate; degrades gracefully when `git rev-parse` fails; gate placed before commit-delta gate (FR-131); pure shell, no Python | `.chaplain/inquisitor.sh`, `tests/unit/test_inquisitor_worktree_gate` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-142 Inquisitor Worktree Gate**: Add worktree-detection gate to `inquisitor.sh` that suppresses audit and propose phases when running inside a git worktree (enforce pipeline). Detects via `-f "$REPO_ROOT/.git"`; `--force` bypasses. Placed before commit-delta gate (FR-131). (REQ-YG-142)
 - **FR-140 Clean GIT_* Test Fixture**: Session-scoped autouse pytest fixture strips `GIT_*` env vars injected by pre-commit, preventing subprocess bleed into `tmp_path`-based test repos. Closes the `--no-verify` bypass loophole. (REQ-YG-140)
 - **FR-134 Diary Folder Refactor — Replace Single File with Date-Prefixed Entries**: Replace the monolithic `docs/diary.md` with a `docs/diary/` folder of date-prefixed entry files, eliminating merge conflicts caused by concurrent appends from `finalize_merge.sh`, `diary_rotate.py`, `inquisitor.sh`, and `examples/shared/diary.py`. (REQ-YG-131)
 - **FR-131 Inquisitor commit-delta gate**: Add a pre-flight gate to `inquisitor.sh` that aborts when no `feat:` or `fix:` commits exist since the last audit, breaking the ritual loop documented in Audits XI–XIII.

--- a/feature-requests/FR-142-inquisitor-worktree-gate.md
+++ b/feature-requests/FR-142-inquisitor-worktree-gate.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Enhancement
-**Status:** Approved
+**Status:** ✅ Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-08
 

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -37,6 +37,7 @@ _ALL_FRAMEWORK_REQS = (
     + [128]  # REQ-YG-128 (CAP-40 Enforce Pipeline Graph Delegation)
     + [131]  # REQ-YG-131 (CAP-39 Inquisitor Commit-Delta Gate)
     + [140]  # REQ-YG-140 (CAP-41 Clean GIT_* Test Fixture)
+    + [142]  # REQ-YG-142 (CAP-42 Inquisitor Worktree Gate)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -206,6 +207,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-39": ("Inquisitor Commit-Delta Gate", ["REQ-YG-131"]),
     "CAP-40": ("Enforce Pipeline Graph Delegation", ["REQ-YG-128"]),
     "CAP-41": ("Clean GIT Env Test Fixture", ["REQ-YG-140"]),
+    "CAP-42": ("Inquisitor Worktree Gate", ["REQ-YG-142"]),
 }
 
 

--- a/tests/unit/test_inquisitor_worktree_gate.py
+++ b/tests/unit/test_inquisitor_worktree_gate.py
@@ -1,0 +1,220 @@
+"""Unit tests for inquisitor.sh worktree gate (FR-142).
+
+Tests the worktree-detection gate that suppresses audit and propose phases
+when running inside a git worktree (i.e., during an enforce pipeline).
+The gate fires before the commit-delta gate (FR-131) and is bypassed by --force.
+
+Detection method: in a worktree, the repo root's .git is a *file* (gitdir pointer),
+not a *directory*. The gate checks `-f "$REPO_ROOT/.git"`.
+"""
+
+import os
+import subprocess
+import textwrap
+
+import pytest
+
+# Strip git env vars that pre-commit injects (GIT_INDEX_FILE from stashing).
+_GIT_ENV_POISON = {"GIT_INDEX_FILE", "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"}
+
+
+def _clean_git_env(**extra: str) -> dict[str, str]:
+    """Return os.environ minus git vars that pollute temp-repo subprocess calls."""
+    env = {k: v for k, v in os.environ.items() if k not in _GIT_ENV_POISON}
+    env.update(extra)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Shell snippet — mirrors the worktree gate logic for isolated testing
+# ---------------------------------------------------------------------------
+
+_WORKTREE_GATE_SCRIPT = textwrap.dedent("""\
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "$TEST_DIR"
+
+    # Parse flags
+    FORCE=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --force) FORCE="true"; shift ;;
+            *) shift ;;
+        esac
+    done
+
+    # --- Worktree gate (FR-142) ---
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+    if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.git" && -z "$FORCE" ]]; then
+        echo "WORKTREE_GATE_BLOCKED"
+        exit 0
+    fi
+
+    echo "WORKTREE_GATE_PASSED"
+""")
+
+
+def _run_gate(test_dir: str, *args: str) -> subprocess.CompletedProcess:
+    """Run the worktree gate script in the given directory."""
+    return subprocess.run(
+        ["bash", "-c", _WORKTREE_GATE_SCRIPT, "--", *args],
+        capture_output=True,
+        text=True,
+        env=_clean_git_env(TEST_DIR=str(test_dir)),
+        timeout=10,
+    )
+
+
+def _init_repo(path) -> None:
+    """Initialise a minimal git repo with one commit."""
+    env = _clean_git_env()
+    subprocess.run(
+        ["git", "init"], cwd=str(path), env=env, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test"],
+        cwd=str(path),
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(path),
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+    (path / "README.md").write_text("init")
+    subprocess.run(
+        ["git", "add", "."], cwd=str(path), env=env, capture_output=True, check=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=str(path),
+        env=env,
+        capture_output=True,
+        check=True,
+    )
+
+
+@pytest.mark.req("REQ-YG-142")
+class TestWorktreeGateDetection:
+    """Tests that the gate detects worktree vs main context."""
+
+    def test_gate_passes_in_normal_repo(self, tmp_path):
+        """Normal repo (.git is a directory) → gate passes."""
+        _init_repo(tmp_path)
+        result = _run_gate(tmp_path)
+        assert result.returncode == 0
+        assert "WORKTREE_GATE_PASSED" in result.stdout
+
+    def test_gate_blocks_in_worktree(self, tmp_path):
+        """Worktree (.git is a file) → gate blocks."""
+        _init_repo(tmp_path)
+        env = _clean_git_env()
+        wt_path = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "worktree", "add", str(wt_path), "-b", "test-wt"],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            check=True,
+        )
+        # Verify .git is a file in worktree
+        assert (wt_path / ".git").is_file(), ".git should be a file in worktree"
+
+        result = _run_gate(wt_path)
+        assert result.returncode == 0
+        assert "WORKTREE_GATE_BLOCKED" in result.stdout
+
+    def test_gate_passes_when_git_not_available(self, tmp_path):
+        """Non-git directory → gate degrades gracefully (passes)."""
+        # tmp_path is not a git repo; git rev-parse will fail
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                textwrap.dedent("""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                cd "$TEST_DIR"
+                FORCE=""
+                REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+                if [[ -n "$REPO_ROOT" && -f "$REPO_ROOT/.git" && -z "$FORCE" ]]; then
+                    echo "WORKTREE_GATE_BLOCKED"
+                    exit 0
+                fi
+                echo "WORKTREE_GATE_PASSED"
+            """),
+            ],
+            capture_output=True,
+            text=True,
+            env=_clean_git_env(TEST_DIR=str(tmp_path)),
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "WORKTREE_GATE_PASSED" in result.stdout
+
+
+@pytest.mark.req("REQ-YG-142")
+class TestWorktreeGateForceBypass:
+    """Tests that --force bypasses the worktree gate."""
+
+    def test_force_bypasses_gate_in_worktree(self, tmp_path):
+        """--force in a worktree → gate passes."""
+        _init_repo(tmp_path)
+        env = _clean_git_env()
+        wt_path = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "worktree", "add", str(wt_path), "-b", "test-force-wt"],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            check=True,
+        )
+        result = _run_gate(wt_path, "--force")
+        assert result.returncode == 0
+        assert "WORKTREE_GATE_PASSED" in result.stdout
+
+    def test_force_still_passes_in_normal_repo(self, tmp_path):
+        """--force in normal repo → gate passes (no-op)."""
+        _init_repo(tmp_path)
+        result = _run_gate(tmp_path, "--force")
+        assert result.returncode == 0
+        assert "WORKTREE_GATE_PASSED" in result.stdout
+
+
+@pytest.mark.req("REQ-YG-142")
+class TestWorktreeGateInFullScript:
+    """Integration test: verify the actual inquisitor.sh contains the worktree gate."""
+
+    def test_inquisitor_script_contains_worktree_gate(self):
+        """The inquisitor.sh script must contain the FR-142 worktree gate."""
+        script_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", ".chaplain", "inquisitor.sh"
+        )
+        assert os.path.exists(script_path), f"inquisitor.sh not found at {script_path}"
+        with open(script_path) as f:
+            content = f.read()
+        assert (
+            "Worktree gate" in content
+            or "worktree gate" in content
+            or "FR-142" in content
+        ), "inquisitor.sh must contain the FR-142 worktree gate"
+
+    def test_worktree_gate_before_commit_delta_gate(self):
+        """Worktree gate must appear before the commit-delta gate in inquisitor.sh."""
+        script_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", ".chaplain", "inquisitor.sh"
+        )
+        with open(script_path) as f:
+            content = f.read()
+        # Match the gate section markers, not header comments
+        wt_pos = content.find("# --- Worktree gate (FR-142)")
+        delta_pos = content.find("# --- Commit-delta gate (FR-131")
+        assert wt_pos != -1, "FR-142 gate section not found in inquisitor.sh"
+        assert delta_pos != -1, "FR-131 gate section not found in inquisitor.sh"
+        assert (
+            wt_pos < delta_pos
+        ), "Worktree gate (FR-142) must appear before commit-delta gate (FR-131)"


### PR DESCRIPTION
## Summary

Add a worktree-detection gate to `inquisitor.sh` that suppresses audit and propose phases when running inside a git worktree (enforce pipeline), ensuring the Inquisitor only fires on completed work on the main working tree.

## Changes

- **Worktree gate** in `.chaplain/inquisitor.sh`: checks `-f "$REPO_ROOT/.git"` (file = worktree, directory = main)
- Gate placed **before** commit-delta gate (FR-131) — cheaper and more decisive
- `--force` bypasses gate, consistent with FR-131 pattern
- Degrades gracefully when `git rev-parse` fails
- **7 tests** covering detection, force bypass, graceful degradation, script integration
- `ARCHITECTURE.md`: CAP-42 / REQ-YG-142
- `scripts/req_coverage.py`: new capability registered
- `CHANGELOG.md`: entry under \[Unreleased\]

See FR at `feature-requests/FR-142-inquisitor-worktree-gate.md`