### PR TITLE
feat(scripts): FR-138 add copilot session GC script

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -315,6 +315,7 @@ YAMLGraph implements **19 capabilities** covering **68 requirements**. Each capa
 | 39 | Inquisitor Commit-Delta Gate | `.chaplain/inquisitor.sh` | REQ-YG-131 |
 | 40 | Enforce Pipeline Graph Delegation | `scripts/enforce_worktree.sh`, `examples/enforce/graph.yaml` | REQ-YG-128 |
 | 41 | Clean GIT_* Test Fixture | `tests/conftest.py` | REQ-YG-140 |
+| 42 | Copilot Session GC | `scripts/copilot_session_gc.sh` | REQ-YG-141 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -678,6 +679,14 @@ Session-scoped autouse pytest fixture strips `GIT_*` environment variables injec
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-140 | `_clean_git_env` session-scoped autouse fixture strips all `GIT_*` env vars at session start, restores on teardown; no-op when vars absent; prevents pre-commit `GIT_DIR`/`GIT_WORK_TREE` from leaking into subprocess git calls in `tmp_path`-based test repos | `tests/conftest.py`, `tests/unit/test_clean_git_env` |
+
+### 42. Copilot Session GC (FR-138)
+
+Shell script that prunes stale Copilot CLI sessions from `~/.copilot/session-state/` based on age. Supports `--max-age`, `--dry-run`, `--verbose` flags and protects the active session via `$COPILOT_SESSION_ID`.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-141 | `copilot_session_gc.sh` removes session directories older than `--max-age` days (default 7); `--dry-run` lists candidates without deleting; active session (`$COPILOT_SESSION_ID`) is never removed; exits cleanly when directory is missing; idempotent; logs UUID and age for each removed session | `scripts/copilot_session_gc.sh`, `tests/unit/test_copilot_session_gc` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-138 Copilot Session GC**: Shell script `scripts/copilot_session_gc.sh` prunes stale Copilot CLI sessions older than `--max-age` days (default 7). Supports `--dry-run` preview and protects the active session via `$COPILOT_SESSION_ID`. (REQ-YG-141)
 - **FR-140 Clean GIT_* Test Fixture**: Session-scoped autouse pytest fixture strips `GIT_*` env vars injected by pre-commit, preventing subprocess bleed into `tmp_path`-based test repos. Closes the `--no-verify` bypass loophole. (REQ-YG-140)
 - **FR-134 Diary Folder Refactor — Replace Single File with Date-Prefixed Entries**: Replace the monolithic `docs/diary.md` with a `docs/diary/` folder of date-prefixed entry files, eliminating merge conflicts caused by concurrent appends from `finalize_merge.sh`, `diary_rotate.py`, `inquisitor.sh`, and `examples/shared/diary.py`. (REQ-YG-131)
 - **FR-131 Inquisitor commit-delta gate**: Add a pre-flight gate to `inquisitor.sh` that aborts when no `feat:` or `fix:` commits exist since the last audit, breaking the ritual loop documented in Audits XI–XIII.

--- a/scripts/copilot_session_gc.sh
+++ b/scripts/copilot_session_gc.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# copilot_session_gc.sh — Prune stale Copilot CLI sessions (FR-138)
+#
+# Usage:
+#   scripts/copilot_session_gc.sh [--max-age DAYS] [--dry-run] [--verbose]
+#
+# Defaults: --max-age 7
+#
+# Environment:
+#   COPILOT_SESSION_DIR  Override session directory (default: ~/.copilot/session-state)
+#   COPILOT_SESSION_ID   Active session UUID to protect from deletion
+
+set -euo pipefail
+
+MAX_AGE_DAYS=7
+DRY_RUN=false
+VERBOSE=false
+SESSION_DIR="${COPILOT_SESSION_DIR:-$HOME/.copilot/session-state}"
+ACTIVE_SESSION="${COPILOT_SESSION_ID:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --max-age)
+            MAX_AGE_DAYS="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -d "$SESSION_DIR" ]]; then
+    [[ "$VERBOSE" == true ]] && echo "Session directory does not exist: $SESSION_DIR"
+    echo "🧹 Copilot session GC: 0 removed, 0 kept (directory absent)"
+    exit 0
+fi
+
+removed=0
+kept=0
+skipped_active=0
+now=$(date +%s)
+
+for entry in "$SESSION_DIR"/*/; do
+    # Skip if glob didn't match (empty directory)
+    [[ -d "$entry" ]] || continue
+
+    uuid=$(basename "$entry")
+
+    # Protect active session
+    if [[ -n "$ACTIVE_SESSION" && "$uuid" == "$ACTIVE_SESSION" ]]; then
+        skipped_active=1
+        echo "⏭  skip active session: $uuid"
+        kept=$((kept + 1))
+        continue
+    fi
+
+    # Calculate age in days using directory mtime
+    if [[ "$(uname)" == "Darwin" ]]; then
+        mtime=$(stat -f %m "$entry")
+    else
+        mtime=$(stat -c %Y "$entry")
+    fi
+    age_days=$(( (now - mtime) / 86400 ))
+
+    if [[ $age_days -ge $MAX_AGE_DAYS ]]; then
+        if [[ "$DRY_RUN" == true ]]; then
+            echo "🔍 would remove: $uuid (${age_days}d old)"
+        else
+            rm -rf "$entry"
+            echo "🗑  removed: $uuid (${age_days}d old)"
+        fi
+        removed=$((removed + 1))
+    else
+        [[ "$VERBOSE" == true ]] && echo "✓  keep: $uuid (${age_days}d old)"
+        kept=$((kept + 1))
+    fi
+done
+
+action="removed"
+[[ "$DRY_RUN" == true ]] && action="would remove"
+
+echo "🧹 Copilot session GC: $removed $action, $kept kept (max-age: ${MAX_AGE_DAYS}d)"

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -37,6 +37,7 @@ _ALL_FRAMEWORK_REQS = (
     + [128]  # REQ-YG-128 (CAP-40 Enforce Pipeline Graph Delegation)
     + [131]  # REQ-YG-131 (CAP-39 Inquisitor Commit-Delta Gate)
     + [140]  # REQ-YG-140 (CAP-41 Clean GIT_* Test Fixture)
+    + [141]  # REQ-YG-141 (CAP-42 Copilot Session GC)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -206,6 +207,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-39": ("Inquisitor Commit-Delta Gate", ["REQ-YG-131"]),
     "CAP-40": ("Enforce Pipeline Graph Delegation", ["REQ-YG-128"]),
     "CAP-41": ("Clean GIT Env Test Fixture", ["REQ-YG-140"]),
+    "CAP-42": ("Copilot Session GC", ["REQ-YG-141"]),
 }
 
 

--- a/tests/unit/test_copilot_session_gc.py
+++ b/tests/unit/test_copilot_session_gc.py
@@ -1,0 +1,256 @@
+"""Unit tests for copilot_session_gc.sh (FR-138).
+
+Tests verify the shell script correctly prunes stale Copilot CLI sessions
+based on age, respects --dry-run, protects active sessions, and handles
+edge cases (missing directory, idempotency).
+
+All tests use a temporary directory as COPILOT_SESSION_DIR to avoid
+touching real session state.
+"""
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "copilot_session_gc.sh"
+
+
+def _make_session(session_dir: Path, uuid: str, age_days: int = 0) -> Path:
+    """Create a fake session directory with controlled mtime."""
+    d = session_dir / uuid
+    d.mkdir(parents=True)
+    (d / "workspace.yaml").write_text(f"session: {uuid}\n")
+    if age_days > 0:
+        old_ts = time.time() - (age_days * 86400 + 60)
+        os.utime(d, (old_ts, old_ts))
+        os.utime(d / "workspace.yaml", (old_ts, old_ts))
+    return d
+
+
+def _run_gc(
+    session_dir: Path,
+    *,
+    max_age: int | None = None,
+    dry_run: bool = False,
+    verbose: bool = False,
+    active_session: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the GC script against a test session directory."""
+    cmd = [str(SCRIPT)]
+    if max_age is not None:
+        cmd += ["--max-age", str(max_age)]
+    if dry_run:
+        cmd.append("--dry-run")
+    if verbose:
+        cmd.append("--verbose")
+
+    env = {**os.environ, "COPILOT_SESSION_DIR": str(session_dir)}
+    if active_session:
+        env["COPILOT_SESSION_ID"] = active_session
+
+    return subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+
+# ---------------------------------------------------------------------------
+# Age-Based Filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-141")
+class TestAgeFiltering:
+    """Sessions older than --max-age are removed; newer ones are kept."""
+
+    def test_old_sessions_removed(self, tmp_path):
+        """Sessions older than max-age are deleted."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "old-session-aaa", age_days=10)
+        _make_session(session_dir, "new-session-bbb", age_days=0)
+
+        result = _run_gc(session_dir, max_age=7)
+        assert result.returncode == 0
+
+        assert not (session_dir / "old-session-aaa").exists()
+        assert (session_dir / "new-session-bbb").exists()
+
+    def test_custom_max_age(self, tmp_path):
+        """--max-age 2 removes sessions older than 2 days."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "three-day-old", age_days=3)
+        _make_session(session_dir, "one-day-old", age_days=1)
+
+        result = _run_gc(session_dir, max_age=2)
+        assert result.returncode == 0
+
+        assert not (session_dir / "three-day-old").exists()
+        assert (session_dir / "one-day-old").exists()
+
+    def test_default_max_age_is_7(self, tmp_path):
+        """Default max-age of 7 days: 8-day-old removed, 5-day-old kept."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "eight-day-old", age_days=8)
+        _make_session(session_dir, "five-day-old", age_days=5)
+
+        result = _run_gc(session_dir)
+        assert result.returncode == 0
+
+        assert not (session_dir / "eight-day-old").exists()
+        assert (session_dir / "five-day-old").exists()
+
+
+# ---------------------------------------------------------------------------
+# Dry Run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-141")
+class TestDryRun:
+    """--dry-run lists sessions without deleting them."""
+
+    def test_dry_run_preserves_sessions(self, tmp_path):
+        """--dry-run does not delete any sessions."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "old-to-delete", age_days=10)
+
+        result = _run_gc(session_dir, max_age=7, dry_run=True)
+        assert result.returncode == 0
+
+        # Session must still exist
+        assert (session_dir / "old-to-delete").exists()
+
+    def test_dry_run_lists_candidates(self, tmp_path):
+        """--dry-run output mentions the session UUID."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "old-to-delete", age_days=10)
+
+        result = _run_gc(session_dir, max_age=7, dry_run=True)
+        assert "old-to-delete" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Active Session Protection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-141")
+class TestActiveSessionProtection:
+    """The session matching $COPILOT_SESSION_ID is never deleted."""
+
+    def test_active_session_preserved(self, tmp_path):
+        """Active session is kept even when older than max-age."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "active-uuid", age_days=30)
+        _make_session(session_dir, "stale-uuid", age_days=30)
+
+        result = _run_gc(session_dir, max_age=7, active_session="active-uuid")
+        assert result.returncode == 0
+
+        assert (session_dir / "active-uuid").exists()
+        assert not (session_dir / "stale-uuid").exists()
+
+    def test_active_session_logged_as_skipped(self, tmp_path):
+        """Output notes the active session was skipped."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "active-uuid", age_days=30)
+
+        result = _run_gc(session_dir, max_age=7, active_session="active-uuid")
+        assert "active-uuid" in result.stdout
+        assert "skip" in result.stdout.lower() or "active" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-141")
+class TestEdgeCases:
+    """Script handles missing directory, empty directory, and non-session files."""
+
+    def test_missing_directory_exits_cleanly(self, tmp_path):
+        """Script exits 0 when session directory does not exist."""
+        nonexistent = tmp_path / "does-not-exist"
+        result = _run_gc(nonexistent)
+        assert result.returncode == 0
+
+    def test_empty_directory(self, tmp_path):
+        """Script exits 0 when session directory is empty."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        result = _run_gc(session_dir)
+        assert result.returncode == 0
+
+    def test_idempotent(self, tmp_path):
+        """Running GC twice produces the same result (no errors on second run)."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "old-one", age_days=10)
+
+        result1 = _run_gc(session_dir, max_age=7)
+        assert result1.returncode == 0
+        assert not (session_dir / "old-one").exists()
+
+        result2 = _run_gc(session_dir, max_age=7)
+        assert result2.returncode == 0
+
+    def test_non_directory_files_ignored(self, tmp_path):
+        """Regular files in session-state/ are not deleted."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        (session_dir / "some-file.txt").write_text("not a session\n")
+        old_ts = time.time() - (30 * 86400)
+        os.utime(session_dir / "some-file.txt", (old_ts, old_ts))
+
+        result = _run_gc(session_dir, max_age=7)
+        assert result.returncode == 0
+        assert (session_dir / "some-file.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-141")
+class TestLogging:
+    """Deleted sessions are logged with UUID and age."""
+
+    def test_deleted_session_logged_with_uuid(self, tmp_path):
+        """Output includes the UUID of each deleted session."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "logged-uuid-123", age_days=10)
+
+        result = _run_gc(session_dir, max_age=7)
+        assert "logged-uuid-123" in result.stdout
+
+    def test_deleted_session_logged_with_age(self, tmp_path):
+        """Output includes the age in days of each deleted session."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "aged-session", age_days=10)
+
+        result = _run_gc(session_dir, max_age=7)
+        # Should mention "10" days somewhere in the output
+        assert "10" in result.stdout
+
+    def test_summary_count(self, tmp_path):
+        """Output includes a summary count of removed sessions."""
+        session_dir = tmp_path / "session-state"
+        session_dir.mkdir()
+        _make_session(session_dir, "rm-1", age_days=10)
+        _make_session(session_dir, "rm-2", age_days=10)
+        _make_session(session_dir, "keep-1", age_days=1)
+
+        result = _run_gc(session_dir, max_age=7)
+        # Should mention "2" removed
+        assert "2" in result.stdout


### PR DESCRIPTION
## FR-138: Copilot Session Cleanup Script

Adds `scripts/copilot_session_gc.sh` — a shell script to prune stale Copilot CLI sessions from `~/.copilot/session-state/`.

### Changes
- **`scripts/copilot_session_gc.sh`** — age-based session pruning with `--max-age`, `--dry-run`, `--verbose` flags
- **`tests/unit/test_copilot_session_gc.py`** — 14 unit tests covering age filtering, dry-run, active session protection, edge cases
- **`ARCHITECTURE.md`** — added REQ-YG-138 requirement
- **`scripts/req_coverage.py`** — extended ALL_REQS range to include 138
- **`CHANGELOG.md`** — added entry

### Key Design Decisions
- Shell script (not Python) — runs outside venv, no yamlgraph dependency
- Age-based pruning (not count-based) — simple, predictable
- `--dry-run` for safe preview before deletion
- Protects active session via `$COPILOT_SESSION_ID`

See FR at `feature-requests/FR-138-copilot-session-cleanup.md`
