### PR TITLE
feat(provider): FR-137 add DeepSeek LLM provider

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -216,8 +216,9 @@ See [examples/npc/architecture.md](examples/npc/architecture.md) for full docume
 ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
 │ llm_factory.py  │  │ schema_loader.py│  │ utils/prompts.py│
 │ • Multi-provider│  │ • YAML → Pydantic│ │ • load_prompt() │
-│ • 8 providers:  │  │ • JSON Schema   │  │ • resolve_path()│
+│ • 9 providers:  │  │ • JSON Schema   │  │ • resolve_path()│
 │   Anthropic,    │  └─────────────────┘  └─────────────────┘
+│   DeepSeek,     │
 │   Google/Gemini,│
 │   Inception,    │
 │   Mistral,      │
@@ -1198,7 +1199,7 @@ _loading_stack: ContextVar[list[Path]] = ContextVar("loading_stack")
 | `tools/shell.py` | Shell tool execution | 5 |
 | `tools/python_tool.py` | Python tool integration | 5 |
 | `tools/nodes.py` | Tool node creation | 5 |
-| `utils/llm_factory.py` | Multi-provider LLM factory (8 providers) | 3 |
+| `utils/llm_factory.py` | Multi-provider LLM factory (9 providers) | 3 |
 | `utils/llm_factory_async.py` | Async LLM factory | 3 |
 | `utils/expressions.py` | Template and state path resolution | 4 |
 | `utils/conditions.py` | Condition expression evaluation | 6 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,9 +336,10 @@ The codebase uses **sync-first with async wrappers**:
 | `MISTRAL_API_KEY` | Mistral authentication |
 | `OPENAI_API_KEY` | OpenAI authentication |
 | `REPLICATE_API_TOKEN` | Replicate authentication |
+| `DEEPSEEK_API_KEY` | DeepSeek authentication |
 | `XAI_API_KEY` | xAI Grok authentication |
 | `LMSTUDIO_BASE_URL` | LM Studio local server URL |
-| `PROVIDER` | Default LLM provider (anthropic/google/inception/mistral/openai/replicate/xai/lmstudio) |
+| `PROVIDER` | Default LLM provider (anthropic/deepseek/google/inception/mistral/openai/replicate/xai/lmstudio) |
 | `LANGCHAIN_TRACING_V2` | Enable LangSmith observability (true/false) |
 | `LANGCHAIN_API_KEY` | LangSmith API key |
 | `LANGCHAIN_PROJECT` | LangSmith project name |

--- a/reference/getting-started.md
+++ b/reference/getting-started.md
@@ -148,6 +148,7 @@ except Exception as e:
 | `MISTRAL_API_KEY` | Mistral auth |
 | `OPENAI_API_KEY` | OpenAI auth |
 | `REPLICATE_API_TOKEN` | Replicate auth |
+| `DEEPSEEK_API_KEY` | DeepSeek auth |
 | `XAI_API_KEY` | xAI Grok auth |
 | `LMSTUDIO_BASE_URL` | LM Studio local URL |
 | `PROVIDER` | Default provider |
@@ -162,6 +163,7 @@ except Exception as e:
 | `inception` | mercury-2 | Diffusion LLM, 660 t/s, best for structured output |
 | `mistral` | mistral-large-latest | Good cost/quality balance |
 | `openai` | gpt-4.1 | Widely supported |
+| `deepseek` | deepseek-chat, deepseek-reasoner | Reasoning models |
 | `replicate` | meta/llama-* | Open model hosting |
 | `xai` | grok-beta | Alternative |
 | `lmstudio` | local | Local inference |

--- a/tests/integration/test_providers.py
+++ b/tests/integration/test_providers.py
@@ -39,6 +39,20 @@ class TestProviderIntegration:
         assert len(result) > 0
 
     @pytest.mark.skipif(
+        not os.getenv("DEEPSEEK_API_KEY"), reason="DEEPSEEK_API_KEY not set"
+    )
+    @pytest.mark.req("REQ-YG-010")
+    def test_execute_prompt_with_deepseek_provider(self):
+        """Should execute prompt with DeepSeek provider."""
+        result = execute_prompt(
+            prompt_name="greet",
+            variables={"name": "Dan", "style": "casual"},
+            provider="deepseek",
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.skipif(
         not os.getenv("MISTRAL_API_KEY"), reason="MISTRAL_API_KEY not set"
     )
     @pytest.mark.req("REQ-YG-010")

--- a/tests/unit/test_architecture_provider_count.py
+++ b/tests/unit/test_architecture_provider_count.py
@@ -46,6 +46,7 @@ class TestArchitectureProviderCount:
         providers = set(get_args(ProviderType))
         expected = {
             "anthropic",
+            "deepseek",
             "google",
             "inception",
             "lmstudio",

--- a/yamlgraph/config.py
+++ b/yamlgraph/config.py
@@ -41,6 +41,7 @@ DEFAULT_TEMPERATURE = 0.7
 #   REPLICATE_API_TOKEN, XAI_API_KEY
 DEFAULT_MODELS = {
     "anthropic": os.getenv("ANTHROPIC_MODEL", "claude-haiku-4-5"),
+    "deepseek": os.getenv("DEEPSEEK_MODEL", "deepseek-chat"),
     "google": os.getenv("GOOGLE_MODEL", "gemini-2.0-flash"),
     "inception": os.getenv("INCEPTION_MODEL", "mercury-2"),
     "lmstudio": os.getenv("LMSTUDIO_MODEL", "qwen2.5-coder-7b-instruct"),

--- a/yamlgraph/utils/llm_factory.py
+++ b/yamlgraph/utils/llm_factory.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Type alias for supported providers
 ProviderType = Literal[
     "anthropic",
+    "deepseek",
     "google",
     "inception",
     "lmstudio",
@@ -33,6 +34,21 @@ _cache_lock = threading.Lock()
 
 
 # --- Provider-specific helper functions ---
+
+
+def _create_deepseek_llm(
+    model: str, temperature: float, **kwargs: object
+) -> BaseChatModel:
+    """Create DeepSeek LLM (OpenAI-compatible API)."""
+    from langchain_openai import ChatOpenAI
+
+    return ChatOpenAI(
+        model=model,
+        temperature=temperature,
+        base_url="https://api.deepseek.com/v1",
+        api_key=os.getenv("DEEPSEEK_API_KEY"),
+        **kwargs,
+    )
 
 
 def _create_google_llm(
@@ -135,6 +151,8 @@ def _dispatch_provider(
     **kwargs: object,
 ) -> BaseChatModel:
     """Dispatch to appropriate provider-specific creation function."""
+    if provider == "deepseek":
+        return _create_deepseek_llm(model, temperature, **kwargs)
     if provider == "google":
         return _create_google_llm(model, temperature, **kwargs)
     if provider == "inception":
@@ -162,7 +180,7 @@ def create_llm(
 ) -> BaseChatModel:
     """Create an LLM instance with multi-provider support.
 
-    Supports Anthropic (default), Google, Mistral, OpenAI, Replicate, and xAI providers.
+    Supports Anthropic (default), DeepSeek, Google, Mistral, OpenAI, Replicate, and xAI providers.
     Provider can be specified via parameter or PROVIDER environment variable.
     Model can be specified via parameter or {PROVIDER}_MODEL environment variable.
 
@@ -170,7 +188,7 @@ def create_llm(
     to improve performance.
 
     Args:
-        provider: LLM provider ("anthropic", "mistral", "openai", "replicate", "xai").
+        provider: LLM provider ("anthropic", "deepseek", "mistral", "openai", "replicate", "xai").
                  Defaults to PROVIDER env var or "anthropic".
         model: Model name. Defaults to {PROVIDER}_MODEL env var or provider default.
         temperature: Temperature for generation (0.0-1.0).


### PR DESCRIPTION
## FR-137: Add DeepSeek LLM Provider

See [feature-requests/FR-137-deepseek-provider.md](feature-requests/FR-137-deepseek-provider.md)

### Changes

- Add `"deepseek"` to `ProviderType` Literal and `_dispatch_provider()` routing
- Add `_create_deepseek_llm()` factory function using `ChatOpenAI` + `base_url` pattern
- Add `"deepseek"` to `DEFAULT_MODELS` in `config.py`
- Update provider count (8→9) in `ARCHITECTURE.md` module table
- Add DeepSeek to env var documentation in `CLAUDE.md` and `getting-started.md`
- Add integration test with `DEEPSEEK_API_KEY` skipif guard
- Update `test_architecture_provider_count` expected set

### Pattern

Follows the proven OpenAI-compatible pattern established by xAI and Inception providers. No new pip dependencies.
