### PR TITLE
feat(diary): FR-124 add diary import CLI command

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -319,6 +319,7 @@ YAMLGraph implements **19 capabilities** covering **68 requirements**. Each capa
 | 42 | Inquisitor Worktree Gate | `.chaplain/inquisitor.sh` | REQ-YG-142 |
 | 43 | Copilot Session GC | `scripts/copilot_session_gc.sh` | REQ-YG-141 |
 | 44 | Judge SPLIT Verdict | `examples/copilot/prompts/judge.yaml`, `scripts/chaplain-prompts/judge.md` | REQ-YG-143 |
+| 45 | Diary Import CLI | `yamlgraph/diary/importer.py`, `yamlgraph/cli/diary_commands.py` | REQ-YG-122 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -706,6 +707,12 @@ Add a fourth judge verdict (`SPLIT`) for multi-concern feature requests, enablin
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-143 | Judge prompts must include `SPLIT` verdict and Scope Count rubric for multi-concern FR decomposition; unit tests verify both prompt sources and conflict fixture behavior | `examples/copilot/prompts/judge.yaml`, `scripts/chaplain-prompts/judge.md`, `tests/unit/test_judge_split_verdict` |
+
+### CAP-45: Diary Import CLI
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-122 | `yamlgraph diary import` CLI command imports pending diary entries and git reports into `docs/diary/` with `--dry-run` and `--source` flags; shared importer returns structured `ImportResult` list; dry-run does not mutate source files; malformed files reported and exit non-zero; explicit missing `--source` emits warning | `yamlgraph/diary/importer.py`, `yamlgraph/cli/diary_commands.py`, `tests/unit/test_diary_importer`, `tests/unit/test_diary_commands` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-124 Diary Import CLI**: `yamlgraph diary import` CLI command imports pending scheduled diary entries and git reports into `docs/diary/` with `--dry-run` and `--source` flags. Extracted shared import logic from `scripts/diary_rotate.py` into `yamlgraph/diary/importer.py`. (REQ-YG-122)
 - **FR-142 Inquisitor Worktree Gate**: Add worktree-detection gate to `inquisitor.sh` that suppresses audit and propose phases when running inside a git worktree (enforce pipeline). Detects via `-f "$REPO_ROOT/.git"`; `--force` bypasses. Placed before commit-delta gate (FR-131). (REQ-YG-142)
 - **FR-138 Copilot Session GC**: Shell script `scripts/copilot_session_gc.sh` prunes stale Copilot CLI sessions older than `--max-age` days (default 7). Supports `--dry-run` preview and protects the active session via `$COPILOT_SESSION_ID`. (REQ-YG-141)
 - **FR-136 Judge SPLIT Verdict**: Add fourth verdict (SPLIT) to judge prompts in `examples/copilot/prompts/judge.yaml` and `scripts/chaplain-prompts/judge.md`, enabling decomposition of multi-concern FRs into focused sub-topics. Adds Scope Count evaluation criterion and multi-concern test fixture. (REQ-YG-143)

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -53,7 +53,7 @@ Each confession must include:
 - **Penance**: Command and args are hardcoded; only file paths from `Path` objects are passed. No user input reaches the shell.
 
 ### CONF-206
-- **File**: [scripts/diary_rotate.py](../scripts/diary_rotate.py#L33)
+- **File**: [scripts/diary_rotate.py](../scripts/diary_rotate.py#L36)
 - **Code**: S603
 - **Sin**: `git_add()` helper uses `subprocess.run(["git", "add", ...])` — S603 flags subprocess call with non-constant arguments.
 - **Penance**: Arguments are `Path` objects from the diary folder; command is hardcoded `["git", "add"]`. No shell expansion, no user input.

--- a/feature-requests/FR-124-diary-import-cli.md
+++ b/feature-requests/FR-124-diary-import-cli.md
@@ -2,7 +2,7 @@
 
 **Priority:** LOW
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 1 day
 **Requested:** 2026-03-07
 **Judged:** 2026-03-08
@@ -279,20 +279,20 @@ imported = sum(1 for r in results if r.status == "imported")
 
 ## Acceptance Criteria
 
-- [ ] `yamlgraph diary import` imports pending diary entries and git reports as individual files into `docs/diary/`
-- [ ] `yamlgraph diary import --dry-run` lists pending files without modifying diary directory
-- [ ] `--source` flag overrides the base directory; both functions preserve their internal glob patterns relative to it
-- [ ] Explicit `--source` with nonexistent path emits a warning before "Nothing to import" (Judge's Note #1)
-- [ ] Dry-run output includes header line with source directory label
-- [ ] Import summary printed to stdout with per-file status
-- [ ] Malformed files are reported with filename and skipped (non-zero exit)
-- [ ] Dry-run does not delete, rename, or otherwise mutate source files (Judge's Note #3)
-- [ ] Missing default source directory prints "Nothing to import" and exits 0
-- [ ] Pre-commit hook still works (uses same extracted `yamlgraph.diary.importer` logic)
-- [ ] Unit tests for CLI command (success, dry-run, empty, missing dir, explicit missing dir warning, malformed)
-- [ ] Tests tagged with `@pytest.mark.req("REQ-YG-122")`
-- [ ] `REQ-YG-122` added to `ARCHITECTURE.md` and `scripts/req_coverage.py`
-- [ ] Documentation updated (CLI help text sufficient; no new docs page needed)
+- [x] `yamlgraph diary import` imports pending diary entries and git reports as individual files into `docs/diary/`
+- [x] `yamlgraph diary import --dry-run` lists pending files without modifying diary directory
+- [x] `--source` flag overrides the base directory; both functions preserve their internal glob patterns relative to it
+- [x] Explicit `--source` with nonexistent path emits a warning before "Nothing to import" (Judge's Note #1)
+- [x] Dry-run output includes header line with source directory label
+- [x] Import summary printed to stdout with per-file status
+- [x] Malformed files are reported with filename and skipped (non-zero exit)
+- [x] Dry-run does not delete, rename, or otherwise mutate source files (Judge's Note #3)
+- [x] Missing default source directory prints "Nothing to import" and exits 0
+- [x] Pre-commit hook still works (uses same extracted `yamlgraph.diary.importer` logic)
+- [x] Unit tests for CLI command (success, dry-run, empty, missing dir, explicit missing dir warning, malformed)
+- [x] Tests tagged with `@pytest.mark.req("REQ-YG-122")`
+- [x] `REQ-YG-122` added to `ARCHITECTURE.md` and `scripts/req_coverage.py`
+- [x] Documentation updated (CLI help text sufficient; no new docs page needed)
 
 ## Alternatives Considered
 

--- a/scripts/diary_rotate.py
+++ b/scripts/diary_rotate.py
@@ -5,6 +5,9 @@ FR-134: Diary folder refactor — replaced monolithic diary.md rotation with
 per-file imports. Each scheduled entry (world digest, git report) becomes
 an individual file in docs/diary/.
 
+FR-124: Import logic extracted to yamlgraph.diary.importer; this script
+is now a thin wrapper for the pre-commit hook.
+
 Run standalone:
     python scripts/diary_rotate.py          # import pending entries
 
@@ -15,13 +18,13 @@ Pre-commit hook:
 
 from __future__ import annotations
 
-import os
-import re
 import subprocess
 from pathlib import Path
 
+from yamlgraph.diary.importer import import_git_reports, import_scheduled_entries
+
 DIARY_DIR = Path("docs/diary")
-SCHEDULED_OUTPUTS = Path(os.path.expanduser("~/scheduled-yamlgraphs/outputs"))
+SCHEDULED_OUTPUTS = Path("~/scheduled-yamlgraphs/outputs").expanduser()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,149 +39,6 @@ def git_add(*paths: Path) -> None:
     )
 
 
-def import_scheduled_entries() -> int:
-    """Import pending diary entries from ~/scheduled-yamlgraphs/outputs/.
-
-    Converts World Digest format to diary entry format, writes as individual
-    files to docs/diary/, and removes the processed source file.
-
-    Returns count of imported entries.
-    """
-    if not SCHEDULED_OUTPUTS.exists():
-        return 0
-
-    imported = 0
-    for entry_file in sorted(SCHEDULED_OUTPUTS.glob("diary_entry_*.md")):
-        content = entry_file.read_text()
-
-        # Extract date from filename: diary_entry_20260221.md → 2026-02-21
-        match = re.search(r"diary_entry_(\d{4})(\d{2})(\d{2})\.md", entry_file.name)
-        if not match:
-            continue
-
-        entry_date = f"{match.group(1)}-{match.group(2)}-{match.group(3)}"
-
-        # Skip if this date's World Digest already exists in diary folder
-        target = DIARY_DIR / f"{entry_date}-world-digest.md"
-        if target.exists():
-            print(f"⏭️  Skipping {entry_file.name} (already in diary)")
-            entry_file.unlink()
-            continue
-
-        # Convert format: "# World Digest — Theme" → "## YYYY-MM-DD: World Digest — Theme"
-        # Remove "**Date:** YYYY-MM-DD" line
-        lines = content.splitlines()
-        converted_lines = []
-
-        for line in lines:
-            if line.startswith("# World Digest"):
-                theme = line[len("# World Digest — ") :]
-                converted_lines.append(f"## {entry_date}: World Digest — {theme}")
-            elif line.startswith("**Date:**"):
-                continue
-            else:
-                converted_lines.append(line)
-
-        converted = "\n".join(converted_lines)
-
-        # Write as individual file
-        DIARY_DIR.mkdir(parents=True, exist_ok=True)
-        target.write_text(converted.strip() + "\n")
-
-        print(f"📥 Imported {entry_file.name} → {target}")
-        entry_file.unlink()
-        imported += 1
-
-    return imported
-
-
-def import_git_reports() -> int:
-    """Import git reports from ~/scheduled-yamlgraphs/outputs/git_report/.
-
-    Parses CLI output (text format), extracts report field,
-    formats as diary entry, writes as individual file to docs/diary/,
-    and renames processed files to .imported.
-
-    Returns count of imported reports.
-    """
-    git_report_dir = SCHEDULED_OUTPUTS / "git_report"
-    if not git_report_dir.exists():
-        return 0
-
-    imported = 0
-    for report_file in sorted(git_report_dir.glob("report_*.txt")):
-        content = report_file.read_text()
-
-        # Extract date from filename: report_20260221_080000.txt → 2026-02-21
-        match = re.search(r"report_(\d{4})(\d{2})(\d{2})_", report_file.name)
-        if not match:
-            continue
-
-        entry_date = f"{match.group(1)}-{match.group(2)}-{match.group(3)}"
-
-        # Check if already in diary folder
-        target = DIARY_DIR / f"{entry_date}-git-report.md"
-        if target.exists():
-            print(f"⏭️  Skipping {report_file.name} (already in diary)")
-            report_file.rename(report_file.with_suffix(".imported"))
-            continue
-
-        # Extract report field from CLI output
-        report_match = re.search(
-            r'report:\s*title="([^"]*)".*?summary="([^"]*)".*?'
-            r"key_findings=\[([^\]]*)\]",
-            content,
-            re.DOTALL,
-        )
-
-        if report_match:
-            title = report_match.group(1)
-            summary = report_match.group(2).replace("\\n", "\n")
-            findings_raw = report_match.group(3)
-            findings = re.findall(r"'([^']*)'", findings_raw)
-
-            entry_lines = [
-                f"## {entry_date}: Git Report — {title}",
-                "",
-                summary,
-                "",
-            ]
-
-            if findings:
-                entry_lines.append("**Key Findings:**")
-                for finding in findings:
-                    entry_lines.append(f"- {finding}")
-                entry_lines.append("")
-        else:
-            # Fallback: extract analysis section
-            analysis_match = re.search(
-                r"analysis:\s*(.+?)(?=\n\s*report:|$)", content, re.DOTALL
-            )
-            if analysis_match:
-                analysis = analysis_match.group(1).strip()
-                entry_lines = [
-                    f"## {entry_date}: Git Report",
-                    "",
-                    analysis[:2000],
-                    "",
-                ]
-            else:
-                print(f"⚠️  Could not parse report: {report_file.name}")
-                continue
-
-        entry = "\n".join(entry_lines)
-
-        # Write as individual file
-        DIARY_DIR.mkdir(parents=True, exist_ok=True)
-        target.write_text(entry.strip() + "\n")
-
-        print(f"📥 Imported git report {report_file.name} → {target}")
-        report_file.rename(report_file.with_suffix(".imported"))
-        imported += 1
-
-    return imported
-
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -187,9 +47,10 @@ def import_git_reports() -> int:
 def main() -> int:
     DIARY_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Import scheduled entries
-    imported = import_scheduled_entries()
-    imported += import_git_reports()
+    results = import_scheduled_entries(DIARY_DIR, SCHEDULED_OUTPUTS)
+    results += import_git_reports(DIARY_DIR, SCHEDULED_OUTPUTS)
+    imported = sum(1 for r in results if r.status == "imported")
+
     if imported > 0:
         git_add(DIARY_DIR)
 

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -40,6 +40,7 @@ _ALL_FRAMEWORK_REQS = (
     + [141]  # REQ-YG-141 (CAP-43 Copilot Session GC)
     + [142]  # REQ-YG-142 (CAP-42 Inquisitor Worktree Gate)
     + [143]  # REQ-YG-143 (CAP-44 Judge SPLIT Verdict)
+    + [122]  # REQ-YG-122 (CAP-45 Diary Import CLI)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -212,6 +213,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-42": ("Inquisitor Worktree Gate", ["REQ-YG-142"]),
     "CAP-43": ("Copilot Session GC", ["REQ-YG-141"]),
     "CAP-44": ("Judge SPLIT Verdict", ["REQ-YG-143"]),
+    "CAP-45": ("Diary Import CLI", ["REQ-YG-122"]),
 }
 
 

--- a/tests/unit/test_diary_commands.py
+++ b/tests/unit/test_diary_commands.py
@@ -1,0 +1,200 @@
+"""Tests for yamlgraph.cli.diary_commands — diary CLI command.
+
+FR-124: Diary Import CLI Command — tests for the CLI surface including
+dry-run, missing directory warning, and error exit codes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from yamlgraph.cli import create_parser
+from yamlgraph.cli.diary_commands import cmd_diary_import
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DIARY_ENTRY_CONTENT = """\
+# World Digest — Test Theme
+**Date:** 2026-03-07
+
+Content here.
+"""
+
+GIT_REPORT_CONTENT = """\
+analysis: Some analysis text
+report: title="Test Report" summary="Summary" key_findings=['Finding 1']
+"""
+
+
+def _make_args(*, dry_run: bool = False, source: str | None = None):
+    """Build a minimal Namespace matching the diary import CLI args."""
+    parser = create_parser()
+    argv = ["diary", "import"]
+    if dry_run:
+        argv.append("--dry-run")
+    if source:
+        argv.extend(["--source", source])
+    return parser.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# CLI parser tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-122")
+class TestDiaryCliParser:
+    """Tests for diary CLI argument parsing."""
+
+    def test_diary_import_parsed(self) -> None:
+        """'diary import' should parse to correct command and defaults."""
+        parser = create_parser()
+        args = parser.parse_args(["diary", "import"])
+        assert args.command == "diary"
+        assert args.diary_command == "import"
+        assert args.dry_run is False
+        assert args.source is None
+
+    def test_diary_import_dry_run_flag(self) -> None:
+        """'--dry-run' flag should be captured."""
+        parser = create_parser()
+        args = parser.parse_args(["diary", "import", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_diary_import_source_flag(self) -> None:
+        """'--source' flag should capture the path."""
+        parser = create_parser()
+        args = parser.parse_args(["diary", "import", "--source", "/tmp/test"])
+        assert args.source == "/tmp/test"
+
+
+# ---------------------------------------------------------------------------
+# cmd_diary_import tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-122")
+class TestCmdDiaryImport:
+    """Tests for cmd_diary_import() handler."""
+
+    def test_imports_pending_entries(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should import files and print success summary."""
+        source = tmp_path / "outputs"
+        source.mkdir()
+        (source / "diary_entry_20260307.md").write_text(DIARY_ENTRY_CONTENT)
+
+        diary_dir = tmp_path / "diary"
+        diary_dir.mkdir()
+
+        args = _make_args(source=str(source))
+        monkeypatch.chdir(tmp_path)
+        # diary_dir is relative "docs/diary" — create it in the monkeypatched cwd
+        (tmp_path / "docs" / "diary").mkdir(parents=True)
+
+        args = _make_args(source=str(source))
+        cmd_diary_import(args)
+
+        out = capsys.readouterr().out
+        assert "Imported" in out
+        assert "1 file(s) imported" in out
+
+    def test_dry_run_lists_pending(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dry-run should list pending files and not import."""
+        source = tmp_path / "outputs"
+        source.mkdir()
+        (source / "diary_entry_20260307.md").write_text(DIARY_ENTRY_CONTENT)
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "docs" / "diary").mkdir(parents=True)
+
+        args = _make_args(dry_run=True, source=str(source))
+        cmd_diary_import(args)
+
+        out = capsys.readouterr().out
+        assert "Pending" in out or "📋" in out
+        assert "ready to import" in out
+        # Source file not deleted
+        assert (source / "diary_entry_20260307.md").exists()
+
+    def test_nothing_to_import(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No pending files should print 'Nothing to import'."""
+        source = tmp_path / "outputs"
+        source.mkdir()
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "docs" / "diary").mkdir(parents=True)
+
+        args = _make_args(source=str(source))
+        cmd_diary_import(args)
+
+        out = capsys.readouterr().out
+        assert "Nothing to import" in out
+
+    def test_missing_default_source_exits_cleanly(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Missing default source dir should print 'Nothing to import' and not crash."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "docs" / "diary").mkdir(parents=True)
+
+        # source=None → defaults to ~/scheduled-yamlgraphs/outputs/ which won't exist
+        args = _make_args()
+        cmd_diary_import(args)
+
+        out = capsys.readouterr().out
+        assert "Nothing to import" in out
+
+    def test_explicit_missing_source_warns(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit --source with nonexistent path should emit warning."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "docs" / "diary").mkdir(parents=True)
+
+        args = _make_args(source=str(tmp_path / "nonexistent"))
+        cmd_diary_import(args)
+
+        out = capsys.readouterr().out
+        assert "not found" in out.lower() or "⚠" in out
+        assert "Nothing to import" in out
+
+    def test_malformed_file_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed file should cause non-zero exit."""
+        source = tmp_path / "outputs"
+        source.mkdir()
+        (source / "diary_entry_baddate.md").write_text("Bad content\n")
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "docs" / "diary").mkdir(parents=True)
+
+        args = _make_args(source=str(source))
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_diary_import(args)
+        assert exc_info.value.code == 1

--- a/tests/unit/test_diary_importer.py
+++ b/tests/unit/test_diary_importer.py
@@ -1,0 +1,226 @@
+"""Tests for yamlgraph.diary.importer — shared diary import logic.
+
+FR-124: Diary Import CLI Command — extract import logic from diary_rotate.py
+into a reusable module with structured results and dry-run support.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from yamlgraph.diary.importer import (
+    ImportResult,
+    import_git_reports,
+    import_scheduled_entries,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DIARY_ENTRY_CONTENT = """\
+# World Digest — Test Theme
+**Date:** 2026-02-17
+
+Content here.
+"""
+
+GIT_REPORT_CONTENT = """\
+analysis: Some analysis text
+report: title="Test Report" summary="This is a summary" key_findings=['Finding 1', 'Finding 2']
+"""
+
+
+@pytest.fixture()
+def source_dir(tmp_path: Path) -> Path:
+    """Create a source directory with sample files."""
+    source = tmp_path / "outputs"
+    source.mkdir()
+    return source
+
+
+@pytest.fixture()
+def diary_dir(tmp_path: Path) -> Path:
+    """Create a diary target directory."""
+    d = tmp_path / "diary"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# import_scheduled_entries
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-122")
+class TestImportScheduledEntries:
+    """Tests for import_scheduled_entries() with structured results."""
+
+    def test_imports_entry_and_returns_result(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """Should import entry, delete source, return ImportResult with status='imported'."""
+        entry = source_dir / "diary_entry_20260217.md"
+        entry.write_text(DIARY_ENTRY_CONTENT)
+
+        results = import_scheduled_entries(diary_dir, source_dir)
+
+        assert len(results) == 1
+        r = results[0]
+        assert isinstance(r, ImportResult)
+        assert r.filename == "diary_entry_20260217.md"
+        assert r.entry_type == "World Digest"
+        assert r.entry_date == "2026-02-17"
+        assert r.status == "imported"
+
+        # Source deleted, target created
+        assert not entry.exists()
+        target = diary_dir / "2026-02-17-world-digest.md"
+        assert target.exists()
+        content = target.read_text()
+        assert "## 2026-02-17: World Digest — Test Theme" in content
+        assert "Content here." in content
+
+    def test_missing_source_dir_returns_empty(self, diary_dir: Path) -> None:
+        """Missing source directory returns empty list."""
+        results = import_scheduled_entries(diary_dir, Path("/nonexistent"))
+        assert results == []
+
+    def test_default_source_dir(self, diary_dir: Path) -> None:
+        """When source_dir is None, uses ~/scheduled-yamlgraphs/outputs/."""
+        # Just verifying it doesn't crash — default dir won't exist in test
+        results = import_scheduled_entries(diary_dir)
+        assert results == []
+
+    def test_skips_duplicate_entry(self, source_dir: Path, diary_dir: Path) -> None:
+        """Should skip if target file already exists."""
+        entry = source_dir / "diary_entry_20260217.md"
+        entry.write_text(DIARY_ENTRY_CONTENT)
+        (diary_dir / "2026-02-17-world-digest.md").write_text("Already exists\n")
+
+        results = import_scheduled_entries(diary_dir, source_dir)
+
+        assert len(results) == 1
+        assert results[0].status == "skipped"
+        assert "already" in results[0].message.lower()
+
+    def test_dry_run_does_not_delete_source(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """Dry-run must not delete, rename, or write anything."""
+        entry = source_dir / "diary_entry_20260217.md"
+        entry.write_text(DIARY_ENTRY_CONTENT)
+
+        results = import_scheduled_entries(diary_dir, source_dir, dry_run=True)
+
+        assert len(results) == 1
+        assert results[0].status == "imported"
+        # Source NOT deleted
+        assert entry.exists()
+        # Target NOT created
+        assert not (diary_dir / "2026-02-17-world-digest.md").exists()
+
+    def test_malformed_filename_returns_error(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """File matching glob but with bad date should return error result."""
+        bad = source_dir / "diary_entry_baddate.md"
+        bad.write_text("Some content\n")
+
+        results = import_scheduled_entries(diary_dir, source_dir)
+
+        assert len(results) == 1
+        assert results[0].status == "error"
+        assert results[0].message is not None
+
+
+# ---------------------------------------------------------------------------
+# import_git_reports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-122")
+class TestImportGitReports:
+    """Tests for import_git_reports() with structured results."""
+
+    def test_imports_report_and_returns_result(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """Should import report, rename source to .imported, return ImportResult."""
+        git_dir = source_dir / "git_report"
+        git_dir.mkdir()
+        report = git_dir / "report_20260218_080000.txt"
+        report.write_text(GIT_REPORT_CONTENT)
+
+        results = import_git_reports(diary_dir, source_dir)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r.filename == "report_20260218_080000.txt"
+        assert r.entry_type == "Git Report"
+        assert r.entry_date == "2026-02-18"
+        assert r.status == "imported"
+
+        # Source renamed, target created
+        assert report.with_suffix(".imported").exists()
+        target = diary_dir / "2026-02-18-git-report.md"
+        assert target.exists()
+        content = target.read_text()
+        assert "## 2026-02-18: Git Report — Test Report" in content
+        assert "This is a summary" in content
+
+    def test_missing_git_report_dir_returns_empty(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """Missing git_report subdirectory returns empty list."""
+        results = import_git_reports(diary_dir, source_dir)
+        assert results == []
+
+    def test_skips_duplicate_report(self, source_dir: Path, diary_dir: Path) -> None:
+        """Should skip if target file already exists."""
+        git_dir = source_dir / "git_report"
+        git_dir.mkdir()
+        report = git_dir / "report_20260218_080000.txt"
+        report.write_text(GIT_REPORT_CONTENT)
+        (diary_dir / "2026-02-18-git-report.md").write_text("Already exists\n")
+
+        results = import_git_reports(diary_dir, source_dir)
+
+        assert len(results) == 1
+        assert results[0].status == "skipped"
+
+    def test_dry_run_does_not_rename_source(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """Dry-run must not rename source or write target."""
+        git_dir = source_dir / "git_report"
+        git_dir.mkdir()
+        report = git_dir / "report_20260218_080000.txt"
+        report.write_text(GIT_REPORT_CONTENT)
+
+        results = import_git_reports(diary_dir, source_dir, dry_run=True)
+
+        assert len(results) == 1
+        assert results[0].status == "imported"
+        # Source NOT renamed
+        assert report.exists()
+        assert not report.with_suffix(".imported").exists()
+        # Target NOT created
+        assert not (diary_dir / "2026-02-18-git-report.md").exists()
+
+    def test_unparseable_report_returns_error(
+        self, source_dir: Path, diary_dir: Path
+    ) -> None:
+        """Report that can't be parsed should return error result."""
+        git_dir = source_dir / "git_report"
+        git_dir.mkdir()
+        report = git_dir / "report_20260218_080000.txt"
+        report.write_text("totally unparseable garbage\n")
+
+        results = import_git_reports(diary_dir, source_dir)
+
+        assert len(results) == 1
+        assert results[0].status == "error"
+        assert results[0].message is not None

--- a/tests/unit/test_diary_rotate.py
+++ b/tests/unit/test_diary_rotate.py
@@ -2,6 +2,7 @@
 
 FR-080: Infrastructure Script Unit Tests — Phase 3 (diary_rotate).
 FR-134: Diary folder refactor — individual files, no rotation.
+FR-124: Import logic extracted to yamlgraph.diary.importer; script is thin wrapper.
 """
 
 from pathlib import Path
@@ -10,11 +11,12 @@ from unittest.mock import patch
 import pytest
 
 from scripts import diary_rotate
+from yamlgraph.diary import importer
 
 
 @pytest.mark.req("REQ-YG-063")
 class TestImportScheduledEntries:
-    """Tests for import_scheduled_entries() function."""
+    """Tests for import_scheduled_entries() via shared importer."""
 
     def test_conversion_creates_individual_file(self, tmp_path: Path) -> None:
         """Should create an individual diary file for each imported entry."""
@@ -31,13 +33,10 @@ Content here.
         diary_dir = tmp_path / "diary"
         diary_dir.mkdir()
 
-        with (
-            patch.object(diary_rotate, "SCHEDULED_OUTPUTS", outputs),
-            patch.object(diary_rotate, "DIARY_DIR", diary_dir),
-        ):
-            imported = diary_rotate.import_scheduled_entries()
+        results = importer.import_scheduled_entries(diary_dir, outputs)
 
-        assert imported == 1
+        assert len(results) == 1
+        assert results[0].status == "imported"
         assert not entry_file.exists()  # Should be deleted
         expected_file = diary_dir / "2026-02-17-world-digest.md"
         assert expected_file.exists()
@@ -45,14 +44,12 @@ Content here.
         assert "## 2026-02-17: World Digest — Test Theme" in content
         assert "Content here." in content
 
-    def test_missing_outputs_dir(self, tmp_path: Path) -> None:
-        """Missing outputs directory should return 0."""
-        outputs = tmp_path / "nonexistent"
-
-        with patch.object(diary_rotate, "SCHEDULED_OUTPUTS", outputs):
-            imported = diary_rotate.import_scheduled_entries()
-
-        assert imported == 0
+    def test_missing_outputs_dir(self) -> None:
+        """Missing outputs directory should return empty list."""
+        results = importer.import_scheduled_entries(
+            Path("/tmp/diary"), Path("/nonexistent")
+        )
+        assert results == []
 
     def test_skip_duplicate_entry(self, tmp_path: Path) -> None:
         """Should skip if diary file for that date/type already exists."""
@@ -71,18 +68,15 @@ Content here.
         # Pre-existing file
         (diary_dir / "2026-02-17-world-digest.md").write_text("Already exists\n")
 
-        with (
-            patch.object(diary_rotate, "SCHEDULED_OUTPUTS", outputs),
-            patch.object(diary_rotate, "DIARY_DIR", diary_dir),
-        ):
-            imported = diary_rotate.import_scheduled_entries()
+        results = importer.import_scheduled_entries(diary_dir, outputs)
 
-        assert imported == 0
+        assert len(results) == 1
+        assert results[0].status == "skipped"
 
 
 @pytest.mark.req("REQ-YG-063")
 class TestImportGitReports:
-    """Tests for import_git_reports() function."""
+    """Tests for import_git_reports() via shared importer."""
 
     def test_parsing_creates_individual_file(self, tmp_path: Path) -> None:
         """Should create an individual diary file for each imported report."""
@@ -99,13 +93,10 @@ report: title="Test Report" summary="This is a summary" key_findings=['Finding 1
         diary_dir = tmp_path / "diary"
         diary_dir.mkdir()
 
-        with (
-            patch.object(diary_rotate, "SCHEDULED_OUTPUTS", outputs),
-            patch.object(diary_rotate, "DIARY_DIR", diary_dir),
-        ):
-            imported = diary_rotate.import_git_reports()
+        results = importer.import_git_reports(diary_dir, outputs)
 
-        assert imported == 1
+        assert len(results) == 1
+        assert results[0].status == "imported"
         assert report_file.with_suffix(".imported").exists()
         expected_file = diary_dir / "2026-02-18-git-report.md"
         assert expected_file.exists()
@@ -115,14 +106,14 @@ report: title="Test Report" summary="This is a summary" key_findings=['Finding 1
         assert "Finding 1" in content
 
     def test_missing_git_report_dir(self, tmp_path: Path) -> None:
-        """Missing git_report directory should return 0."""
+        """Missing git_report directory should return empty list."""
         outputs = tmp_path / "outputs"
         outputs.mkdir()
 
-        with patch.object(diary_rotate, "SCHEDULED_OUTPUTS", outputs):
-            imported = diary_rotate.import_git_reports()
-
-        assert imported == 0
+        results = importer.import_git_reports(
+            diary_dir=Path("/tmp/diary"), source_dir=outputs
+        )
+        assert results == []
 
 
 @pytest.mark.req("REQ-YG-063")

--- a/yamlgraph/cli/__init__.py
+++ b/yamlgraph/cli/__init__.py
@@ -9,6 +9,7 @@ Usage:
 
 import argparse
 
+from yamlgraph.cli.diary_commands import cmd_diary_dispatch
 from yamlgraph.cli.graph_commands import cmd_graph_dispatch
 from yamlgraph.cli.schema_commands import cmd_schema_dispatch
 
@@ -157,6 +158,31 @@ def create_parser() -> argparse.ArgumentParser:
     schema_subparsers.add_parser("path", help="Print path to bundled JSON Schema")
 
     schema_parser.set_defaults(func=cmd_schema_dispatch)
+
+    # === Diary commands (FR-124) ===
+    diary_parser = subparsers.add_parser("diary", help="Diary management commands")
+    diary_subparsers = diary_parser.add_subparsers(
+        dest="diary_command", help="Diary subcommands"
+    )
+
+    # diary import
+    diary_import_parser = diary_subparsers.add_parser(
+        "import", help="Import pending scheduled insights into docs/diary/"
+    )
+    diary_import_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Show pending imports without modifying diary",
+    )
+    diary_import_parser.add_argument(
+        "--source",
+        type=str,
+        default=None,
+        help="Override source base directory (default: ~/scheduled-yamlgraphs/outputs/)",
+    )
+
+    diary_parser.set_defaults(func=cmd_diary_dispatch)
 
     return parser
 

--- a/yamlgraph/cli/diary_commands.py
+++ b/yamlgraph/cli/diary_commands.py
@@ -1,0 +1,64 @@
+"""Diary CLI commands (FR-124).
+
+Implements:
+- diary import [--dry-run] [--source DIR]
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+from yamlgraph.diary.importer import import_git_reports, import_scheduled_entries
+
+
+def cmd_diary_import(args: Namespace) -> None:
+    """Import pending scheduled insights into docs/diary/."""
+    diary_dir = Path("docs/diary")
+    source_dir = Path(args.source) if args.source else None
+    dry_run = args.dry_run
+
+    if source_dir and not source_dir.exists():
+        print(f"⚠️  Source directory not found: {source_dir}")
+
+    if dry_run:
+        label = source_dir or "~/scheduled-yamlgraphs/outputs/"
+        print(f"📋 Pending scheduled imports ({label}):")
+
+    results = import_scheduled_entries(diary_dir, source_dir, dry_run=dry_run)
+    results += import_git_reports(diary_dir, source_dir, dry_run=dry_run)
+
+    if not results:
+        print("Nothing to import.")
+        return
+
+    has_errors = False
+    for r in results:
+        if r.status == "error":
+            print(f"✗ {r.filename}: {r.message}")
+            has_errors = True
+        elif r.status == "skipped":
+            print(f"⏭️  {r.filename} ({r.message})")
+        elif dry_run:
+            print(f"  📝 {r.filename}  ({r.entry_type})")
+        else:
+            print(f"✓ Imported {r.filename} ({r.entry_type})")
+
+    count = sum(1 for r in results if r.status == "imported")
+    if dry_run:
+        pending = sum(1 for r in results if r.status != "error")
+        print(f"\n{pending} file(s) ready to import. Run without --dry-run to apply.")
+    else:
+        print(f"\n{count} file(s) imported into {diary_dir}/.")
+
+    if has_errors:
+        raise SystemExit(1)
+
+
+def cmd_diary_dispatch(args: Namespace) -> None:
+    """Dispatch to diary subcommands."""
+    if args.diary_command == "import":
+        cmd_diary_import(args)
+    else:
+        print("Unknown diary command. Use: yamlgraph diary import --help")
+        raise SystemExit(1)

--- a/yamlgraph/diary/__init__.py
+++ b/yamlgraph/diary/__init__.py
@@ -1,0 +1,4 @@
+"""Diary management package (FR-124).
+
+Provides import logic for scheduled YAMLGraph outputs into docs/diary/.
+"""

--- a/yamlgraph/diary/importer.py
+++ b/yamlgraph/diary/importer.py
@@ -1,0 +1,247 @@
+"""Shared diary import logic (FR-124).
+
+Extracted from ``scripts/diary_rotate.py`` to enable both the pre-commit
+hook and the ``yamlgraph diary import`` CLI command to share the same
+import pipeline with structured results and dry-run support.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_SOURCE = Path(os.path.expanduser("~/scheduled-yamlgraphs/outputs"))
+
+
+@dataclass
+class ImportResult:
+    """Result of importing a single file."""
+
+    filename: str
+    entry_type: str  # "World Digest" | "Git Report"
+    entry_date: str  # "YYYY-MM-DD"
+    status: str  # "imported" | "skipped" | "error"
+    message: str | None = None  # Error detail or skip reason
+
+
+# ---------------------------------------------------------------------------
+# Scheduled diary entries
+# ---------------------------------------------------------------------------
+
+
+def import_scheduled_entries(
+    diary_dir: Path,
+    source_dir: Path | None = None,
+    *,
+    dry_run: bool = False,
+) -> list[ImportResult]:
+    """Import pending diary entries from source directory.
+
+    Globs ``{source_dir}/diary_entry_*.md``.  When *source_dir* is ``None``
+    the default ``~/scheduled-yamlgraphs/outputs/`` is used.
+
+    Each entry is written as an individual file to *diary_dir* following
+    the ``{date}-world-digest.md`` naming convention.
+    """
+    source = source_dir if source_dir is not None else DEFAULT_SOURCE
+    if not source.exists():
+        return []
+
+    results: list[ImportResult] = []
+    for entry_file in sorted(source.glob("diary_entry_*.md")):
+        match = re.search(r"diary_entry_(\d{4})(\d{2})(\d{2})\.md", entry_file.name)
+        if not match:
+            results.append(
+                ImportResult(
+                    filename=entry_file.name,
+                    entry_type="World Digest",
+                    entry_date="",
+                    status="error",
+                    message=f"Cannot parse date from filename: {entry_file.name}",
+                )
+            )
+            continue
+
+        entry_date = f"{match.group(1)}-{match.group(2)}-{match.group(3)}"
+        target = diary_dir / f"{entry_date}-world-digest.md"
+
+        if target.exists():
+            if not dry_run:
+                entry_file.unlink()
+            results.append(
+                ImportResult(
+                    filename=entry_file.name,
+                    entry_type="World Digest",
+                    entry_date=entry_date,
+                    status="skipped",
+                    message="already in diary",
+                )
+            )
+            continue
+
+        if not dry_run:
+            content = entry_file.read_text()
+            lines = content.splitlines()
+            converted_lines = []
+            for line in lines:
+                if line.startswith("# World Digest"):
+                    theme = line[len("# World Digest — ") :]
+                    converted_lines.append(f"## {entry_date}: World Digest — {theme}")
+                elif line.startswith("**Date:**"):
+                    continue
+                else:
+                    converted_lines.append(line)
+
+            converted = "\n".join(converted_lines)
+            diary_dir.mkdir(parents=True, exist_ok=True)
+            target.write_text(converted.strip() + "\n")
+            entry_file.unlink()
+
+        results.append(
+            ImportResult(
+                filename=entry_file.name,
+                entry_type="World Digest",
+                entry_date=entry_date,
+                status="imported",
+            )
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Git reports
+# ---------------------------------------------------------------------------
+
+
+def import_git_reports(
+    diary_dir: Path,
+    source_dir: Path | None = None,
+    *,
+    dry_run: bool = False,
+) -> list[ImportResult]:
+    """Import pending git reports from source directory.
+
+    Globs ``{source_dir}/git_report/report_*.txt``.  When *source_dir*
+    is ``None`` the default ``~/scheduled-yamlgraphs/outputs/`` is used.
+
+    Each report is written as an individual file to *diary_dir* following
+    the ``{date}-git-report.md`` naming convention.
+    """
+    source = source_dir if source_dir is not None else DEFAULT_SOURCE
+    git_report_dir = source / "git_report"
+    if not git_report_dir.exists():
+        return []
+
+    results: list[ImportResult] = []
+    for report_file in sorted(git_report_dir.glob("report_*.txt")):
+        match = re.search(r"report_(\d{4})(\d{2})(\d{2})_", report_file.name)
+        if not match:
+            results.append(
+                ImportResult(
+                    filename=report_file.name,
+                    entry_type="Git Report",
+                    entry_date="",
+                    status="error",
+                    message=f"Cannot parse date from filename: {report_file.name}",
+                )
+            )
+            continue
+
+        entry_date = f"{match.group(1)}-{match.group(2)}-{match.group(3)}"
+        target = diary_dir / f"{entry_date}-git-report.md"
+
+        if target.exists():
+            if not dry_run:
+                report_file.rename(report_file.with_suffix(".imported"))
+            results.append(
+                ImportResult(
+                    filename=report_file.name,
+                    entry_type="Git Report",
+                    entry_date=entry_date,
+                    status="skipped",
+                    message="already in diary",
+                )
+            )
+            continue
+
+        content = report_file.read_text()
+        entry_lines = _parse_git_report(content, entry_date)
+
+        if entry_lines is None:
+            results.append(
+                ImportResult(
+                    filename=report_file.name,
+                    entry_type="Git Report",
+                    entry_date=entry_date,
+                    status="error",
+                    message=f"Could not parse report: {report_file.name}",
+                )
+            )
+            continue
+
+        if not dry_run:
+            entry = "\n".join(entry_lines)
+            diary_dir.mkdir(parents=True, exist_ok=True)
+            target.write_text(entry.strip() + "\n")
+            report_file.rename(report_file.with_suffix(".imported"))
+
+        results.append(
+            ImportResult(
+                filename=report_file.name,
+                entry_type="Git Report",
+                entry_date=entry_date,
+                status="imported",
+            )
+        )
+
+    return results
+
+
+def _parse_git_report(content: str, entry_date: str) -> list[str] | None:
+    """Parse git report content into diary entry lines.
+
+    Returns ``None`` when the content cannot be parsed.
+    """
+    report_match = re.search(
+        r'report:\s*title="([^"]*)".*?summary="([^"]*)".*?'
+        r"key_findings=\[([^\]]*)\]",
+        content,
+        re.DOTALL,
+    )
+
+    if report_match:
+        title = report_match.group(1)
+        summary = report_match.group(2).replace("\\n", "\n")
+        findings_raw = report_match.group(3)
+        findings = re.findall(r"'([^']*)'", findings_raw)
+
+        entry_lines = [
+            f"## {entry_date}: Git Report — {title}",
+            "",
+            summary,
+            "",
+        ]
+        if findings:
+            entry_lines.append("**Key Findings:**")
+            for finding in findings:
+                entry_lines.append(f"- {finding}")
+            entry_lines.append("")
+        return entry_lines
+
+    # Fallback: extract analysis section
+    analysis_match = re.search(
+        r"analysis:\s*(.+?)(?=\n\s*report:|$)", content, re.DOTALL
+    )
+    if analysis_match:
+        analysis = analysis_match.group(1).strip()
+        return [
+            f"## {entry_date}: Git Report",
+            "",
+            analysis[:2000],
+            "",
+        ]
+
+    return None


### PR DESCRIPTION
## FR-124: Diary Import CLI Command

See FR at [`feature-requests/FR-124-diary-import-cli.md`](feature-requests/FR-124-diary-import-cli.md)

### Summary

Adds `yamlgraph diary import` CLI command exposing existing `diary_rotate.py` import logic as a user-invocable operation with dry-run support and status reporting.

### Changes

- **`yamlgraph/diary/`** — New package extracting import logic from `scripts/diary_rotate.py`
  - `importer.py`: `import_scheduled_entries()` and `import_git_reports()` with `ImportResult` dataclass
- **`yamlgraph/cli/diary_cli.py`** — `diary import` subcommand with `--dry-run` and `--source` flags
- **`scripts/diary_rotate.py`** — Refactored to delegate to `yamlgraph.diary.importer`
- **Tests** — Unit tests for importer and CLI covering dry-run, source override, no-pending scenarios
- **FR doc** — Status updated to Implemented with implementation notes

### Testing

```bash
pytest tests/unit/test_diary_importer.py tests/unit/test_diary_cli.py -v
```
