### PR TITLE
fix(traceability): FR-146 register REQ-YG-145 for phantom requirement detection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -321,6 +321,7 @@ YAMLGraph implements **19 capabilities** covering **68 requirements**. Each capa
 | 44 | Judge SPLIT Verdict | `examples/copilot/prompts/judge.yaml`, `scripts/chaplain-prompts/judge.md` | REQ-YG-143 |
 | 45 | Diary Reflection Enforcement | `.pre-commit-config.yaml`, `scripts/finalize_merge.sh` | REQ-YG-144 |
 | 46 | Diary Import CLI | `yamlgraph/diary/importer.py`, `yamlgraph/cli/diary_commands.py` | REQ-YG-122 |
+| 47 | Phantom Requirement Detection | `scripts/req_coverage.py`, `tests/unit/test_req_coverage` | REQ-YG-145 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -724,6 +725,14 @@ CLI command to import pending diary entries and git report data into `docs/diary
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-122 | `yamlgraph diary import` CLI command imports pending diary entries and git reports into `docs/diary/` with `--dry-run` and `--source` flags; shared importer returns structured `ImportResult` list; dry-run does not mutate source files; malformed files reported and exit non-zero; explicit missing `--source` emits warning | `yamlgraph/diary/importer.py`, `yamlgraph/cli/diary_commands.py`, `tests/unit/test_diary_importer`, `tests/unit/test_diary_commands` |
+
+### 47. Phantom Requirement Detection (FR-145)
+
+Detect and reject test markers that reference non-existent requirement IDs.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-145 | **Phantom requirement detection**: `req_coverage.py --strict` rejects `@pytest.mark.req` markers referencing requirement IDs absent from `ALL_REQS` or `ARCHITECTURE.md` | `scripts/req_coverage.py`, `tests/unit/test_req_coverage` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-145 Phantom Requirement Detection**: `req_coverage.py --strict` rejects `@pytest.mark.req` markers referencing requirement IDs absent from `ALL_REQS` or `ARCHITECTURE.md`. (REQ-YG-145)
 - **FR-144 Enforce Diary Reflection Content**: Add `diary-reflection-check` pre-commit hook that rejects commits containing unfilled diary reflection stubs. Modify `finalize_merge.sh` to create diary stubs as untracked files. Unstage existing unfilled stubs (FR-127, FR-128, FR-134) to comply with enforcement. (REQ-YG-144)
 - **FR-124 Diary Import CLI**: `yamlgraph diary import` CLI command imports pending scheduled diary entries and git reports into `docs/diary/` with `--dry-run` and `--source` flags. Extracted shared import logic from `scripts/diary_rotate.py` into `yamlgraph/diary/importer.py`. (REQ-YG-122)
 - **FR-142 Inquisitor Worktree Gate**: Add worktree-detection gate to `inquisitor.sh` that suppresses audit and propose phases when running inside a git worktree (enforce pipeline). Detects via `-f "$REPO_ROOT/.git"`; `--force` bypasses. Placed before commit-delta gate (FR-131). (REQ-YG-142)

--- a/feature-requests/FR-146-register-req-yg-145-traceability.md
+++ b/feature-requests/FR-146-register-req-yg-145-traceability.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Bug
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.25 days
 **Requested:** 2026-03-08
 
@@ -85,14 +85,14 @@ Under `### Added`:
 
 ## Acceptance Criteria
 
-- [ ] `REQ-YG-145` exists in `ARCHITECTURE.md` capability summary table (CAP-45) and in a detail section
-- [ ] `REQ-YG-145` is present in `ALL_REQS` via `_ALL_FRAMEWORK_REQS` in `scripts/req_coverage.py`
-- [ ] `CAP-45` entry exists in `CAPABILITIES` dict in `scripts/req_coverage.py`
-- [ ] All 6 `TestPhantomRequirementDetection` tests are tagged `@pytest.mark.req("REQ-YG-145")`, not `REQ-YG-063`
-- [ ] `CHANGELOG.md` `[Unreleased]` section contains FR-145 entry with `REQ-YG-145`
-- [ ] `python scripts/req_coverage.py --strict` passes (no phantom IDs, no uncovered reqs)
-- [ ] `pytest tests/unit/test_req_coverage.py -v` passes (all 6 phantom tests green)
-- [ ] Commit message: `fix(traceability): FR-146 register REQ-YG-145 for phantom requirement detection`
+- [x] `REQ-YG-145` exists in `ARCHITECTURE.md` capability summary table (CAP-47) and in a detail section
+- [x] `REQ-YG-145` is present in `ALL_REQS` via `_ALL_FRAMEWORK_REQS` in `scripts/req_coverage.py`
+- [x] `CAP-47` entry exists in `CAPABILITIES` dict in `scripts/req_coverage.py`
+- [x] All 6 `TestPhantomRequirementDetection` tests are tagged `@pytest.mark.req("REQ-YG-145")`, not `REQ-YG-063`
+- [x] `CHANGELOG.md` `[Unreleased]` section contains FR-145 entry with `REQ-YG-145`
+- [x] `python scripts/req_coverage.py --strict` passes (no phantom IDs, no uncovered reqs)
+- [x] `pytest tests/unit/test_req_coverage.py -v` passes (all 6 phantom tests green)
+- [x] Commit message: `fix(traceability): FR-146 register REQ-YG-145 for phantom requirement detection`
 
 ## Alternatives Considered
 

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -42,6 +42,7 @@ _ALL_FRAMEWORK_REQS = (
     + [143]  # REQ-YG-143 (CAP-44 Judge SPLIT Verdict)
     + [144]  # REQ-YG-144 (CAP-45 Diary Reflection Enforcement)
     + [122]  # REQ-YG-122 (CAP-46 Diary Import CLI)
+    + [145]  # REQ-YG-145 (CAP-47 Phantom Requirement Detection)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -216,6 +217,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-44": ("Judge SPLIT Verdict", ["REQ-YG-143"]),
     "CAP-45": ("Diary Reflection Enforcement", ["REQ-YG-144"]),
     "CAP-46": ("Diary Import CLI", ["REQ-YG-122"]),
+    "CAP-47": ("Phantom Requirement Detection", ["REQ-YG-145"]),
 }
 
 

--- a/tests/unit/test_req_coverage.py
+++ b/tests/unit/test_req_coverage.py
@@ -356,7 +356,7 @@ def test_smoke():
         assert "missing from ARCHITECTURE.md" not in captured.out
 
 
-@pytest.mark.req("REQ-YG-063")
+@pytest.mark.req("REQ-YG-145")
 class TestPhantomRequirementDetection:
     """Tests for reverse-check: phantom requirement detection — FR-145.
 


### PR DESCRIPTION
## Summary

Register REQ-YG-145 for phantom requirement detection (FR-145) in the requirement traceability registry.

See FR at `feature-requests/FR-146-register-req-yg-145-traceability.md`

## Changes

- **ARCHITECTURE.md**: Add CAP-45 and REQ-YG-145 for phantom requirement detection
- **scripts/req_coverage.py**: Register 145 in `ALL_REQS` and add `CAP-45` to `CAPABILITIES`
- **tests/unit/test_req_coverage.py**: Re-tag `TestPhantomRequirementDetection` from `REQ-YG-063` → `REQ-YG-145`
- **CHANGELOG.md**: Add entry under `[Unreleased]`
- **feature-requests/FR-146**: Status → Implemented

## Audit Resolution

Closes gaps flagged by Inquisitor Audits XXXVIII and XXXIX.
