### PR TITLE
feat(ci): FR-149 add CHANGELOG gate for feat/fix PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -43,3 +43,26 @@ jobs:
             echo "Example: feat(streaming): FR-030 add subgraphs parameter"
             exit 1
           fi
+
+  changelog-gate:
+    name: CHANGELOG required for feat/fix
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.event.pull_request.title, 'feat') ||
+      startsWith(github.event.pull_request.title, 'fix')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify CHANGELOG.md modified
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '^CHANGELOG\.md$'; then
+            echo "✅ CHANGELOG.md is modified"
+          else
+            echo "::error::feat/fix PRs must include changes to CHANGELOG.md"
+            exit 1
+          fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -324,6 +324,7 @@ YAMLGraph implements **19 capabilities** covering **68 requirements**. Each capa
 | 47 | Phantom Requirement Detection | `scripts/req_coverage.py`, `tests/unit/test_req_coverage` | REQ-YG-145 |
 | 48 | CHANGELOG Removal Completeness | `CHANGELOG.md` | REQ-YG-146 |
 | 49 | Examples Documentation Audit | `examples/README.md` | REQ-YG-147 |
+| 50 | CI CHANGELOG Gate | `.github/workflows/commitlint.yml` | REQ-YG-148 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -751,6 +752,14 @@ Every on-disk example and demo is accurately indexed in `examples/README.md` wit
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-147 | `examples/README.md` lists every demo directory and top-level example on disk; demos are split into Learning / Utility / FR Validation sections; inclusion criteria are documented; each listed entry has a `README.md` and at least one runnable artifact (YAML graph, `demo.sh`, or Python script) | `examples/README.md`, `tests/unit/test_examples_readme_audit` |
+
+### 50. CI CHANGELOG Gate (FR-149)
+
+GitHub Actions job in `commitlint.yml` that blocks merge of `feat` and `fix` PRs unless `CHANGELOG.md` is modified in the PR diff. Closes the structural gap where server-side squash merges bypass local commit-msg hooks.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-148 | `changelog-gate` job in `commitlint.yml` runs `git diff --name-only` against base/head SHAs and fails when `CHANGELOG.md` is absent from diff; job-level `if` condition restricts to `feat`/`fix` PR titles (skipped for other types); uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `tests/unit/test_ci_changelog_gate` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **FR-145 Phantom Requirement Detection**: `req_coverage.py --strict` rejects `@pytest.mark.req` markers referencing requirement IDs absent from `ALL_REQS` or `ARCHITECTURE.md`. (REQ-YG-145)
+- **FR-149 CI CHANGELOG Gate**: Add `changelog-gate` job to `.github/workflows/commitlint.yml` that blocks merge of `feat` and `fix` PRs unless `CHANGELOG.md` is modified in the PR diff. Uses job-level `if` condition to skip for other PR types. Closes the structural gap where server-side squash merges bypass local commit-msg hooks. (REQ-YG-148)
 - **FR-144 Enforce Diary Reflection Content**: Add `diary-reflection-check` pre-commit hook that rejects commits containing unfilled diary reflection stubs. Modify `finalize_merge.sh` to create diary stubs as untracked files. Unstage existing unfilled stubs (FR-127, FR-128, FR-134) to comply with enforcement. (REQ-YG-144)
 - **FR-124 Diary Import CLI**: `yamlgraph diary import` CLI command imports pending scheduled diary entries and git reports into `docs/diary/` with `--dry-run` and `--source` flags. Extracted shared import logic from `scripts/diary_rotate.py` into `yamlgraph/diary/importer.py`. (REQ-YG-122)
 - **FR-142 Inquisitor Worktree Gate**: Add worktree-detection gate to `inquisitor.sh` that suppresses audit and propose phases when running inside a git worktree (enforce pipeline). Detects via `-f "$REPO_ROOT/.git"`; `--force` bypasses. Placed before commit-delta gate (FR-131). (REQ-YG-142)

--- a/docs/diary/2026-03-08-reflection-fr-149.md
+++ b/docs/diary/2026-03-08-reflection-fr-149.md
@@ -1,0 +1,9 @@
+## 2026-03-08: FR-149 — CI CHANGELOG Gate Reflection
+
+**Context:** Implemented a GitHub Actions job (`changelog-gate`) that blocks feat/fix PRs from merging without CHANGELOG.md changes, closing a structural enforcement gap.
+
+**Trap:** audit_as_ritual — Two prior mechanisms (FR-077 local hook, FR-125 post-merge script) existed but neither created a pre-merge gate. The audit kept flagging the same gap (Audits XXXIV, XXXV) without a blocking fix. The cure was obvious once framed as a boundary problem: enforcement must happen at the merge boundary (CI), not downstream (local hooks or manual scripts).
+
+**Heuristic:** When an audit repeatedly flags the same category of violation, the fix is a gate at the boundary, not a better post-hoc process. Local hooks are bypassed by server-side operations; manual scripts are forgotten. Only CI-level checks create true pre-merge gates.
+
+**Seed:** Could we auto-generate the `changelog-gate` condition from the Conventional Commits type list, so adding a new type that requires CHANGELOG updates only needs a config change?

--- a/feature-requests/FR-149-ci-changelog-gate.md
+++ b/feature-requests/FR-149-ci-changelog-gate.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-08
 
@@ -62,11 +62,11 @@ Extend `.github/workflows/commitlint.yml` with a job that checks whether `CHANGE
 
 ## Acceptance Criteria
 
-- [ ] `feat` PRs targeting `main` without `CHANGELOG.md` in diff → check fails, merge blocked
-- [ ] `fix` PRs targeting `main` without `CHANGELOG.md` in diff → check fails, merge blocked
-- [ ] `feat`/`fix` PRs with `CHANGELOG.md` modified → check passes
-- [ ] `chore`/`docs`/`refactor`/`test`/`ci`/`perf`/`style`/`build` PRs → check skipped (not failed)
-- [ ] Job added to `.github/workflows/commitlint.yml` as a separate job (`changelog-gate`)
+- [x] `feat` PRs targeting `main` without `CHANGELOG.md` in diff → check fails, merge blocked
+- [x] `fix` PRs targeting `main` without `CHANGELOG.md` in diff → check fails, merge blocked
+- [x] `feat`/`fix` PRs with `CHANGELOG.md` modified → check passes
+- [x] `chore`/`docs`/`refactor`/`test`/`ci`/`perf`/`style`/`build` PRs → check skipped (not failed)
+- [x] Job added to `.github/workflows/commitlint.yml` as a separate job (`changelog-gate`)
 - [ ] Check configured as a required status check in branch protection rules for `main`
 
 ## Alternatives Considered

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -45,6 +45,7 @@ _ALL_FRAMEWORK_REQS = (
     + [145]  # REQ-YG-145 (CAP-47 Phantom Requirement Detection)
     + [146]  # REQ-YG-146 (CAP-48 CHANGELOG Removal Completeness)
     + [147]  # REQ-YG-147 (CAP-49 Examples Documentation Audit)
+    + [148]  # REQ-YG-148 (CAP-50 CI CHANGELOG Gate)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -222,6 +223,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-47": ("Phantom Requirement Detection", ["REQ-YG-145"]),
     "CAP-48": ("CHANGELOG Removal Completeness", ["REQ-YG-146"]),
     "CAP-49": ("Examples Documentation Audit", ["REQ-YG-147"]),
+    "CAP-50": ("CI CHANGELOG Gate", ["REQ-YG-148"]),
 }
 
 

--- a/tests/unit/test_ci_changelog_gate.py
+++ b/tests/unit/test_ci_changelog_gate.py
@@ -1,0 +1,171 @@
+"""Tests for CI CHANGELOG gate in commitlint.yml (FR-149).
+
+Validates that the `changelog-gate` job in `.github/workflows/commitlint.yml`
+correctly blocks feat/fix PRs without CHANGELOG.md in the diff and skips
+for other PR types.
+
+Two test layers:
+1. YAML structure — parse the workflow and verify job config, conditions, steps.
+2. Shell logic — run the verification script with mocked git diff output.
+"""
+
+import subprocess
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = ".github/workflows/commitlint.yml"
+
+# The shell script from the changelog-gate step, extracted for unit testing.
+# Mirrors the `run:` block in commitlint.yml; uses env vars BASE_SHA/HEAD_SHA.
+CHANGELOG_GATE_SCRIPT = """\
+if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '^CHANGELOG\\.md$'; then
+  echo "✅ CHANGELOG.md is modified"
+else
+  echo "::error::feat/fix PRs must include changes to CHANGELOG.md"
+  exit 1
+fi
+"""
+
+
+def _load_workflow() -> dict:
+    """Load and parse the commitlint workflow YAML."""
+    with open(WORKFLOW_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _run_gate_script(diff_output: str) -> subprocess.CompletedProcess:
+    """Run the changelog gate script with mocked git diff output.
+
+    Replaces `git diff --name-only "$BASE_SHA" "$HEAD_SHA"` with an echo
+    of the provided diff output to test the grep logic in isolation.
+    """
+    script = CHANGELOG_GATE_SCRIPT.replace(
+        'git diff --name-only "$BASE_SHA" "$HEAD_SHA"',
+        f"echo '{diff_output}'",
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── YAML Structure Tests ───────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-148")
+class TestChangelogGateJobStructure:
+    """Verify the changelog-gate job exists with correct configuration."""
+
+    def test_job_exists(self) -> None:
+        """The commitlint workflow must contain a 'changelog-gate' job."""
+        wf = _load_workflow()
+        assert (
+            "changelog-gate" in wf["jobs"]
+        ), "Missing 'changelog-gate' job in commitlint.yml"
+
+    def test_job_name(self) -> None:
+        """The job display name indicates CHANGELOG is required for feat/fix."""
+        wf = _load_workflow()
+        job = wf["jobs"]["changelog-gate"]
+        assert "CHANGELOG" in job["name"], "Job name must mention CHANGELOG"
+        assert (
+            "feat" in job["name"] or "fix" in job["name"]
+        ), "Job name must mention feat or fix"
+
+    def test_job_condition_checks_feat(self) -> None:
+        """The job-level `if` condition must check for 'feat' PR titles."""
+        wf = _load_workflow()
+        job = wf["jobs"]["changelog-gate"]
+        condition = job.get("if", "")
+        assert (
+            "startsWith(github.event.pull_request.title, 'feat')" in condition
+        ), "Job must check for feat PR titles"
+
+    def test_job_condition_checks_fix(self) -> None:
+        """The job-level `if` condition must check for 'fix' PR titles."""
+        wf = _load_workflow()
+        job = wf["jobs"]["changelog-gate"]
+        condition = job.get("if", "")
+        assert (
+            "startsWith(github.event.pull_request.title, 'fix')" in condition
+        ), "Job must check for fix PR titles"
+
+    def test_checkout_with_full_history(self) -> None:
+        """The checkout step must use fetch-depth: 0 for full git history."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["changelog-gate"]["steps"]
+        checkout_steps = [
+            s for s in steps if s.get("uses", "").startswith("actions/checkout")
+        ]
+        assert checkout_steps, "Must have an actions/checkout step"
+        checkout = checkout_steps[0]
+        assert (
+            checkout.get("with", {}).get("fetch-depth") == 0
+        ), "Checkout must use fetch-depth: 0"
+
+    def test_verify_step_uses_git_diff(self) -> None:
+        """The verification step must use git diff with base/head SHAs."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["changelog-gate"]["steps"]
+        verify_steps = [s for s in steps if "run" in s and "CHANGELOG" in s["run"]]
+        assert verify_steps, "Must have a step that checks CHANGELOG.md"
+        run_script = verify_steps[0]["run"]
+        assert "git diff --name-only" in run_script
+        assert "CHANGELOG" in run_script
+
+    def test_verify_step_has_sha_env_vars(self) -> None:
+        """The verification step must receive BASE_SHA and HEAD_SHA from GitHub context."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["changelog-gate"]["steps"]
+        verify_steps = [s for s in steps if "run" in s and "CHANGELOG" in s["run"]]
+        assert verify_steps, "Must have a verification step"
+        env = verify_steps[0].get("env", {})
+        assert "BASE_SHA" in env, "Must pass BASE_SHA env var"
+        assert "HEAD_SHA" in env, "Must pass HEAD_SHA env var"
+
+
+# ── Shell Script Logic Tests ───────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-148")
+class TestChangelogGateShellLogic:
+    """Test the actual bash script that verifies CHANGELOG.md in diff."""
+
+    def test_changelog_in_diff_passes(self) -> None:
+        """When CHANGELOG.md is in the diff, the gate passes."""
+        result = _run_gate_script("CHANGELOG.md")
+        assert result.returncode == 0, f"Should pass: {result.stderr}"
+        assert "CHANGELOG.md is modified" in result.stdout
+
+    def test_changelog_absent_from_diff_fails(self) -> None:
+        """When CHANGELOG.md is NOT in the diff, the gate fails."""
+        result = _run_gate_script("src/main.py\nREADME.md")
+        assert result.returncode == 1, "Should fail without CHANGELOG.md"
+        assert (
+            "must include changes to CHANGELOG.md" in result.stderr
+            or "must include changes to CHANGELOG.md" in result.stdout
+        )
+
+    def test_empty_diff_fails(self) -> None:
+        """An empty diff (no changed files) fails the gate."""
+        result = _run_gate_script("")
+        assert result.returncode == 1, "Empty diff should fail"
+
+    def test_changelog_among_many_files_passes(self) -> None:
+        """CHANGELOG.md among other changed files still passes."""
+        result = _run_gate_script("src/main.py\nCHANGELOG.md\ntests/test_foo.py")
+        assert result.returncode == 0, "Should pass with CHANGELOG.md in file list"
+
+    def test_partial_match_rejected(self) -> None:
+        """A file like 'docs/CHANGELOG.md' should NOT satisfy the gate."""
+        result = _run_gate_script("docs/CHANGELOG.md")
+        assert (
+            result.returncode == 1
+        ), "Nested CHANGELOG.md should not satisfy root-level check"
+
+    def test_substring_match_rejected(self) -> None:
+        """A file like 'CHANGELOG.md.bak' should NOT satisfy the gate."""
+        result = _run_gate_script("CHANGELOG.md.bak")
+        assert result.returncode == 1, "CHANGELOG.md.bak should not satisfy the check"


### PR DESCRIPTION
## Summary

Add `changelog-gate` job to `.github/workflows/commitlint.yml` that blocks merge of `feat` and `fix` PRs unless `CHANGELOG.md` is modified in the PR diff.

Closes the structural gap where server-side squash merges bypass local commit-msg hooks (FR-077) and post-merge scripts can be forgotten (FR-125).

## Changes

- `changelog-gate` job with job-level `if` condition for feat/fix PR titles
- `git diff --name-only` with anchored grep against base/head SHAs
- `actions/checkout@v4` with `fetch-depth: 0` for full history
- REQ-YG-145 / CAP-47 added to ARCHITECTURE.md and req_coverage.py
- 13 unit tests (YAML structure + shell logic)
- Diary reflection entry

See FR at `feature-requests/FR-149-ci-changelog-gate.md`