### PR TITLE
fix(changelog): FR-153 add missing Removed section for stale demo cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -322,6 +322,7 @@ YAMLGraph implements **19 capabilities** covering **68 requirements**. Each capa
 | 45 | Diary Reflection Enforcement | `.pre-commit-config.yaml`, `scripts/finalize_merge.sh` | REQ-YG-144 |
 | 46 | Diary Import CLI | `yamlgraph/diary/importer.py`, `yamlgraph/cli/diary_commands.py` | REQ-YG-122 |
 | 47 | Phantom Requirement Detection | `scripts/req_coverage.py`, `tests/unit/test_req_coverage` | REQ-YG-145 |
+| 48 | CHANGELOG Removal Completeness | `CHANGELOG.md` | REQ-YG-146 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -733,6 +734,14 @@ Detect and reject test markers that reference non-existent requirement IDs.
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-145 | **Phantom requirement detection**: `req_coverage.py --strict` rejects `@pytest.mark.req` markers referencing requirement IDs absent from `ALL_REQS` or `ARCHITECTURE.md` | `scripts/req_coverage.py`, `tests/unit/test_req_coverage` |
+
+### 48. CHANGELOG Removal Completeness (FR-153)
+
+CHANGELOG.md `[Unreleased]` documents significant file removals per Commandment 8.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-146 | CHANGELOG.md `[Unreleased]` contains a `### Removed` section documenting stale demo file deletions (commit a0e6f00): `examples/cost-router/poc_granite.py`, `scripts/loopback-poc/` (419 lines); section ordering follows Keep a Changelog convention (Added → Removed → Fixed) | `CHANGELOG.md`, `tests/unit/test_demo_cleanup_changelog` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FR-113 Linter W015**: Warn when cycle node has explicit `skip_if_exists: true` — the node will cache its first output and return stale results on every iteration. Only fires on explicit setting; runtime `apply_loop_node_defaults()` handles the default case. (REQ-YG-113)
 - **FR-106 Next Steps Output**: Print merge, discard, and cleanup commands after successful PR creation in `enforce_worktree.sh`
 
+### Removed
+- Stale demo files: `examples/cost-router/poc_granite.py`, `scripts/loopback-poc/` experiment (419 lines, commit a0e6f00)
+
 ### Fixed
 - **FR-139 Enforce Worktree bare=true Corruption Guard**: Add three-layer defense against `.git/config` corruption (env sanitization, cleanup trap restoration, post-run assertion) that can set `bare = true` after worktree operations. (REQ-YG-UTIL)
 - **Enforce Pipeline Timeout**: Increase `submit_pr` timeout from 120s to 500s to prevent premature abort during PR creation

--- a/feature-requests/FR-153-demo-cleanup-changelog-entry.md
+++ b/feature-requests/FR-153-demo-cleanup-changelog-entry.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Bug
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.25 days
 **Requested:** 2026-03-08
 
@@ -37,11 +37,11 @@ Add a `### Removed` section under `[Unreleased]` in CHANGELOG.md, before the exi
 
 ## Acceptance Criteria
 
-- [ ] CHANGELOG.md `[Unreleased]` contains a `### Removed` section
-- [ ] Entry references the three deleted files and commit `a0e6f00`
-- [ ] Entry describes the removal as stale demo cleanup
-- [ ] `grep -c "poc_granite\|loopback-poc" CHANGELOG.md` returns ≥ 1
-- [ ] Section ordering follows Keep a Changelog convention (Added → Changed → Removed → Fixed)
+- [x] CHANGELOG.md `[Unreleased]` contains a `### Removed` section
+- [x] Entry references the three deleted files and commit `a0e6f00`
+- [x] Entry describes the removal as stale demo cleanup
+- [x] `grep -c "poc_granite\|loopback-poc" CHANGELOG.md` returns ≥ 1
+- [x] Section ordering follows Keep a Changelog convention (Added → Changed → Removed → Fixed)
 
 ## Alternatives Considered
 

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -43,6 +43,7 @@ _ALL_FRAMEWORK_REQS = (
     + [144]  # REQ-YG-144 (CAP-45 Diary Reflection Enforcement)
     + [122]  # REQ-YG-122 (CAP-46 Diary Import CLI)
     + [145]  # REQ-YG-145 (CAP-47 Phantom Requirement Detection)
+    + [146]  # REQ-YG-146 (CAP-48 CHANGELOG Removal Completeness)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -218,6 +219,8 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-45": ("Diary Reflection Enforcement", ["REQ-YG-144"]),
     "CAP-46": ("Diary Import CLI", ["REQ-YG-122"]),
     "CAP-47": ("Phantom Requirement Detection", ["REQ-YG-145"]),
+    "CAP-47": ("Phantom Requirement Detection", ["REQ-YG-145"]),
+    "CAP-48": ("CHANGELOG Removal Completeness", ["REQ-YG-146"]),
 }
 
 

--- a/tests/unit/test_demo_cleanup_changelog.py
+++ b/tests/unit/test_demo_cleanup_changelog.py
@@ -1,0 +1,65 @@
+"""Unit tests for FR-153: Stale demo cleanup CHANGELOG entry.
+
+Verifies that CHANGELOG.md documents the removal of stale demo files
+from commit a0e6f00, per Commandment 8: "record significant removals
+in commit notes."
+"""
+
+import os
+import re
+
+import pytest
+
+
+def _read_changelog() -> str:
+    """Read the current CHANGELOG.md content."""
+    changelog_path = os.path.join(os.path.dirname(__file__), "..", "..", "CHANGELOG.md")
+    with open(changelog_path) as f:
+        return f.read()
+
+
+def _unreleased_block() -> str:
+    """Extract the [Unreleased] section from CHANGELOG.md."""
+    changelog = _read_changelog()
+    unreleased_start = changelog.index("[Unreleased]")
+    next_section = changelog.find("\n## [0.", unreleased_start)
+    return changelog[unreleased_start:next_section]
+
+
+@pytest.mark.req("REQ-YG-146")
+class TestDemoCleanupChangelog:
+    """Verify CHANGELOG.md documents the stale demo cleanup (FR-153)."""
+
+    def test_changelog_has_removed_section(self):
+        """AC1: CHANGELOG.md [Unreleased] contains a ### Removed section."""
+        unreleased = _unreleased_block()
+        assert "### Removed" in unreleased
+
+    def test_removed_entry_references_deleted_files(self):
+        """AC2: Entry references the three deleted files and commit a0e6f00."""
+        unreleased = _unreleased_block()
+        assert "poc_granite" in unreleased
+        assert "loopback-poc" in unreleased
+        assert "a0e6f00" in unreleased
+
+    def test_removed_entry_describes_stale_cleanup(self):
+        """AC3: Entry describes the removal as stale demo cleanup."""
+        unreleased = _unreleased_block()
+        # Must mention stale and demo/cleanup context
+        lower = unreleased.lower()
+        assert "stale" in lower
+        assert "demo" in lower or "cleanup" in lower
+
+    def test_grep_matches_deleted_files(self):
+        """AC4: grep -c 'poc_granite|loopback-poc' CHANGELOG.md returns >= 1."""
+        changelog = _read_changelog()
+        matches = len(re.findall(r"poc_granite|loopback-poc", changelog))
+        assert matches >= 1
+
+    def test_section_ordering_follows_convention(self):
+        """AC5: Section ordering follows Keep a Changelog (Added → Removed → Fixed)."""
+        unreleased = _unreleased_block()
+        added_pos = unreleased.index("### Added")
+        removed_pos = unreleased.index("### Removed")
+        fixed_pos = unreleased.index("### Fixed")
+        assert added_pos < removed_pos < fixed_pos


### PR DESCRIPTION
## Summary

Add the missing `### Removed` CHANGELOG entry for commit `a0e6f00` (`chore: cleanup of stale demos`), which deleted 419 lines across 3 files without recording the removal.

This resolves a three-audit CHANGELOG violation flagged in Inquisitor Audits XXXVI, XXXVIII, and XXXIX.

### Changes
- Added `### Removed` section under `[Unreleased]` in CHANGELOG.md
- Entry references deleted files: `poc_granite.py`, `scripts/loopback-poc/`
- Section ordering follows Keep a Changelog convention

See FR at `feature-requests/FR-153-demo-cleanup-changelog-entry.md`