### PR TITLE
feat(ci): FR-158 add diary-gate CI job for reflection enforcement

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -66,3 +66,46 @@ jobs:
             echo "::error::feat/fix PRs must include changes to CHANGELOG.md"
             exit 1
           fi
+
+  diary-gate:
+    name: Diary reflection required for feat/fix
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.event.pull_request.title, 'feat') ||
+      startsWith(github.event.pull_request.title, 'fix')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify diary reflection exists
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Extract FR number from PR title
+          FR_NUM=$(echo "$PR_TITLE" | grep -oE 'FR-[0-9]+' | head -1 | sed 's/FR-//')
+
+          if [ -z "$FR_NUM" ]; then
+            echo "⏭️ No FR-XXX reference in title — diary gate skipped"
+            exit 0
+          fi
+
+          echo "🔍 Checking for diary reflection for FR-$FR_NUM..."
+
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "docs/diary/.*reflection.*fr-${FR_NUM}[^0-9]"; then
+            echo "✅ Diary reflection found for FR-$FR_NUM"
+          else
+            echo "::error::feat/fix PRs referencing FR-$FR_NUM must include a diary reflection in docs/diary/"
+            echo ""
+            echo "Expected: docs/diary/YYYY-MM-DD-reflection-fr-${FR_NUM}.md"
+            echo ""
+            echo "The diary reflection should document:"
+            echo "  - Cognitive traps encountered"
+            echo "  - Heuristics learned"
+            echo "  - A Seed question for future work"
+            echo ""
+            echo "See docs/diary/ for examples."
+            exit 1
+          fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,7 @@ Key flow anchors in code:
 
 ## Capabilities & Requirements Traceability
 
-YAMLGraph implements **51 capabilities** covering **113 requirements**. Each capability maps to specific modules.
+YAMLGraph implements **52 capabilities** covering **114 requirements**. Each capability maps to specific modules.
 
 ### Capability Summary
 
@@ -327,6 +327,7 @@ YAMLGraph implements **51 capabilities** covering **113 requirements**. Each cap
 | 50 | CI CHANGELOG Gate | `.github/workflows/commitlint.yml` | REQ-YG-148 |
 | 51 | Branch Protection Documentation | `reference/break-glass.md` | REQ-YG-149 |
 | 52 | Architecture Capability Count Guard | `tests/unit/test_architecture_capability_count` | REQ-YG-150 |
+| 53 | CI Diary Existence Gate | `.github/workflows/commitlint.yml` | REQ-YG-151 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -778,6 +779,14 @@ Guard test ensuring the capability and requirement counts in the summary sentenc
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-150 | **Architecture capability count guard**: CI test verifies the capability and requirement counts in the ARCHITECTURE.md summary sentence match the actual capability table rows and unique REQ-YG-IDs | `tests/unit/test_architecture_capability_count` |
+
+### 53. CI Diary Existence Gate (FR-158)
+
+CI gate ensuring feat/fix PRs with FR references include a diary reflection file in the diff.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-151 | `diary-gate` job in `commitlint.yml` extracts `FR-XXX` from PR title, runs `git diff --name-only` against base/head SHAs, and fails when no `docs/diary/*reflection*fr-{number}*` file is in diff; skips (passes) when PR title has no FR reference; job-level `if` condition restricts to `feat`/`fix` PR titles; uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `tests/unit/test_ci_diary_gate` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **FR-158 Diary Gate CI Job**: Add `diary-gate` job to `.github/workflows/commitlint.yml` that blocks merge of `feat`/`fix` PRs with `FR-XXX` reference unless a diary reflection file exists in the PR diff. Closes the enforcement gap where server-side squash merges bypass local pre-commit diary hooks.
+
 ## [0.4.61] — 2026-03-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,12 +294,13 @@ The `main` branch is protected by GitHub branch protection rules (FR-150). These
 |------|---------|---------|
 | Require pull request | Enabled (0 approvals) | No direct pushes to `main` |
 | Squash merge only | Merge commits and rebase disabled | PR title = commit message; enforces Conventional Commits |
-| Required status checks | `commitlint`, `test` | PR cannot merge with failing CI |
+| Required status checks | `commitlint`, `test`, `diary-gate` | PR cannot merge with failing CI |
 
 ### Required status checks
 
 - **`commitlint`** (`.github/workflows/commitlint.yml`): Validates PR title follows Conventional Commits format. `feat` PRs must include `FR-XXX` reference.
 - **`test`** (`.github/workflows/workflow.yml`): Runs `pytest` with 80% coverage threshold and `ruff` linting.
+- **`diary-gate`** (`.github/workflows/commitlint.yml`): Blocks `feat`/`fix` PRs with `FR-XXX` reference unless a diary reflection file exists in the diff.
 
 ### Emergency bypass
 

--- a/docs/diary/2026-03-08-reflection-fr-158.md
+++ b/docs/diary/2026-03-08-reflection-fr-158.md
@@ -1,0 +1,9 @@
+## 2026-03-08: FR-158 — CI Diary Gate Reflection
+
+**Context:** Implemented a `diary-gate` GitHub Actions job that blocks feat/fix PRs referencing FR-XXX from merging unless a diary reflection file exists in the diff. This closes the structural gap that five consecutive Inquisitor audits (XL–XLIV) identified but could not remediate — missing diary reflections for merged features.
+
+**Trap:** audit_as_ritual — "3+ audits without fix → ritual, not process." Five audits flagged missing diary reflections. FR-152 retroactively created missing files, but recurrence was immediate. The per-instance fix doesn't scale. The cure was already proven by FR-149 (CHANGELOG gate): enforcement at the merge boundary, not detection after the fact. The pattern was right there — I just needed to apply it a second time.
+
+**Heuristic:** When the same enforcement pattern (CI gate for file existence) solves two problems (CHANGELOG, diary), extract the structural insight: any artifact that must accompany a change type needs a pre-merge gate, not a post-merge audit. Detection without blocking is observation without agency. The gate template — check PR title prefix, extract identifier, verify file glob — is now a reusable pattern for future "must accompany" constraints.
+
+**Seed:** Could we generalize the gate pattern into a single parameterized workflow job that takes (pr_title_prefix, identifier_regex, required_file_glob) and eliminates the need to write a new job for each "must accompany" constraint?

--- a/feature-requests/FR-158-diary-existence-ci-gate.md
+++ b/feature-requests/FR-158-diary-existence-ci-gate.md
@@ -3,7 +3,7 @@
 **ID:** FR-158
 **Priority:** HIGH
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-08
 
@@ -96,15 +96,15 @@ The two gates compose cleanly with no overlap:
 
 ## Acceptance Criteria
 
-- [ ] New job `diary-gate` added to `.github/workflows/commitlint.yml`
-- [ ] `feat` PRs with `FR-XXX` reference and no `docs/diary/*reflection*fr-XXX*.md` in changed files → check fails
-- [ ] `feat` PRs with `FR-XXX` reference and matching diary file in changed files → check passes
-- [ ] `fix` PRs with `FR-XXX` reference follow same logic as `feat`
-- [ ] `fix` PRs without `FR-XXX` reference → check skips (passes)
-- [ ] `chore`, `docs`, `test`, `ci`, `refactor`, `perf`, `style`, `build`, `revert` PRs → job skipped entirely via `if` condition
+- [x] New job `diary-gate` added to `.github/workflows/commitlint.yml`
+- [x] `feat` PRs with `FR-XXX` reference and no `docs/diary/*reflection*fr-XXX*.md` in changed files → check fails
+- [x] `feat` PRs with `FR-XXX` reference and matching diary file in changed files → check passes
+- [x] `fix` PRs with `FR-XXX` reference follow same logic as `feat`
+- [x] `fix` PRs without `FR-XXX` reference → check skips (passes)
+- [x] `chore`, `docs`, `test`, `ci`, `refactor`, `perf`, `style`, `build`, `revert` PRs → job skipped entirely via `if` condition
 - [ ] `diary-gate` added as required status check in branch protection (FR-150)
-- [ ] Error message includes expected file path pattern and content guidance
-- [ ] Documentation: `CLAUDE.md` Branch Protection table updated with new required check
+- [x] Error message includes expected file path pattern and content guidance
+- [x] Documentation: `CLAUDE.md` Branch Protection table updated with new required check
 
 ## Alternatives Considered
 

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -48,6 +48,7 @@ _ALL_FRAMEWORK_REQS = (
     + [148]  # REQ-YG-148 (CAP-50 CI CHANGELOG Gate)
     + [149]  # REQ-YG-149 (CAP-51 Branch Protection Documentation)
     + [150]  # REQ-YG-150 (CAP-52 Architecture Capability Count Guard)
+    + [151]  # REQ-YG-151 (CAP-53 CI Diary Existence Gate)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -228,6 +229,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-50": ("CI CHANGELOG Gate", ["REQ-YG-148"]),
     "CAP-51": ("Branch Protection Documentation", ["REQ-YG-149"]),
     "CAP-52": ("Architecture Capability Count Guard", ["REQ-YG-150"]),
+    "CAP-53": ("CI Diary Existence Gate", ["REQ-YG-151"]),
 }
 
 

--- a/tests/unit/test_ci_diary_gate.py
+++ b/tests/unit/test_ci_diary_gate.py
@@ -1,0 +1,253 @@
+"""Tests for CI diary reflection gate in commitlint.yml (FR-158).
+
+Validates that the `diary-gate` job in `.github/workflows/commitlint.yml`
+correctly blocks feat/fix PRs without a diary reflection file for the
+referenced FR number, and skips for PRs without an FR reference.
+
+Two test layers:
+1. YAML structure — parse the workflow and verify job config, conditions, steps.
+2. Shell logic — run the verification script with mocked git diff output.
+"""
+
+import subprocess
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = ".github/workflows/commitlint.yml"
+
+# The shell script from the diary-gate step, extracted for unit testing.
+# Mirrors the `run:` block in commitlint.yml; uses env vars BASE_SHA/HEAD_SHA/PR_TITLE.
+DIARY_GATE_SCRIPT = """\
+FR_NUM=$(echo "$PR_TITLE" | grep -oE 'FR-[0-9]+' | head -1 | sed 's/FR-//')
+
+if [ -z "$FR_NUM" ]; then
+  echo "⏭️ No FR-XXX reference in title — diary gate skipped"
+  exit 0
+fi
+
+echo "🔍 Checking for diary reflection for FR-$FR_NUM..."
+
+if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "docs/diary/.*reflection.*fr-${FR_NUM}[^0-9]"; then
+  echo "✅ Diary reflection found for FR-$FR_NUM"
+else
+  echo "::error::feat/fix PRs referencing FR-$FR_NUM must include a diary reflection in docs/diary/"
+  echo ""
+  echo "Expected: docs/diary/YYYY-MM-DD-reflection-fr-${FR_NUM}.md"
+  echo ""
+  echo "The diary reflection should document:"
+  echo "  - Cognitive traps encountered"
+  echo "  - Heuristics learned"
+  echo "  - A Seed question for future work"
+  echo ""
+  echo "See docs/diary/ for examples."
+  exit 1
+fi
+"""
+
+
+def _load_workflow() -> dict:
+    """Load and parse the commitlint workflow YAML."""
+    with open(WORKFLOW_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _run_gate_script(
+    diff_output: str, pr_title: str = "feat(core): FR-158 add diary gate"
+) -> subprocess.CompletedProcess:
+    """Run the diary gate script with mocked git diff output.
+
+    Replaces `git diff --name-only "$BASE_SHA" "$HEAD_SHA"` with an echo
+    of the provided diff output to test the grep logic in isolation.
+    """
+    script = DIARY_GATE_SCRIPT.replace(
+        'git diff --name-only "$BASE_SHA" "$HEAD_SHA"',
+        f"echo '{diff_output}'",
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={"PR_TITLE": pr_title, "PATH": "/usr/bin:/bin"},
+    )
+
+
+# ── YAML Structure Tests ───────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-151")
+class TestDiaryGateJobStructure:
+    """Verify the diary-gate job exists with correct configuration."""
+
+    def test_job_exists(self) -> None:
+        """The commitlint workflow must contain a 'diary-gate' job."""
+        wf = _load_workflow()
+        assert (
+            "diary-gate" in wf["jobs"]
+        ), "Missing 'diary-gate' job in commitlint.yml"
+
+    def test_job_name(self) -> None:
+        """The job display name indicates diary is required for feat/fix."""
+        wf = _load_workflow()
+        job = wf["jobs"]["diary-gate"]
+        name = job["name"].lower()
+        assert "diary" in name, "Job name must mention diary"
+        assert (
+            "feat" in name or "fix" in name
+        ), "Job name must mention feat or fix"
+
+    def test_job_condition_checks_feat(self) -> None:
+        """The job-level `if` condition must check for 'feat' PR titles."""
+        wf = _load_workflow()
+        job = wf["jobs"]["diary-gate"]
+        condition = job.get("if", "")
+        assert (
+            "startsWith(github.event.pull_request.title, 'feat')" in condition
+        ), "Job must check for feat PR titles"
+
+    def test_job_condition_checks_fix(self) -> None:
+        """The job-level `if` condition must check for 'fix' PR titles."""
+        wf = _load_workflow()
+        job = wf["jobs"]["diary-gate"]
+        condition = job.get("if", "")
+        assert (
+            "startsWith(github.event.pull_request.title, 'fix')" in condition
+        ), "Job must check for fix PR titles"
+
+    def test_checkout_with_full_history(self) -> None:
+        """The checkout step must use fetch-depth: 0 for full git history."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["diary-gate"]["steps"]
+        checkout_steps = [
+            s for s in steps if s.get("uses", "").startswith("actions/checkout")
+        ]
+        assert checkout_steps, "Must have an actions/checkout step"
+        checkout = checkout_steps[0]
+        assert (
+            checkout.get("with", {}).get("fetch-depth") == 0
+        ), "Checkout must use fetch-depth: 0"
+
+    def test_verify_step_uses_git_diff(self) -> None:
+        """The verification step must use git diff with base/head SHAs."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["diary-gate"]["steps"]
+        verify_steps = [s for s in steps if "run" in s and "diary" in s["run"].lower()]
+        assert verify_steps, "Must have a step that checks diary reflection"
+        run_script = verify_steps[0]["run"]
+        assert "git diff --name-only" in run_script
+        assert "diary" in run_script.lower()
+
+    def test_verify_step_has_required_env_vars(self) -> None:
+        """The verification step must receive BASE_SHA, HEAD_SHA, and PR_TITLE."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["diary-gate"]["steps"]
+        verify_steps = [s for s in steps if "run" in s and "diary" in s["run"].lower()]
+        assert verify_steps, "Must have a verification step"
+        env = verify_steps[0].get("env", {})
+        assert "BASE_SHA" in env, "Must pass BASE_SHA env var"
+        assert "HEAD_SHA" in env, "Must pass HEAD_SHA env var"
+        assert "PR_TITLE" in env, "Must pass PR_TITLE env var"
+
+    def test_error_message_includes_guidance(self) -> None:
+        """The error message must include expected path pattern and content guidance."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["diary-gate"]["steps"]
+        verify_steps = [s for s in steps if "run" in s and "diary" in s["run"].lower()]
+        assert verify_steps, "Must have a verification step"
+        run_script = verify_steps[0]["run"]
+        assert "reflection" in run_script, "Error must mention reflection"
+        assert "Seed" in run_script, "Error must mention Seed question"
+        assert "Cognitive traps" in run_script or "traps" in run_script.lower(), (
+            "Error must mention cognitive traps"
+        )
+
+
+# ── Shell Script Logic Tests ───────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-151")
+class TestDiaryGateShellLogic:
+    """Test the actual bash script that verifies diary reflection in diff."""
+
+    def test_diary_reflection_in_diff_passes(self) -> None:
+        """When a matching diary reflection is in the diff, the gate passes."""
+        result = _run_gate_script(
+            "docs/diary/2026-03-08-reflection-fr-158.md",
+            pr_title="feat(ci): FR-158 add diary gate",
+        )
+        assert result.returncode == 0, f"Should pass: {result.stderr}"
+        assert "Diary reflection found" in result.stdout
+
+    def test_diary_reflection_absent_from_diff_fails(self) -> None:
+        """When no diary reflection is in the diff, the gate fails."""
+        result = _run_gate_script(
+            "src/main.py\nREADME.md",
+            pr_title="feat(ci): FR-158 add diary gate",
+        )
+        assert result.returncode == 1, "Should fail without diary reflection"
+        assert "must include a diary reflection" in result.stdout
+
+    def test_empty_diff_fails(self) -> None:
+        """An empty diff (no changed files) fails the gate."""
+        result = _run_gate_script(
+            "",
+            pr_title="feat(ci): FR-158 add diary gate",
+        )
+        assert result.returncode == 1, "Empty diff should fail"
+
+    def test_diary_among_many_files_passes(self) -> None:
+        """A matching diary file among other changed files still passes."""
+        result = _run_gate_script(
+            "src/main.py\ndocs/diary/2026-03-08-reflection-fr-158.md\ntests/test_foo.py",
+            pr_title="feat(ci): FR-158 add diary gate",
+        )
+        assert result.returncode == 0, "Should pass with diary in file list"
+
+    def test_wrong_fr_number_rejected(self) -> None:
+        """A diary file for a different FR number should NOT satisfy the gate."""
+        result = _run_gate_script(
+            "docs/diary/2026-03-08-reflection-fr-999.md",
+            pr_title="feat(ci): FR-158 add diary gate",
+        )
+        assert result.returncode == 1, "Wrong FR number should not satisfy the check"
+
+    def test_no_fr_reference_skips(self) -> None:
+        """A PR without FR-XXX reference skips the gate (passes)."""
+        result = _run_gate_script(
+            "src/main.py",
+            pr_title="fix(typo): correct spelling in README",
+        )
+        assert result.returncode == 0, "No FR reference should skip"
+        assert "diary gate skipped" in result.stdout
+
+    def test_fix_pr_with_fr_enforced(self) -> None:
+        """A fix PR with FR reference must also include diary reflection."""
+        result = _run_gate_script(
+            "src/main.py",
+            pr_title="fix(core): FR-042 resolve edge case",
+        )
+        assert result.returncode == 1, "fix PR with FR reference should enforce diary"
+
+    def test_fix_pr_with_fr_and_diary_passes(self) -> None:
+        """A fix PR with FR reference and matching diary file passes."""
+        result = _run_gate_script(
+            "src/main.py\ndocs/diary/2026-03-08-reflection-fr-042.md",
+            pr_title="fix(core): FR-042 resolve edge case",
+        )
+        assert result.returncode == 0, "fix PR with FR and diary should pass"
+
+    def test_substring_fr_number_not_matched(self) -> None:
+        """FR-15 should NOT match a diary file for FR-158."""
+        result = _run_gate_script(
+            "docs/diary/2026-03-08-reflection-fr-158.md",
+            pr_title="feat(ci): FR-15 some feature",
+        )
+        assert result.returncode == 1, "FR-15 should not match fr-158 diary file"
+
+    def test_diary_file_with_extra_suffix_passes(self) -> None:
+        """Diary files with extra descriptive suffixes should still match."""
+        result = _run_gate_script(
+            "docs/diary/2026-03-08-reflection-fr-158-diary-gate.md",
+            pr_title="feat(ci): FR-158 add diary gate",
+        )
+        assert result.returncode == 0, "Descriptive suffix should still match"

--- a/tests/unit/test_ci_diary_gate.py
+++ b/tests/unit/test_ci_diary_gate.py
@@ -82,9 +82,7 @@ class TestDiaryGateJobStructure:
     def test_job_exists(self) -> None:
         """The commitlint workflow must contain a 'diary-gate' job."""
         wf = _load_workflow()
-        assert (
-            "diary-gate" in wf["jobs"]
-        ), "Missing 'diary-gate' job in commitlint.yml"
+        assert "diary-gate" in wf["jobs"], "Missing 'diary-gate' job in commitlint.yml"
 
     def test_job_name(self) -> None:
         """The job display name indicates diary is required for feat/fix."""
@@ -92,9 +90,7 @@ class TestDiaryGateJobStructure:
         job = wf["jobs"]["diary-gate"]
         name = job["name"].lower()
         assert "diary" in name, "Job name must mention diary"
-        assert (
-            "feat" in name or "fix" in name
-        ), "Job name must mention feat or fix"
+        assert "feat" in name or "fix" in name, "Job name must mention feat or fix"
 
     def test_job_condition_checks_feat(self) -> None:
         """The job-level `if` condition must check for 'feat' PR titles."""
@@ -157,9 +153,9 @@ class TestDiaryGateJobStructure:
         run_script = verify_steps[0]["run"]
         assert "reflection" in run_script, "Error must mention reflection"
         assert "Seed" in run_script, "Error must mention Seed question"
-        assert "Cognitive traps" in run_script or "traps" in run_script.lower(), (
-            "Error must mention cognitive traps"
-        )
+        assert (
+            "Cognitive traps" in run_script or "traps" in run_script.lower()
+        ), "Error must mention cognitive traps"
 
 
 # ── Shell Script Logic Tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a `diary-gate` GitHub Actions job to `.github/workflows/commitlint.yml` that blocks `feat` and `fix` PRs referencing `FR-XXX` from merging unless a diary reflection file (`docs/diary/*-reflection-fr-XXX.md`) exists in the diff.

Closes the structural gap that five consecutive Inquisitor audits (XL–XLIV) identified: missing diary reflections for merged features.

## Changes

- **CI job**: `diary-gate` in `commitlint.yml` — extracts FR number from PR title, verifies diary file in diff
- **Tests**: 15 unit tests covering job structure, shell script logic, and edge cases
- **Diary**: Reflection for FR-158 with audit_as_ritual trap and parameterized gate seed

See FR at `feature-requests/FR-158-diary-existence-ci-gate.md`