### PR TITLE
docs(diary): FR-161 add missing reflections for FR-150 and FR-154

### DIFF
--- a/docs/diary/2026-03-08-reflection-fr-150.md
+++ b/docs/diary/2026-03-08-reflection-fr-150.md
@@ -1,0 +1,9 @@
+## 2026-03-08: FR-150 — Branch Protection for Main Reflection
+
+**Context:** FR-150 added GitHub branch protection rules to `main` — requiring pull requests (no direct pushes), squash-merge only, and two required status checks (`commitlint` and `test`). The emergency bypass procedure was documented in `reference/break-glass.md`. This closed the structural gap where prior enforcement gates (FR-127 commitlint, FR-149 CI CHANGELOG gate) operated inside the PR path but could be entirely bypassed by pushing directly to `main`.
+
+**Trap:** *downstream_fix* — Before FR-150, all enforcement existed downstream of the actual merge boundary. Conventional Commits linting, CHANGELOG gates, and test suites ran inside PRs, but a direct `git push origin main` sidestepped every one of them. The instinct was to keep adding more PR-level checks, when the real fix was moving the enforcement boundary upstream to the repository settings level. GitHub's branch protection API creates a true pre-merge gate at the path itself — no local workflow can bypass it. The trap was adding ever-more checks inside an already-guarded path while leaving the unguarded path wide open.
+
+**Heuristic:** When enforcement gates are bypassed by an alternative path (direct push vs PR), the fix is to gate the path itself (branch protection), not add more checks inside the existing path. This is a specific instance of the Knowledge Graph's `the_one_law`: normalize at the boundary where external data enters, not downstream where it manifests. The push-to-main path was the boundary; PR checks were downstream.
+
+**Seed:** Could branch protection rules be declaratively managed in a YAML config file (like `.github/branch-protection.yaml`) and enforced by CI, closing the gap between documented rules and actual GitHub API settings? This would make protection rules version-controlled and auditable, preventing drift between what the team believes is enforced and what GitHub actually enforces.

--- a/docs/diary/2026-03-08-reflection-fr-154.md
+++ b/docs/diary/2026-03-08-reflection-fr-154.md
@@ -1,0 +1,9 @@
+## 2026-03-08: FR-154 — Architecture Capability Count Guard Reflection
+
+**Context:** FR-154 added a guard test in `test_architecture_capability_count.py` that reads `ARCHITECTURE.md`, counts the actual capability table rows and requirement IDs, and asserts they match the prose claim. The prose stated "19 capabilities covering 68 requirements" while the actual document had grown to 46 capabilities and 109 requirements — 27 capabilities added without ever updating the summary. The fix was structural: a test that fails when the counts drift.
+
+**Trap:** *audit_as_ritual* — The capability count was accurate when first written (at CAP-19). As new capabilities were added through subsequent FRs, the prose became stale. No one noticed because the number was treated as decoration, not as a testable claim. Manual discipline failed silently across 27 capability additions — each individual contributor assumed someone else would update the summary, or didn't notice the summary existed. The audits detected the drift but, for three consecutive cycles (XLII → XLIII → XLIV), the detection produced no remediation. Detection without enforcement is ritual, not process.
+
+**Heuristic:** When a document makes quantitative claims about the codebase, guard those claims with a test. Manual discipline decays; structural enforcement closes drift permanently. This mirrors the pattern FR-121 established for provider counts in `ARCHITECTURE.md` — the same class of problem (prose claiming a number that the code has outgrown) solved by the same class of fix (a guard test that reads the document and asserts correctness). If a number appears in prose and that number can be computed, it must be computed.
+
+**Seed:** Should the guard test auto-update the prose counts on failure (fix-on-detect) rather than merely failing, or does the manual correction step serve as a valuable review checkpoint that forces the author to survey what changed?

--- a/feature-requests/FR-161-missing-diary-reflections-fr150-fr154.md
+++ b/feature-requests/FR-161-missing-diary-reflections-fr150-fr154.md
@@ -3,7 +3,7 @@
 **ID:** FR-161
 **Priority:** HIGH
 **Type:** Bug
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.25 days
 **Requested:** 2026-03-08
 
@@ -50,12 +50,12 @@ Create two diary reflection files following the established naming convention an
 
 ## Acceptance Criteria
 
-- [ ] `docs/diary/2026-03-08-reflection-fr-150.md` exists with genuine metacognitive content (not placeholder stubs)
-- [ ] `docs/diary/2026-03-08-reflection-fr-154.md` exists with genuine metacognitive content (not placeholder stubs)
-- [ ] Each reflection identifies at least one cognitive trap from the Knowledge Graph (`downstream_fix`, `audit_as_ritual`, or equivalent)
-- [ ] Each reflection contains a forward-looking **Seed** question
-- [ ] Both files follow the naming convention `YYYY-MM-DD-reflection-fr-NNN.md`
-- [ ] Both files pass the `diary-reflection-check` pre-commit hook (no unfilled placeholders)
+- [x] `docs/diary/2026-03-08-reflection-fr-150.md` exists with genuine metacognitive content (not placeholder stubs)
+- [x] `docs/diary/2026-03-08-reflection-fr-154.md` exists with genuine metacognitive content (not placeholder stubs)
+- [x] Each reflection identifies at least one cognitive trap from the Knowledge Graph (`downstream_fix`, `audit_as_ritual`, or equivalent)
+- [x] Each reflection contains a forward-looking **Seed** question
+- [x] Both files follow the naming convention `YYYY-MM-DD-reflection-fr-NNN.md`
+- [x] Both files pass the `diary-reflection-check` pre-commit hook (no unfilled placeholders)
 - [ ] Next inquisitor audit clears both violations (no ✗ VIOLATION for FR-150/FR-154 reflections)
 
 ## Alternatives Considered

--- a/tests/unit/test_diary_reflections_fr161.py
+++ b/tests/unit/test_diary_reflections_fr161.py
@@ -1,0 +1,125 @@
+"""Tests for FR-161: Missing diary reflections for FR-150 and FR-154.
+
+Validates that diary reflection files exist with genuine metacognitive content,
+not placeholder stubs. Each reflection must identify a cognitive trap and
+contain a forward-looking Seed question per the Sermon's Distill obligation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+DIARY_DIR = Path(__file__).resolve().parents[2] / "docs" / "diary"
+
+# ── FR-150 reflection ────────────────────────────────────────────────
+
+
+FR150_PATH = DIARY_DIR / "2026-03-08-reflection-fr-150.md"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr150_reflection_exists():
+    """AC: docs/diary/2026-03-08-reflection-fr-150.md exists."""
+    assert FR150_PATH.is_file(), f"Missing reflection: {FR150_PATH}"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr150_reflection_not_stub():
+    """AC: Genuine metacognitive content, not a placeholder stub."""
+    content = FR150_PATH.read_text()
+    assert len(content.strip()) > 200, "Reflection is too short to be genuine"
+    placeholder_markers = ["[What cognitive trap", "[What lesson", "[What question"]
+    for marker in placeholder_markers:
+        assert marker not in content, f"Placeholder text found: {marker}"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr150_reflection_has_cognitive_trap():
+    """AC: Identifies at least one cognitive trap from the Knowledge Graph."""
+    content = FR150_PATH.read_text().lower()
+    known_traps = [
+        "batch_fatigue",
+        "partial_remediation",
+        "quick_confidence",
+        "downstream_fix",
+        "symptom_patch",
+        "intent_drift",
+        "false_duplicate",
+        "audit_as_ritual",
+        "plausible_wrong_answer",
+        "framework_costume",
+        "working_system_inertia",
+    ]
+    found = [t for t in known_traps if t in content]
+    assert found, f"No known cognitive trap found. Expected one of: {known_traps}"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr150_reflection_has_seed():
+    """AC: Contains a forward-looking Seed question."""
+    content = FR150_PATH.read_text()
+    assert "**Seed:**" in content, "Missing **Seed:** section"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr150_reflection_naming_convention():
+    """AC: Follows YYYY-MM-DD-reflection-fr-NNN.md convention."""
+    assert FR150_PATH.name == "2026-03-08-reflection-fr-150.md"
+
+
+# ── FR-154 reflection ────────────────────────────────────────────────
+
+
+FR154_PATH = DIARY_DIR / "2026-03-08-reflection-fr-154.md"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr154_reflection_exists():
+    """AC: docs/diary/2026-03-08-reflection-fr-154.md exists."""
+    assert FR154_PATH.is_file(), f"Missing reflection: {FR154_PATH}"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr154_reflection_not_stub():
+    """AC: Genuine metacognitive content, not a placeholder stub."""
+    content = FR154_PATH.read_text()
+    assert len(content.strip()) > 200, "Reflection is too short to be genuine"
+    placeholder_markers = ["[What cognitive trap", "[What lesson", "[What question"]
+    for marker in placeholder_markers:
+        assert marker not in content, f"Placeholder text found: {marker}"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr154_reflection_has_cognitive_trap():
+    """AC: Identifies at least one cognitive trap from the Knowledge Graph."""
+    content = FR154_PATH.read_text().lower()
+    known_traps = [
+        "batch_fatigue",
+        "partial_remediation",
+        "quick_confidence",
+        "downstream_fix",
+        "symptom_patch",
+        "intent_drift",
+        "false_duplicate",
+        "audit_as_ritual",
+        "plausible_wrong_answer",
+        "framework_costume",
+        "working_system_inertia",
+    ]
+    found = [t for t in known_traps if t in content]
+    assert found, f"No known cognitive trap found. Expected one of: {known_traps}"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr154_reflection_has_seed():
+    """AC: Contains a forward-looking Seed question."""
+    content = FR154_PATH.read_text()
+    assert "**Seed:**" in content, "Missing **Seed:** section"
+
+
+@pytest.mark.req("REQ-YG-144")
+def test_fr154_reflection_naming_convention():
+    """AC: Follows YYYY-MM-DD-reflection-fr-NNN.md convention."""
+    assert FR154_PATH.name == "2026-03-08-reflection-fr-154.md"


### PR DESCRIPTION
## Summary

Closes the long-standing audit violations for FR-150 and FR-154 missing diary reflections (5 and 3 consecutive ✗ respectively).

- **FR-150 reflection:** Identifies `downstream_fix` trap — enforcement gates inside PRs were bypassed by direct pushes; branch protection gates the path itself
- **FR-154 reflection:** Identifies `audit_as_ritual` trap — prose claimed 19 capabilities while 46 existed; guard test closes drift permanently

See FR at `feature-requests/FR-161-missing-diary-reflections-fr150-fr154.md`