### PR TITLE
feat(claude-md): FR-163 add chaplain inbox instructions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,7 @@ Key flow anchors in code:
 
 ## Capabilities & Requirements Traceability
 
-YAMLGraph implements **53 capabilities** covering **115 requirements**. Each capability maps to specific modules.
+YAMLGraph implements **54 capabilities** covering **116 requirements**. Each capability maps to specific modules.
 
 ### Capability Summary
 
@@ -329,6 +329,7 @@ YAMLGraph implements **53 capabilities** covering **115 requirements**. Each cap
 | 52 | Architecture Capability Count Guard | `tests/unit/test_architecture_capability_count` | REQ-YG-150 |
 | 53 | CI Conflict Marker Gate | `.github/workflows/commitlint.yml` | REQ-YG-151 |
 | 54 | CI Diary Existence Gate | `.github/workflows/commitlint.yml` | REQ-YG-152 |
+| 55 | Chaplain Inbox Documentation | `CLAUDE.md` | REQ-YG-153 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -796,6 +797,14 @@ CI gate ensuring feat/fix PRs with FR references include a diary reflection file
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-152 | `diary-gate` job in `commitlint.yml` extracts `FR-XXX` from PR title, runs `git diff --name-only` against base/head SHAs, and fails when no `docs/diary/*reflection*fr-{number}*` file is in diff; skips (passes) when PR title has no FR reference; job-level `if` condition restricts to `feat`/`fix` PR titles; uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `tests/unit/test_ci_diary_gate` |
+
+### 23. Chaplain Inbox Documentation
+
+Document the `.chaplain/inbox/` workflow in `CLAUDE.md` so Claude Code sessions can discover and use the autonomous proposal pipeline.
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-153 | `CLAUDE.md` contains a "Submitting Proposals" subsection documenting the `.chaplain/inbox/` workflow, matching the canonical source in `.github/copilot-instructions.md` verbatim, placed between the "Development Process" and "Development Commands" sections | `CLAUDE.md`, `tests/unit/test_claude_md_chaplain_inbox` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-163 Chaplain Inbox Instructions in CLAUDE.md**: Add "Submitting Proposals" section to `CLAUDE.md` documenting the `.chaplain/inbox/` workflow, mirroring `.github/copilot-instructions.md`. Closes discovery gap for Claude Code sessions.
 - **FR-158 Diary Gate CI Job**: Add `diary-gate` job to `.github/workflows/commitlint.yml` that blocks merge of `feat`/`fix` PRs with `FR-XXX` reference unless a diary reflection file exists in the PR diff. Closes the enforcement gap where server-side squash merges bypass local pre-commit diary hooks. (REQ-YG-152)
 - **FR-157 CI Conflict Marker Gate**: Add `conflict-check` job to `.github/workflows/commitlint.yml` that greps tracked files for unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), excluding `.github/` and `*.md.bak`. Complements the local `check-merge-conflict` pre-commit hook which is bypassed by server-side squash merges. Document `conflict-check` status check and "require branches to be up to date" setting in `CLAUDE.md` branch protection table. (REQ-YG-151)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,13 @@ Before implementing any feature or fix:
 
 > **Example**: URL-based prompt loading was proposed as a 2-day feature. After reflection, we realized documenting deployment patterns (volume mounts, git-sync, ConfigMaps) solved the same problem without adding framework complexity. See `reference/prompt-deployment.md`.
 
+### Submitting Proposals
+- Write a markdown file to `.chaplain/inbox/` with a descriptive kebab-case filename (e.g., `refactor-state-builder.md`)
+- Content: plain text description of the problem or task — freeform, but actionable
+- The `.chaplain/watch.sh` daemon picks it up and runs Plan → Judge → Enforce automatically
+- For new features, a one-paragraph problem statement suffices — the Chaplain generates the FR and PR
+- Proposals are consumed on pickup (moved out of inbox); rejected FRs are skipped by the enforce pipeline
+
 ## Development Commands
 
 ### Environment Setup

--- a/docs/diary/2026-03-08-reflection-fr-163.md
+++ b/docs/diary/2026-03-08-reflection-fr-163.md
@@ -1,0 +1,9 @@
+## 2026-03-08: FR-163 — Chaplain Inbox Instructions in CLAUDE.md
+
+**Context:** Added a "Submitting Proposals" section to `CLAUDE.md` documenting the `.chaplain/inbox/` workflow, mirroring the canonical source in `.github/copilot-instructions.md`. This closes a discovery gap where Claude Code sessions could not find the autonomous proposal pipeline.
+
+**Trap:** documentation_drift — Two AI instruction files (`.github/copilot-instructions.md` and `CLAUDE.md`) with asymmetric coverage of the same workflow. The chaplain inbox mechanism existed and was documented in one place but invisible to agents consuming the other. The fix was trivial (copy four lines), but the detection required an audit to notice the asymmetry. The real cost of drift is not the fix — it's the silent failure of agents that never discover the capability.
+
+**Heuristic:** When a workflow is documented in one AI instruction file, check all instruction files for parity. Instruction file drift is a special case of the boundary normalization law: the boundary here is "where an agent reads its instructions." Normalize at every entry point, not just the first one discovered. The test (`test_matches_canonical_source`) enforces this structurally — if either file drifts, the test fails.
+
+**Seed:** Could we generate a single canonical source for shared instructions (e.g., `reference/ai-instructions.yaml`) and have both `CLAUDE.md` and `.github/copilot-instructions.md` include from it, eliminating the possibility of drift entirely?

--- a/feature-requests/FR-163-chaplain-inbox-instructions-in-claude-md.md
+++ b/feature-requests/FR-163-chaplain-inbox-instructions-in-claude-md.md
@@ -2,7 +2,7 @@
 
 **Priority:** LOW
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-08
 
@@ -41,11 +41,11 @@ Add a "Submitting Proposals" subsection to `CLAUDE.md`, placed after the "Develo
 
 ## Acceptance Criteria
 
-- [ ] `CLAUDE.md` contains a "### Submitting Proposals" section describing the `.chaplain/inbox/` workflow
-- [ ] Section text matches the canonical source in `.github/copilot-instructions.md` (verbatim)
-- [ ] Section is placed between "Development Process" and "Development Commands"
-- [ ] `grep -c "chaplain/inbox" CLAUDE.md` returns ≥ 1
-- [ ] No duplication or contradiction with existing documentation
+- [x] `CLAUDE.md` contains a "### Submitting Proposals" section describing the `.chaplain/inbox/` workflow
+- [x] Section text matches the canonical source in `.github/copilot-instructions.md` (verbatim)
+- [x] Section is placed between "Development Process" and "Development Commands"
+- [x] `grep -c "chaplain/inbox" CLAUDE.md` returns ≥ 1
+- [x] No duplication or contradiction with existing documentation
 - [ ] PR follows Conventional Commits: `docs(claude-md): FR-163 add chaplain inbox instructions`
 
 ## Alternatives Considered

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -50,6 +50,7 @@ _ALL_FRAMEWORK_REQS = (
     + [150]  # REQ-YG-150 (CAP-52 Architecture Capability Count Guard)
     + [151]  # REQ-YG-151 (CAP-53 CI Conflict Marker Gate)
     + [152]  # REQ-YG-152 (CAP-54 CI Diary Existence Gate)
+    + [153]  # REQ-YG-153 (CAP-55 Chaplain Inbox Documentation)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -232,6 +233,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-52": ("Architecture Capability Count Guard", ["REQ-YG-150"]),
     "CAP-53": ("CI Conflict Marker Gate", ["REQ-YG-151"]),
     "CAP-54": ("CI Diary Existence Gate", ["REQ-YG-152"]),
+    "CAP-55": ("Chaplain Inbox Documentation", ["REQ-YG-153"]),
 }
 
 

--- a/tests/unit/test_claude_md_chaplain_inbox.py
+++ b/tests/unit/test_claude_md_chaplain_inbox.py
@@ -1,0 +1,95 @@
+"""Tests for FR-163: Chaplain inbox instructions in CLAUDE.md.
+
+Verifies that CLAUDE.md documents the .chaplain/inbox/ workflow
+so Claude Code sessions can discover the autonomous proposal pipeline.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.req("REQ-YG-153")
+class TestClaudeMdChaplainInbox:
+    """Verify CLAUDE.md contains chaplain inbox instructions."""
+
+    def test_claude_md_has_submitting_proposals_section(self):
+        content = (REPO_ROOT / "CLAUDE.md").read_text()
+        assert (
+            "### Submitting Proposals" in content
+        ), "CLAUDE.md must have a 'Submitting Proposals' subsection (FR-163 AC-1)"
+
+    def test_claude_md_mentions_chaplain_inbox(self):
+        content = (REPO_ROOT / "CLAUDE.md").read_text()
+        assert (
+            ".chaplain/inbox/" in content
+        ), "CLAUDE.md must mention .chaplain/inbox/ path (FR-163 AC-4)"
+
+    def test_claude_md_mentions_watch_daemon(self):
+        content = (REPO_ROOT / "CLAUDE.md").read_text()
+        assert (
+            ".chaplain/watch.sh" in content
+        ), "CLAUDE.md must reference the watch.sh daemon"
+
+    def test_claude_md_mentions_plan_judge_enforce(self):
+        content = (REPO_ROOT / "CLAUDE.md").read_text()
+        assert (
+            "Plan → Judge → Enforce" in content
+            or "Plan → Judge → Enforce" in content
+        ), "CLAUDE.md must describe the Plan → Judge → Enforce pipeline"
+
+    def test_section_placed_before_development_commands(self):
+        content = (REPO_ROOT / "CLAUDE.md").read_text()
+        proposals_pos = content.find("### Submitting Proposals")
+        dev_commands_pos = content.find("## Development Commands")
+        assert proposals_pos != -1, "Submitting Proposals section not found"
+        assert dev_commands_pos != -1, "Development Commands section not found"
+        assert proposals_pos < dev_commands_pos, (
+            "Submitting Proposals must appear before Development Commands"
+        )
+
+    def test_section_placed_after_development_process(self):
+        content = (REPO_ROOT / "CLAUDE.md").read_text()
+        reflect_pos = content.find("### 4. Reflect")
+        proposals_pos = content.find("### Submitting Proposals")
+        assert reflect_pos != -1, "'Reflect' section not found"
+        assert proposals_pos != -1, "Submitting Proposals section not found"
+        assert reflect_pos < proposals_pos, (
+            "Submitting Proposals must appear after the Reflect section"
+        )
+
+    def test_matches_canonical_source(self):
+        """Section text must match .github/copilot-instructions.md verbatim."""
+        claude_md = (REPO_ROOT / "CLAUDE.md").read_text()
+        copilot_md = (REPO_ROOT / ".github" / "copilot-instructions.md").read_text()
+
+        # Extract "### Submitting Proposals" section from both files
+        for source, name in [
+            (claude_md, "CLAUDE.md"),
+            (copilot_md, "copilot-instructions.md"),
+        ]:
+            assert "### Submitting Proposals" in source, (
+                f"{name} missing 'Submitting Proposals' section"
+            )
+
+        def extract_section(text: str) -> str:
+            start = text.index("### Submitting Proposals")
+            # Find next heading (## or ###) or end of file
+            rest = text[start + len("### Submitting Proposals") :]
+            for i, line in enumerate(rest.split("\n")):
+                if i > 0 and line.startswith("#"):
+                    end = start + len("### Submitting Proposals") + sum(
+                        len(l) + 1 for l in rest.split("\n")[:i]
+                    )
+                    return text[start:end].strip()
+            return text[start:].strip()
+
+        claude_section = extract_section(claude_md)
+        copilot_section = extract_section(copilot_md)
+        assert claude_section == copilot_section, (
+            "Submitting Proposals section must match canonical source verbatim.\n"
+            f"CLAUDE.md:\n{claude_section}\n\n"
+            f"copilot-instructions.md:\n{copilot_section}"
+        )

--- a/tests/unit/test_claude_md_chaplain_inbox.py
+++ b/tests/unit/test_claude_md_chaplain_inbox.py
@@ -36,8 +36,7 @@ class TestClaudeMdChaplainInbox:
     def test_claude_md_mentions_plan_judge_enforce(self):
         content = (REPO_ROOT / "CLAUDE.md").read_text()
         assert (
-            "Plan → Judge → Enforce" in content
-            or "Plan → Judge → Enforce" in content
+            "Plan → Judge → Enforce" in content or "Plan → Judge → Enforce" in content
         ), "CLAUDE.md must describe the Plan → Judge → Enforce pipeline"
 
     def test_section_placed_before_development_commands(self):
@@ -46,9 +45,9 @@ class TestClaudeMdChaplainInbox:
         dev_commands_pos = content.find("## Development Commands")
         assert proposals_pos != -1, "Submitting Proposals section not found"
         assert dev_commands_pos != -1, "Development Commands section not found"
-        assert proposals_pos < dev_commands_pos, (
-            "Submitting Proposals must appear before Development Commands"
-        )
+        assert (
+            proposals_pos < dev_commands_pos
+        ), "Submitting Proposals must appear before Development Commands"
 
     def test_section_placed_after_development_process(self):
         content = (REPO_ROOT / "CLAUDE.md").read_text()
@@ -56,9 +55,9 @@ class TestClaudeMdChaplainInbox:
         proposals_pos = content.find("### Submitting Proposals")
         assert reflect_pos != -1, "'Reflect' section not found"
         assert proposals_pos != -1, "Submitting Proposals section not found"
-        assert reflect_pos < proposals_pos, (
-            "Submitting Proposals must appear after the Reflect section"
-        )
+        assert (
+            reflect_pos < proposals_pos
+        ), "Submitting Proposals must appear after the Reflect section"
 
     def test_matches_canonical_source(self):
         """Section text must match .github/copilot-instructions.md verbatim."""
@@ -70,9 +69,9 @@ class TestClaudeMdChaplainInbox:
             (claude_md, "CLAUDE.md"),
             (copilot_md, "copilot-instructions.md"),
         ]:
-            assert "### Submitting Proposals" in source, (
-                f"{name} missing 'Submitting Proposals' section"
-            )
+            assert (
+                "### Submitting Proposals" in source
+            ), f"{name} missing 'Submitting Proposals' section"
 
         def extract_section(text: str) -> str:
             start = text.index("### Submitting Proposals")
@@ -80,8 +79,10 @@ class TestClaudeMdChaplainInbox:
             rest = text[start + len("### Submitting Proposals") :]
             for i, line in enumerate(rest.split("\n")):
                 if i > 0 and line.startswith("#"):
-                    end = start + len("### Submitting Proposals") + sum(
-                        len(l) + 1 for l in rest.split("\n")[:i]
+                    end = (
+                        start
+                        + len("### Submitting Proposals")
+                        + sum(len(line_text) + 1 for line_text in rest.split("\n")[:i])
                     )
                     return text[start:end].strip()
             return text[start:].strip()


### PR DESCRIPTION
## Summary

Add "Submitting Proposals" section to `CLAUDE.md` documenting the `.chaplain/inbox/` workflow, mirroring the canonical source in `.github/copilot-instructions.md`.

## Changes
- Add chaplain inbox instructions to `CLAUDE.md` (placed after Development Process, before Development Commands)
- Add test ensuring section exists, is correctly placed, and matches canonical source verbatim
- Add diary reflection for FR-163
- CHANGELOG entry under [Unreleased]

See FR at `feature-requests/FR-163-chaplain-inbox-instructions-in-claude-md.md`