### PR TITLE
feat(ci): FR-167 remove copilot trailer requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FR-157 CI Conflict Marker Gate**: Add `conflict-check` job to `.github/workflows/commitlint.yml` that greps tracked files for unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`), excluding `.github/` and `*.md.bak`. Complements the local `check-merge-conflict` pre-commit hook which is bypassed by server-side squash merges. Document `conflict-check` status check and "require branches to be up to date" setting in `CLAUDE.md` branch protection table. (REQ-YG-151)
 
 ### Removed
+- **FR-167 Remove Copilot Trailer Requirement**: Remove `Co-authored-by: Copilot` trailer from `finalize_merge.sh` commit message. Delete `test_commit_includes_co_author` test; replace with `test_commit_excludes_co_author_trailer`. Supersede FR-132. (REQ-YG-125)
 - **FR-162 Vulture Dead Code Cleanup**: Delete dead `yamlgraph/utils/sanitize.py` module and orphaned `tests/unit/test_sanitize.py` (zero production callers). Add `vulture_whitelist.py` for `worktree_helpers` false positives (shell-invoked via `python3 -c`). Lower Vulture confidence threshold from 80→60. (REQ-YG-046)
 
 ### Fixed

--- a/docs/diary/2026-03-08-inquisitor-audit-61.md
+++ b/docs/diary/2026-03-08-inquisitor-audit-61.md
@@ -1,0 +1,15 @@
+## 2026-03-08: Inquisitor Audit — FR-166 Post-Squash Commits
+
+**Context:** Audited 5 most recent commits on `main`: the squash-merged PR `9de67ac` (feat: FR-166 CountRangeClaim) and 4 follow-up local commits (`18fe85c` RED, `d2bc138` GREEN, `68490d2` chore, `0c58a96` diary batch). Focus: Conventional Commits, CHANGELOG, ADR-001, diary compliance, Co-authored-by trailers.
+
+**Findings:**
+
+- ✓ COMPLIANT — All 5 commits follow Conventional Commits with correct type/scope/FR reference. RED and GREEN commits are properly separated with descriptive bodies.
+- ✓ COMPLIANT — CHANGELOG has entries under both Added (CountRangeClaim model) and Fixed (Pydantic extraction bug). REQ-YG-154 and REQ-YG-155 registered in ARCHITECTURE.md. All 7 new tests carry `@pytest.mark.req("REQ-YG-154")`.
+- ✓ COMPLIANT — Two diary reflections exist: `2026-03-08-reflection-fr-166.md` (from squash PR) and `2026-03-08-fr166-pydantic-extraction.md` (post-fix). Both identify traps (`downstream_fix`, `plausible_wrong_answer`) and plant seeds.
+- ⚠ DRIFT — The 4 post-squash commits (`18fe85c`..`0c58a96`) lack the `Co-authored-by: Copilot` trailer required by custom instructions. The squash-merged PR commit `9de67ac` has it. Local commits authored with Copilot assistance should carry the trailer.
+- ⚠ DRIFT — 39 inquisitor audit files exist for this single date, mixing Arabic (54–60) and Roman (xlix–lviii) numbering. The audit process is generating entropy (Commandment 8). Consider a single rolling audit log per day or per sprint instead of per-invocation files.
+
+**Heuristic:** Audit infrastructure must itself be audited for entropy. When a process designed to enforce order produces more disorder than the code it inspects, the process needs refactoring — not more invocations.
+
+**Seed:** Should inquisitor audits be appended to a single weekly log file rather than spawning individual files? A `docs/diary/audits/YYYY-WXX.md` format would reduce file count by ~40× while preserving traceability.

--- a/docs/diary/2026-03-08-inquisitor-audit-62.md
+++ b/docs/diary/2026-03-08-inquisitor-audit-62.md
@@ -1,0 +1,19 @@
+## 2026-03-08: Inquisitor Audit 62 — FR-166 Pydantic Extraction & FR-167 Trailer Proposal
+
+**Context:** Audited the 5 most recent commits (18fe85c → d2ae6c0) covering FR-166 (count_range Pydantic extraction fix) and FR-167 (remove Co-authored-by trailer requirement proposal). Checked Conventional Commits, CHANGELOG, ADR-001 traceability, TDD discipline, diary reflections, and noqa confessions.
+
+**Findings:**
+
+1. ✓ COMPLIANT — **TDD discipline exemplary.** FR-166 RED (18fe85c) and GREEN (d2bc138) are separate commits. The RED commit message lists each failing test by name and explains what will fix it. The GREEN commit is surgically scoped to `_extract_countable()` plus ARCHITECTURE/CHANGELOG updates. Commandment 7 fully honoured.
+
+2. ✓ COMPLIANT — **ADR-001 traceability complete.** REQ-YG-154 and REQ-YG-155 exist in ARCHITECTURE.md. All 20+ tests in `test_verification.py` carry `@pytest.mark.req` markers. CHANGELOG entries reference both requirements.
+
+3. ✓ COMPLIANT — **Conventional Commits consistent.** All 5 commits follow `type(scope): description` format. `fix` and `test` commits reference FR-166. `docs(FR)` correctly scoped for the FR-167 proposal.
+
+4. ✓ COMPLIANT — **noqa confessions current.** Both active suppressions (`executor_async.py:310` ANN001, `token_tracker.py:51` ARG002) are documented in `docs/confessions.md`. No new suppressions introduced.
+
+5. ⚠ DRIFT — **Co-authored-by trailers absent on all 5 commits.** The system prompt still mandates the trailer, but FR-167 (status: Approved) argues it is `audit_as_ritual` — non-functional metadata consuming disproportionate audit bandwidth. The Knowledge Graph's own trap definition applies: "3+ audits without fix → ritual, not process." Until FR-167 is enforced (removing the requirement from the system prompt), this remains a technical deviation. Classified as DRIFT rather than VIOLATION because the approved FR signals deliberate intent to remove the criterion.
+
+**Heuristic:** When an audit criterion triggers repeatedly without leading to corrective action, the criterion itself — not the codebase — is the defect. Escalate to eliminate the criterion rather than mechanizing enforcement of a non-requirement. (`audit_as_ritual` → FR-167 is the canonical example.)
+
+**Seed:** FR-167 proposes deleting the trailer requirement. Once enforced, should the Inquisitor's audit checklist be itself version-controlled as a YAML config — so that adding/removing audit criteria leaves a traceable commit trail rather than being embedded in prose prompts?

--- a/docs/diary/2026-03-09-git-report.md
+++ b/docs/diary/2026-03-09-git-report.md
@@ -1,0 +1,46 @@
+## 2026-03-09: Git Report
+
+Excellent! Now I have a comprehensive picture. Let me compile the analysis:
+
+---
+
+## 📊 Git Repository Analysis: Last 3 Days (March 6-8, 2026)
+
+### **Overview**
+The repository shows **intense, focused development** with **7 major features completed** and comprehensive documentation/testing. All commits are from March 8, 2026, indicating a single high-velocity development day.
+
+---
+
+### **🎯 Feature-Level Summary**
+
+#### **1. FR-166: Pydantic Verification Model Enhancement** ✅ COMPLETED
+- **Status:** Completed with all acceptance criteria met
+- **Changes:** 
+  - Added `CountRangeClaim` Pydantic model for structured verification claims
+  - Fixed bug where `len(BaseModel)` raised TypeError → now properly extracts countable data
+  - Implemented `_extract_countable()` helper for single-list field unwrapping
+- **Impact:** Verification gate demo now runs without false violations
+- **Test Coverage:** 45 verification tests passing, 2182 total unit tests green
+
+#### **2. FR-165: Silent Fallback Lint Rule** ✅ COMPLETED
+- **Status:** Completed
+- **Changes:**
+  - Added W017 lint check flagging `on_error: skip` patterns
+  - Registered requirement REQ-YG-069 for lint coverage
+- **Impact:** Prevents silent failure patterns in graph definitions
+- **Test Coverage:** 5 new unit tests + 139 total linter contract tests
+
+#### **3. FR-164: Verification Gate Pattern** ✅ COMPLETED
+- **Status:** Completed with full integration
+- **Changes:**
+  - Added `VerificationConfig` schema with predict/check/threshold fields
+  - Implemented runtime verification with cosine similarity checking
+  - Integrated into LLM node execution pipeline
+  - Added linter checks for verification field contracts
+  - Added demo example: `examples/demos/verification-gate/`
+- **Impact:** Enables silent failure detection in LLM outputs
+- **Test Coverage:** 36 new unit tests covering schema, runtime, linter, and integration
+
+#### **4. FR-163: Chaplain Inbox Instructions** ✅ COMPLETED
+- **Status:** Completed
+- **Changes:** Add

--- a/docs/diary/2026-03-09-reflection-fr-167.md
+++ b/docs/diary/2026-03-09-reflection-fr-167.md
@@ -1,0 +1,9 @@
+# FR-167 Reflection: Removing the Copilot Trailer
+
+**Trap:** `audit_as_ritual` — 3+ audits without fix is ritual, not process.
+
+**Insight:** The Copilot `Co-authored-by` trailer was flagged CALCIFIED-4 through CALCIFIED-6 across five consecutive Inquisitor audits. The proposed cure (FR-132: pre-commit enforcement) would mechanize a ritual that served no functional purpose.
+
+**Heuristic:** When an audit criterion repeatedly yields violations without clear value, question the criterion, not just the compliance gap. Metadata injected by tool conventions is not the same as project requirements.
+
+**Seed:** What other conventions are we enforcing simply because tooling defaults to them?

--- a/docs/diary/2026-03-09-world-digest.md
+++ b/docs/diary/2026-03-09-world-digest.md
@@ -1,0 +1,39 @@
+## 2026-03-09: World Digest — LangGraph Release Surge
+
+
+# Diary Entry – 2026‑03‑09
+
+Today’s feed was dominated by a cascade of LangGraph releases. The flagship `langgraph==1.0.10` (and its RC `1.0.10rc1`) landed on GitHub, bringing a host of stability fixes, a revamped CLI (`langgraph-cli==0.4.14`), and the new checkpoint package `langgraph-checkpoint==4.0.1` (plus its RC). The release notes highlight:
+
+- **Enhanced checkpointing** with deterministic IDs and optional compression, a direct response to the growing need for reproducible state in long‑running agents.
+- **CLI upgrades** that now expose a `graph lint` command, enabling users to run custom lint rules (e.g., flagging the `if not results: results = all_items` pattern you’ve been eye‑balling).
+- **Better integration with LangSmith**, making it trivial to push evaluation metrics from a LangGraph run straight into the LangSmith dashboard.
+
+In parallel, the LangChain ecosystem announced several agent‑orchestration updates that feel like natural companions to the LangGraph rollout:
+
+- **Agent Observability Powers Agent Evaluation** – a deep dive into telemetry hooks that can be attached to any LangGraph node, feeding fine‑grained logs into LangSmith for post‑hoc analysis.
+- **New in Agent Builder** – file uploads, a richer tool registry, and a revamped chat UI, all of which will likely rely on the newer checkpoint format for state persistence.
+- **Memory System Refactor** – a new memory layer that stores embeddings in a versioned store, again leaning on the checkpoint API.
+
+These announcements intersect nicely with several of the open Seeds we’ve been tracking:
+
+1. **Silent‑fallback lint rule** – the new `graph lint` command gives us a concrete enforcement point.
+2. **Verification‑question gate** – LangSmith’s observability hooks could be repurposed to require a falsifiable question before a node proceeds.
+3. **Protocol archaeology** – with the richer CLI we can now script a “graph‑extract” that pulls endpoint definitions from a repo and spits out a YAMLGraph‑compatible integration brief.
+4. **Invisible decisions registry** – the checkpoint metadata now supports arbitrary key‑value pairs, opening a path to store “confession” entries (e.g., hard‑coded defaults) alongside the graph definition.
+
+Overall, the momentum suggests the community is moving toward tighter coupling of **graph definition**, **runtime observability**, and **evaluation pipelines**. The next step will be to see how these pieces can be stitched together into a seamless developer experience that reduces the friction of debugging, testing, and deploying complex agent workflows.
+
+---
+
+**Open Questions to Watch**
+- Should the `graph lint` command ship with a default rule set that includes the “no‑silent‑fallback” pattern?
+- How can we formalize the “verification question” as a first‑class node attribute that LangSmith can validate automatically?
+- What new constraints will dominate once model inference costs approach zero – latency, evaluation quality, or something we haven’t named yet?
+
+---
+
+**Future Exploration Seed**
+
+
+**Seed:** How can LangGraph’s checkpoint metadata be extended to automatically capture and surface invisible decision registries (e.g., hard‑coded defaults, deferred migrations) for downstream observability and audit tooling?

--- a/feature-requests/FR-132-copilot-trailer-enforcement.md
+++ b/feature-requests/FR-132-copilot-trailer-enforcement.md
@@ -3,7 +3,7 @@
 **FR-132**
 **Priority:** HIGH
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Superseded by FR-167
 **Effort:** 0.25 days
 **Requested:** 2026-03-07
 

--- a/feature-requests/FR-167-remove-copilot-trailer-requirement.md
+++ b/feature-requests/FR-167-remove-copilot-trailer-requirement.md
@@ -3,7 +3,7 @@
 **FR-167**
 **Priority:** MEDIUM
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-08
 
@@ -75,13 +75,13 @@ FR-132 proposed adding the trailer to `enforce_worktree.sh`. Since FR-132 is sup
 
 ## Acceptance Criteria
 
-- [ ] `scripts/finalize_merge.sh` no longer injects `Co-authored-by: Copilot` trailer
-- [ ] `tests/unit/test_finalize_merge.py::test_commit_includes_co_author` deleted
-- [ ] FR-132 status updated to `Superseded by FR-167`
-- [ ] `pytest tests/unit/test_finalize_merge.py -v` passes without the removed test
-- [ ] `ruff check scripts/ yamlgraph/ tests/` clean
-- [ ] No REQ-YG-XXX references need updating (none exist for the trailer)
-- [ ] CHANGELOG.md updated
+- [x] `scripts/finalize_merge.sh` no longer injects `Co-authored-by: Copilot` trailer
+- [x] `tests/unit/test_finalize_merge.py::test_commit_includes_co_author` deleted
+- [x] FR-132 status updated to `Superseded by FR-167`
+- [x] `pytest tests/unit/test_finalize_merge.py -v` passes without the removed test
+- [x] `ruff check scripts/ yamlgraph/ tests/` clean
+- [x] No REQ-YG-XXX references need updating (none exist for the trailer)
+- [x] CHANGELOG.md updated
 
 ## Alternatives Considered
 

--- a/scripts/finalize_merge.sh
+++ b/scripts/finalize_merge.sh
@@ -102,8 +102,6 @@ chore: ${FR_NUM} post-merge finalization
 - CHANGELOG [Unreleased] entry added
 - FR status updated to Implemented
 - Diary reflection stub created (untracked)
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 EOF
 git commit -F ./tmp/msg.txt
 

--- a/tests/unit/test_finalize_merge.py
+++ b/tests/unit/test_finalize_merge.py
@@ -432,10 +432,10 @@ class TestCommit:
         )
         assert "chore: FR-240 post-merge finalization" in result.stdout
 
-    def test_commit_includes_co_author(self, tmp_path):
-        """Commit includes Co-authored-by trailer."""
+    def test_commit_excludes_co_author_trailer(self, tmp_path):
+        """FR-167: Commit must NOT contain Co-authored-by Copilot trailer."""
         repo = _make_repo(tmp_path)
-        fr_rel = _write_fr(repo, "FR-241-coauthor-test.md")
+        fr_rel = _write_fr(repo, "FR-242-no-trailer-test.md")
         _run_finalize(repo, fr_rel)
 
         result = subprocess.run(
@@ -445,7 +445,7 @@ class TestCommit:
             text=True,
             env=_clean_git_env(),
         )
-        assert "Co-authored-by: Copilot" in result.stdout
+        assert "Co-authored-by: Copilot" not in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Remove the `Co-authored-by: Copilot` trailer requirement from the codebase. Supersede FR-132 (copilot-trailer-enforcement).

## Changes

- Remove trailer injection from `scripts/finalize_merge.sh` commit template
- Replace `test_commit_includes_co_author` with `test_commit_excludes_co_author_trailer`
- Update FR-132 status to `Superseded by FR-167`
- CHANGELOG.md updated

See FR at `feature-requests/FR-167-remove-copilot-trailer-requirement.md`