### PR TITLE
feat(session): FR-168 cross-graph session continuity

### DIFF
--- a/.chaplain/watch.sh
+++ b/.chaplain/watch.sh
@@ -39,7 +39,19 @@ while true; do
             echo "🚀 Spawning enforce pipeline for: $new_fr"
             mkdir -p tmp
             LOG="tmp/enforce-$(basename "$new_fr" .md).log"
-            nohup scripts/enforce_worktree.sh "$new_fr" > "$LOG" 2>&1 &
+
+            # FR-168: Thread session ID from plan-judge to enforce pipeline
+            session_id=""
+            if [[ -f tmp/last-plan-session-id ]]; then
+                session_id=$(cat tmp/last-plan-session-id)
+                rm -f tmp/last-plan-session-id
+            fi
+
+            if [[ -n "$session_id" ]]; then
+                nohup scripts/enforce_worktree.sh "$new_fr" --session-id "$session_id" > "$LOG" 2>&1 &
+            else
+                nohup scripts/enforce_worktree.sh "$new_fr" > "$LOG" 2>&1 &
+            fi
             echo "   PID: $!  Log: $LOG"
         fi
     fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,7 @@ Key flow anchors in code:
 
 ## Capabilities & Requirements Traceability
 
-YAMLGraph implements **55 capabilities** covering **119 requirements**. Each capability maps to specific modules.
+YAMLGraph implements **56 capabilities** covering **121 requirements**. Each capability maps to specific modules.
 
 ### Capability Summary
 
@@ -331,6 +331,7 @@ YAMLGraph implements **55 capabilities** covering **119 requirements**. Each cap
 | 54 | CI Diary Existence Gate | `.github/workflows/commitlint.yml` | REQ-YG-152 |
 | 55 | Chaplain Inbox Documentation | `CLAUDE.md` | REQ-YG-153 |
 | 56 | Verification Gate Pattern | `yamlgraph/verification`, `node_factory/llm_nodes`, `linter/checks_contracts` | REQ-YG-154 |
+| 57 | Cross-Graph Session Continuity | `examples/shared/session_handoff`, `examples/copilot/graph.yaml`, `examples/enforce/graph.yaml` | REQ-YG-156, REQ-YG-157 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -816,6 +817,8 @@ Per-node runtime verification with deterministic pattern matching. Checks stated
 |------------|-------------|-------------|
 | REQ-YG-154 | `NodeConfig` accepts optional `verification` field (`VerificationConfig`) with `question` (str, required), `on_fail` (warn\|halt\|retry, default warn), `max_retries` (int, default 1). Runtime evaluator extracts deterministic checks (count_range, non_empty, contains) from question text; unrecognized patterns degrade to annotation. `warn` appends `VerificationViolation` to errors; `halt` raises `VerificationError`; `retry` re-executes then falls to warn. Lint rule W022 warns on `on_error: skip` without verification | `yamlgraph/verification`, `yamlgraph/models/graph_schema`, `yamlgraph/models/schemas`, `yamlgraph/node_factory/llm_nodes`, `yamlgraph/linter/checks_contracts`, `tests/unit/test_verification` |
 | REQ-YG-155 | Count range verification claim parsed into `CountRangeClaim` Pydantic model with `min_count` (int, ge=0), `max_count` (int, ge=0) and `model_validator` enforcing min ≤ max. Inverted ranges raise `ValueError` at parse time. Violation `details` exposes `expected_min`, `expected_max`, `actual_count` for programmatic inspection | `yamlgraph/verification`, `yamlgraph/models/__init__`, `tests/unit/test_verification` |
+| REQ-YG-156 | `write_session_id` tool extracts `session_id` from `judge_result` (CopilotResult or dict) and writes to `tmp/last-plan-session-id`. `read_session_id` reads back the value; `cleanup_session_id` removes the file. Empty/missing session ID writes empty string and returns `session_exported: False` | `examples/shared/session_handoff`, `tests/unit/test_session_handoff` |
+| REQ-YG-157 | Enforce pipeline's `implement` node accepts `plan_session_id` state variable and passes `--resume` flag to Copilot CLI when non-empty. Empty or missing `plan_session_id` starts a fresh session (graceful degradation). `watch.sh` threads session ID file to `enforce_worktree.sh` via `--session-id` flag | `examples/enforce/graph.yaml`, `.chaplain/watch.sh`, `scripts/enforce_worktree.sh`, `tests/unit/test_session_handoff` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-168 Cross-Graph Session Continuity**: Thread Copilot CLI session ID from plan-judge pipeline to enforce pipeline via file-based handoff (`tmp/last-plan-session-id`). Add `session_handoff.py` (write/read/cleanup), `export_session` node in copilot graph, `plan_session_id` resume in enforce graph, `--session-id` flag in `watch.sh` and `enforce_worktree.sh`. Linter updated to accept direct `session_id` variable names in resume expressions. (REQ-YG-156, REQ-YG-157)
 - **FR-166 CountRangeClaim Pydantic Model**: Replace loose `int` variables in count range verification with a validated `CountRangeClaim` Pydantic model. Inverted ranges (min > max) now fail at parse time. `VerificationViolation.details` populated with structured claim data. (REQ-YG-155)
 - **FR-165 No-Silent-Fallback Lint Rule (W017)**: Add lint rule W017 that flags `on_error: skip` nodes as silent fallback patterns violating Commandment 6. Suggests `on_error: fail` or `on_error: fallback` with explicit fallback node instead. (REQ-YG-114)
 - **FR-164 Verification Gate Pattern**: Add optional `verification` field to node definitions for silent failure detection. LLM states a falsifiable prediction before acting; runtime compares prediction against actual output using cosine similarity. Includes `VerificationConfig` schema, `verification.py` runtime, LLM node integration, linter checks, and demo example. (REQ-YG-064, REQ-YG-065)

--- a/docs/diary/2026-03-09-git-report.md
+++ b/docs/diary/2026-03-09-git-report.md
@@ -15,7 +15,7 @@ The repository shows **intense, focused development** with **7 major features co
 
 #### **1. FR-166: Pydantic Verification Model Enhancement** ✅ COMPLETED
 - **Status:** Completed with all acceptance criteria met
-- **Changes:** 
+- **Changes:**
   - Added `CountRangeClaim` Pydantic model for structured verification claims
   - Fixed bug where `len(BaseModel)` raised TypeError → now properly extracts countable data
   - Implemented `_extract_countable()` helper for single-list field unwrapping

--- a/docs/diary/2026-03-09-reflection-fr-168.md
+++ b/docs/diary/2026-03-09-reflection-fr-168.md
@@ -1,0 +1,10 @@
+
+---
+
+## 2026-03-09: Reflection — FR-168 Cross-Graph Session Continuity
+
+**Trap:** Linter false positive as hidden coupling. The W-COPILOT-SESSION lint rule checked for `.session_id` in the resume expression, assuming the pattern is always `{state.result.session_id}`. The cross-graph handoff uses `{state.plan_session_id}` where the variable IS the session ID. The check `".session_id" not in resume_val` excluded the valid pattern `plan_session_id` because it lacks a dot prefix. Fix: broaden to `"session_id" not in resume_val`.
+
+**Heuristic:** When introducing a new valid pattern that an existing lint rule doesn't anticipate, update the lint rule in the same commit. Lint rules encode assumptions — new patterns must update those assumptions, not work around them.
+
+**Seed:** Could the linter infer variable types from state declarations (e.g., `plan_session_id: str` in YAML state) to distinguish "this IS a session ID" from "this is a CopilotResult with a session_id attribute"? Type-aware linting would catch more classes of resume expression errors.

--- a/examples/copilot/graph.yaml
+++ b/examples/copilot/graph.yaml
@@ -4,6 +4,7 @@
 # FR-093: Added summarize + write_diary for automatic diary append
 # FR-098: Consolidated from .chaplain/graph.yaml
 # FR-105: Session continuation - judge resumes plan's session
+# FR-168: Cross-graph session continuity - export session ID for enforce pipeline
 
 version: "1.0"
 name: copilot-workflow
@@ -29,6 +30,11 @@ tools:
     type: python
     module: examples.shared.diary
     function: write_diary
+
+  write_session_id_tool:
+    type: python
+    module: examples.shared.session_handoff
+    function: write_session_id
 
 nodes:
   # Stage 1: Plan - Copilot reads topic and drafts feature request
@@ -75,6 +81,12 @@ nodes:
     tool: write_diary_tool
     state_key: written
 
+  # Stage 5: Export session ID for cross-graph handoff (FR-168)
+  export_session:
+    type: python
+    tool: write_session_id_tool
+    state_key: session_exported
+
 edges:
   - from: START
     to: plan
@@ -85,4 +97,6 @@ edges:
   - from: summarize
     to: write_diary
   - from: write_diary
+    to: export_session
+  - from: export_session
     to: END

--- a/examples/enforce/graph.yaml
+++ b/examples/enforce/graph.yaml
@@ -8,6 +8,7 @@
 #
 # All phases chain via session continuations (FR-105), creating a single
 # conversation thread where each phase has full context from prior phases.
+# FR-168: implement node resumes plan-judge session when plan_session_id provided.
 #
 # Usage via orchestration script:
 #   scripts/enforce_worktree.sh feature-requests/FR-106-parallel-worktree-pipeline.md
@@ -25,6 +26,7 @@ prompts_dir: prompts
 state:
   fr_path: str           # Path to the approved feature request
   branch: str            # Git branch name
+  plan_session_id: str   # Optional: session ID from plan-judge pipeline (FR-168)
   implement_result: dict
   test_result: dict
   precommit_result: dict
@@ -33,12 +35,14 @@ state:
 nodes:
   # Phase 1: Implement with TDD
   # Read the FR, write failing tests, implement minimal change, refactor
+  # FR-168: Resumes plan-judge session when plan_session_id is provided
   implement:
     type: copilot
     prompt: enforce-implement
     cli_flags:
       allow_all_paths: true
       allow_all_tools: true
+      resume: "{state.plan_session_id}"
     variables:
       fr_path: "{state.fr_path}"
       branch: "{state.branch}"

--- a/examples/shared/session_handoff.py
+++ b/examples/shared/session_handoff.py
@@ -1,0 +1,100 @@
+"""Cross-graph session handoff utilities.
+
+FR-168: Exports session ID from plan-judge pipeline to a well-known file,
+enabling the enforce pipeline to resume the same Copilot CLI session.
+
+The handoff uses a file-based contract (tmp/last-plan-session-id) rather than
+stdout parsing or shared state, for robustness and explicit contracts.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SESSION_ID_FILENAME = "last-plan-session-id"
+DEFAULT_OUTPUT_DIR = Path("tmp")
+
+
+def write_session_id(
+    state: dict[str, Any],
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+) -> dict[str, bool]:
+    """Write judge session ID to file for cross-graph handoff.
+
+    Extracts session_id from state["judge_result"] (CopilotResult or dict)
+    and writes it to ``output_dir/last-plan-session-id``.
+
+    Args:
+        state: Graph state containing judge_result with session_id.
+        output_dir: Directory to write session ID file. Defaults to ``tmp/``.
+
+    Returns:
+        State update with ``session_exported: bool``.
+    """
+    session_id = _extract_session_id_from_state(state)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    session_file = output_dir / SESSION_ID_FILENAME
+    session_file.write_text(session_id or "")
+
+    exported = bool(session_id)
+    if exported:
+        logger.info(f"[session-handoff] Exported session ID to {session_file}")
+    else:
+        logger.warning("[session-handoff] No session ID found in judge_result")
+
+    return {"session_exported": exported}
+
+
+def read_session_id(input_dir: Path = DEFAULT_OUTPUT_DIR) -> str | None:
+    """Read session ID from handoff file.
+
+    Args:
+        input_dir: Directory containing the session ID file.
+
+    Returns:
+        Session ID string if found and non-empty, None otherwise.
+    """
+    session_file = input_dir / SESSION_ID_FILENAME
+    if not session_file.exists():
+        return None
+
+    content = session_file.read_text().strip()
+    return content if content else None
+
+
+def cleanup_session_id(input_dir: Path = DEFAULT_OUTPUT_DIR) -> None:
+    """Remove session ID file after consumption.
+
+    Prevents stale session IDs from being reused by subsequent runs.
+
+    Args:
+        input_dir: Directory containing the session ID file.
+    """
+    session_file = input_dir / SESSION_ID_FILENAME
+    if session_file.exists():
+        session_file.unlink()
+        logger.info(f"[session-handoff] Cleaned up {session_file}")
+
+
+def _extract_session_id_from_state(state: dict[str, Any]) -> str | None:
+    """Extract session_id from judge_result in state.
+
+    Handles both CopilotResult (Pydantic model with .session_id attribute)
+    and plain dict with 'session_id' key.
+    """
+    judge_result = state.get("judge_result")
+    if judge_result is None:
+        return None
+
+    # CopilotResult (Pydantic model) — attribute access
+    if hasattr(judge_result, "session_id"):
+        return judge_result.session_id
+
+    # Dict fallback
+    if isinstance(judge_result, dict):
+        return judge_result.get("session_id")
+
+    return None

--- a/feature-requests/FR-168-cross-graph-session-continuity.md
+++ b/feature-requests/FR-168-cross-graph-session-continuity.md
@@ -2,7 +2,7 @@
 
 **Priority:** MEDIUM
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 2 days
 **Requested:** 2026-03-09
 
@@ -152,15 +152,15 @@ When `plan_session_id` is empty/None, the `resume` expression resolves to a fals
 
 ## Acceptance Criteria
 
-- [ ] Plan-judge graph exports `judge_result.session_id` to `tmp/last-plan-session-id`
-- [ ] `watch.sh` reads session ID file and passes to `enforce_worktree.sh`
-- [ ] `enforce_worktree.sh` accepts optional `--session-id` flag
-- [ ] Enforce graph's `implement` node resumes plan-judge session when session ID is provided
-- [ ] Enforce pipeline still works when no session ID is provided (graceful degradation — fresh session)
-- [ ] Session ID file is cleaned up after consumption (no stale state)
-- [ ] Unit test: session handoff tool writes and reads correctly
-- [ ] Integration test: enforce graph accepts `plan_session_id` variable and passes `--resume` flag
-- [ ] Documentation updated in `reference/graph-yaml.md` (cross-graph session pattern)
+- [x] Plan-judge graph exports `judge_result.session_id` to `tmp/last-plan-session-id`
+- [x] `watch.sh` reads session ID file and passes to `enforce_worktree.sh`
+- [x] `enforce_worktree.sh` accepts optional `--session-id` flag
+- [x] Enforce graph's `implement` node resumes plan-judge session when session ID is provided
+- [x] Enforce pipeline still works when no session ID is provided (graceful degradation — fresh session)
+- [x] Session ID file is cleaned up after consumption (no stale state)
+- [x] Unit test: session handoff tool writes and reads correctly
+- [x] Integration test: enforce graph accepts `plan_session_id` variable and passes `--resume` flag
+- [x] Documentation updated in `reference/graph-yaml.md` (cross-graph session pattern)
 
 ## Constraints
 

--- a/reference/graph-yaml.md
+++ b/reference/graph-yaml.md
@@ -564,6 +564,44 @@ nodes:
 
 See [examples/copilot/](../examples/copilot/) for a complete demo.
 
+**Cross-Graph Session Continuity (FR-168):**
+
+When two graphs run sequentially (e.g., plan-judge → enforce), you can thread the session ID via file-based handoff:
+
+1. **Export** — The first graph writes `judge_result.session_id` to `tmp/last-plan-session-id` using the `write_session_id` tool from `examples.shared.session_handoff`.
+2. **Thread** — The orchestration script reads the file and passes the session ID as a `--var` to the second graph.
+3. **Resume** — The second graph's first node uses `resume: "{state.plan_session_id}"` to continue the session.
+
+```yaml
+# Graph 1: copilot/graph.yaml (plan-judge pipeline)
+tools:
+  write_session_id_tool:
+    type: python
+    module: examples.shared.session_handoff
+    function: write_session_id
+
+nodes:
+  # ... plan, judge, summarize, write_diary ...
+  export_session:
+    type: python
+    tool: write_session_id_tool
+    state_key: session_exported
+
+# Graph 2: enforce/graph.yaml (enforce pipeline)
+state:
+  plan_session_id: str  # Passed via --var from orchestration script
+
+nodes:
+  implement:
+    type: copilot
+    prompt: enforce-implement
+    cli_flags:
+      resume: "{state.plan_session_id}"  # Resumes plan-judge session
+    state_key: implement_result
+```
+
+When `plan_session_id` is empty or missing, the `resume` expression resolves to a falsy value and the node starts a fresh session.
+
 ### `type: map` - Parallel Fan-Out Node
 
 Process each item in a list in parallel using LangGraph's `Send()` API.

--- a/scripts/enforce_worktree.sh
+++ b/scripts/enforce_worktree.sh
@@ -32,12 +32,18 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 # Validate arguments
 if [[ $# -lt 1 ]]; then
-    log_error "Usage: $0 <feature-request-path> [base-branch]"
+    log_error "Usage: $0 <feature-request-path> [base-branch] [--session-id <id>]"
     exit 1
 fi
 
-FR_PATH="$1"
-BASE_BRANCH="${2:-main}"
+# Parse arguments (FR-168: added --session-id flag)
+FR_PATH="" BASE_BRANCH="main" SESSION_ID=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --session-id) SESSION_ID="$2"; shift 2 ;;
+        *) [[ -z "$FR_PATH" ]] && FR_PATH="$1" || BASE_BRANCH="$1"; shift ;;
+    esac
+done
 
 # Validate FR file exists
 if [[ ! -f "$FR_PATH" ]]; then
@@ -116,12 +122,12 @@ cd "$WORKTREE_DIR"
 unset GIT_DIR GIT_WORK_TREE 2>/dev/null || true
 log_info "Working in: $(pwd)"
 
-# Delegate all LLM phases to the enforce pipeline graph (FR-128)
-# The graph handles: implement → test/demo → pre-commit → submit PR
+# Delegate to enforce pipeline graph (FR-128); FR-168: pass plan_session_id
 log_info "Running enforce pipeline graph..."
 yamlgraph graph run examples/enforce/graph.yaml \
     --var fr_path="$FR_PATH" \
     --var branch="$BRANCH" \
+    ${SESSION_ID:+--var plan_session_id="$SESSION_ID"} \
     --full
 
 # FR-139: Post-run assertion — catch mid-run corruption
@@ -138,21 +144,10 @@ echo ""
 echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
 echo -e "${GREEN}  NEXT STEPS${NC}"
 echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
-echo ""
-echo -e "  ${YELLOW}To merge via command line:${NC}"
-echo "    gh pr merge $BRANCH --squash --delete-branch"
-echo ""
-echo -e "  ${YELLOW}To merge via GitHub web:${NC}"
-echo "    gh pr view $BRANCH --web"
-echo ""
-echo -e "  ${YELLOW}To discard (close PR and delete branch):${NC}"
-echo "    gh pr close $BRANCH --delete-branch"
-echo ""
-echo -e "  ${YELLOW}To delete branch only (if PR already closed):${NC}"
-echo "    git push origin --delete $BRANCH"
-echo "    git branch -D $BRANCH 2>/dev/null || true"
-echo ""
-echo -e "  ${YELLOW}After merging, finalize:${NC}"
-echo "    git checkout main && git pull"
-echo "    scripts/finalize_merge.sh $FR_PATH"
-echo ""
+echo -e "
+  ${YELLOW}To merge:${NC}         gh pr merge $BRANCH --squash --delete-branch
+  ${YELLOW}To view:${NC}          gh pr view $BRANCH --web
+  ${YELLOW}To discard:${NC}       gh pr close $BRANCH --delete-branch
+  ${YELLOW}To delete branch:${NC} git push origin --delete $BRANCH
+  ${YELLOW}After merging:${NC}    git checkout main && git pull && scripts/finalize_merge.sh $FR_PATH
+"

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -54,6 +54,7 @@ _ALL_FRAMEWORK_REQS = (
     + [154]  # REQ-YG-154 (CAP-56 Verification Gate Pattern)
     + [114]  # REQ-YG-114 (CAP-57 No-Silent-Fallback Lint W017)
     + [155]  # REQ-YG-155 (CAP-58 Verification Count Range Pydantic)
+    + [156, 157]  # REQ-YG-156, 157 (CAP-57 Cross-Graph Session Continuity)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -242,6 +243,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-55": ("Chaplain Inbox Documentation", ["REQ-YG-153"]),
     "CAP-56": ("Verification Gate Pattern", ["REQ-YG-154"]),
     "CAP-57": ("Verification Count Range Pydantic", ["REQ-YG-155"]),
+    "CAP-58": ("Cross-Graph Session Continuity", ["REQ-YG-156", "REQ-YG-157"]),
 }
 
 

--- a/tests/unit/test_session_handoff.py
+++ b/tests/unit/test_session_handoff.py
@@ -1,0 +1,290 @@
+"""Unit tests for cross-graph session handoff.
+
+FR-168: Cross-Graph Session Continuity — file-based session ID handoff
+between plan-judge and enforce pipelines.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from yamlgraph.models.schemas import CopilotResult
+
+
+@pytest.mark.req("REQ-YG-156")
+class TestWriteSessionId:
+    """Tests for write_session_id tool — exports session ID to file."""
+
+    def test_writes_session_id_from_copilot_result(self, tmp_path: Path) -> None:
+        """write_session_id extracts session_id from CopilotResult and writes to file."""
+        from examples.shared.session_handoff import write_session_id
+
+        judge_result = CopilotResult(
+            output="Verdict: Approved",
+            exit_code=0,
+            backend="cli",
+            session_id="abc-123-def",
+        )
+        state = {"judge_result": judge_result}
+
+        result = write_session_id(state, output_dir=tmp_path)
+
+        assert result["session_exported"] is True
+        session_file = tmp_path / "last-plan-session-id"
+        assert session_file.exists()
+        assert session_file.read_text() == "abc-123-def"
+
+    def test_writes_empty_when_no_session_id(self, tmp_path: Path) -> None:
+        """write_session_id writes empty string when session_id is None."""
+        from examples.shared.session_handoff import write_session_id
+
+        judge_result = CopilotResult(
+            output="Verdict: Approved",
+            exit_code=0,
+            backend="cli",
+            session_id=None,
+        )
+        state = {"judge_result": judge_result}
+
+        result = write_session_id(state, output_dir=tmp_path)
+
+        assert result["session_exported"] is False
+        session_file = tmp_path / "last-plan-session-id"
+        assert session_file.exists()
+        assert session_file.read_text() == ""
+
+    def test_writes_from_dict_state(self, tmp_path: Path) -> None:
+        """write_session_id handles dict-based judge_result (not Pydantic)."""
+        from examples.shared.session_handoff import write_session_id
+
+        state = {
+            "judge_result": {
+                "output": "Approved",
+                "session_id": "dict-session-456",
+            }
+        }
+
+        result = write_session_id(state, output_dir=tmp_path)
+
+        assert result["session_exported"] is True
+        session_file = tmp_path / "last-plan-session-id"
+        assert session_file.read_text() == "dict-session-456"
+
+    def test_handles_missing_judge_result(self, tmp_path: Path) -> None:
+        """write_session_id handles state with no judge_result."""
+        from examples.shared.session_handoff import write_session_id
+
+        result = write_session_id({}, output_dir=tmp_path)
+
+        assert result["session_exported"] is False
+        session_file = tmp_path / "last-plan-session-id"
+        assert session_file.exists()
+        assert session_file.read_text() == ""
+
+    def test_creates_output_directory(self, tmp_path: Path) -> None:
+        """write_session_id creates parent directories if needed."""
+        from examples.shared.session_handoff import write_session_id
+
+        output_dir = tmp_path / "nested" / "dir"
+        state = {
+            "judge_result": CopilotResult(
+                output="OK",
+                exit_code=0,
+                backend="cli",
+                session_id="nested-789",
+            )
+        }
+
+        result = write_session_id(state, output_dir=output_dir)
+
+        assert result["session_exported"] is True
+        assert (output_dir / "last-plan-session-id").read_text() == "nested-789"
+
+
+@pytest.mark.req("REQ-YG-156")
+class TestReadSessionId:
+    """Tests for read_session_id — reads session ID from handoff file."""
+
+    def test_reads_existing_session_id(self, tmp_path: Path) -> None:
+        """read_session_id reads session ID from file."""
+        from examples.shared.session_handoff import read_session_id
+
+        session_file = tmp_path / "last-plan-session-id"
+        session_file.write_text("read-session-abc")
+
+        result = read_session_id(tmp_path)
+
+        assert result == "read-session-abc"
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        """read_session_id returns None when file doesn't exist."""
+        from examples.shared.session_handoff import read_session_id
+
+        result = read_session_id(tmp_path)
+
+        assert result is None
+
+    def test_returns_none_for_empty_file(self, tmp_path: Path) -> None:
+        """read_session_id returns None when file is empty."""
+        from examples.shared.session_handoff import read_session_id
+
+        session_file = tmp_path / "last-plan-session-id"
+        session_file.write_text("")
+
+        result = read_session_id(tmp_path)
+
+        assert result is None
+
+    def test_strips_whitespace(self, tmp_path: Path) -> None:
+        """read_session_id strips trailing whitespace/newlines."""
+        from examples.shared.session_handoff import read_session_id
+
+        session_file = tmp_path / "last-plan-session-id"
+        session_file.write_text("  session-with-spaces  \n")
+
+        result = read_session_id(tmp_path)
+
+        assert result == "session-with-spaces"
+
+
+@pytest.mark.req("REQ-YG-156")
+class TestCleanupSessionId:
+    """Tests for cleanup_session_id — removes handoff file after consumption."""
+
+    def test_removes_file(self, tmp_path: Path) -> None:
+        """cleanup_session_id removes the session ID file."""
+        from examples.shared.session_handoff import cleanup_session_id
+
+        session_file = tmp_path / "last-plan-session-id"
+        session_file.write_text("to-be-cleaned")
+
+        cleanup_session_id(tmp_path)
+
+        assert not session_file.exists()
+
+    def test_noop_if_file_missing(self, tmp_path: Path) -> None:
+        """cleanup_session_id is a no-op if file doesn't exist."""
+        from examples.shared.session_handoff import cleanup_session_id
+
+        # Should not raise
+        cleanup_session_id(tmp_path)
+
+
+@pytest.mark.req("REQ-YG-157")
+class TestEnforceGraphResumeFlag:
+    """Tests for enforce graph's implement node accepting plan_session_id."""
+
+    def test_resume_flag_passed_when_session_id_provided(self, tmp_path: Path) -> None:
+        """Implement node should pass --resume when plan_session_id is in state."""
+        from unittest.mock import MagicMock, patch
+
+        from yamlgraph.node_factory.copilot_node import create_copilot_node
+
+        prompt_file = tmp_path / "prompts" / "test.yaml"
+        prompt_file.parent.mkdir(parents=True)
+        prompt_file.write_text("system: Implement\nuser: Do the work")
+
+        config = {
+            "type": "copilot",
+            "prompt": str(prompt_file),
+            "state_key": "implement_result",
+            "cli_flags": {
+                "allow_all_paths": True,
+                "allow_all_tools": True,
+                "resume": "{state.plan_session_id}",
+            },
+            "variables": {"fr_path": "{state.fr_path}"},
+        }
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Implementation complete"
+        mock_result.returncode = 0
+        mock_result.stderr = "Session: impl-session-001"
+
+        state = {
+            "plan_session_id": "plan-session-abc-123",
+            "fr_path": "feature-requests/FR-168.md",
+        }
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            node_fn = create_copilot_node("implement", config)
+            result = node_fn(state)
+
+            cmd = mock_run.call_args[0][0]
+            assert "--resume" in cmd
+            resume_idx = cmd.index("--resume")
+            assert cmd[resume_idx + 1] == "plan-session-abc-123"
+
+            assert "implement_result" in result
+
+    def test_no_resume_flag_when_session_id_empty(self, tmp_path: Path) -> None:
+        """Implement node should NOT pass --resume when plan_session_id is empty."""
+        from unittest.mock import MagicMock, patch
+
+        from yamlgraph.node_factory.copilot_node import create_copilot_node
+
+        prompt_file = tmp_path / "prompts" / "test.yaml"
+        prompt_file.parent.mkdir(parents=True)
+        prompt_file.write_text("system: Implement\nuser: Do the work")
+
+        config = {
+            "type": "copilot",
+            "prompt": str(prompt_file),
+            "state_key": "implement_result",
+            "cli_flags": {
+                "allow_all_paths": True,
+                "allow_all_tools": True,
+                "resume": "{state.plan_session_id}",
+            },
+        }
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Fresh session"
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        # Empty string → should not resume
+        state = {"plan_session_id": ""}
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            node_fn = create_copilot_node("implement", config)
+            node_fn(state)
+
+            cmd = mock_run.call_args[0][0]
+            assert "--resume" not in cmd
+
+    def test_no_resume_flag_when_session_id_missing(self, tmp_path: Path) -> None:
+        """Implement node should NOT pass --resume when plan_session_id is not in state."""
+        from unittest.mock import MagicMock, patch
+
+        from yamlgraph.node_factory.copilot_node import create_copilot_node
+
+        prompt_file = tmp_path / "prompts" / "test.yaml"
+        prompt_file.parent.mkdir(parents=True)
+        prompt_file.write_text("system: Implement\nuser: Do the work")
+
+        config = {
+            "type": "copilot",
+            "prompt": str(prompt_file),
+            "state_key": "implement_result",
+            "cli_flags": {
+                "allow_all_paths": True,
+                "allow_all_tools": True,
+                "resume": "{state.plan_session_id}",
+            },
+        }
+
+        mock_result = MagicMock()
+        mock_result.stdout = "Fresh session"
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+
+        # No plan_session_id in state at all
+        state = {"fr_path": "some/path.md"}
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            node_fn = create_copilot_node("implement", config)
+            node_fn(state)
+
+            cmd = mock_run.call_args[0][0]
+            assert "--resume" not in cmd

--- a/yamlgraph/linter/patterns/copilot.py
+++ b/yamlgraph/linter/patterns/copilot.py
@@ -44,13 +44,14 @@ def check_copilot_node_structure(
         )
 
     # W-COPILOT-SESSION: Warning if resume looks like a state expression but
-    # doesn't reference a likely session_id path
+    # doesn't reference a likely session_id path.
+    # FR-168: Also accept direct session_id variable names (cross-graph handoff)
     if has_resume:
         resume_val = cli_flags.get("resume", "")
         if (
             isinstance(resume_val, str)
             and "{state." in resume_val
-            and ".session_id" not in resume_val
+            and "session_id" not in resume_val
         ):
             issues.append(
                 LintIssue(


### PR DESCRIPTION
## FR-168: Cross-Graph Session Continuity

Thread Copilot CLI session ID from plan-judge pipeline to enforce pipeline via file-based handoff (`tmp/last-plan-session-id`).

### Changes
- **`examples/shared/session_handoff.py`**: write/read/cleanup session ID functions
- **`examples/copilot/graph.yaml`**: `export_session` node after `write_diary`
- **`examples/enforce/graph.yaml`**: `plan_session_id` state + resume flag
- **`.chaplain/watch.sh`**: read session file, pass `--session-id` to enforce
- **`scripts/enforce_worktree.sh`**: accept `--session-id`, pass as `--var`
- **Linter**: accept direct `session_id` variable names in resume expressions
- **`ARCHITECTURE.md`**: CAP-58, REQ-YG-156, REQ-YG-157
- **`reference/graph-yaml.md`**: cross-graph session continuity pattern docs

### Tests
14 new tests in `tests/unit/test_session_handoff.py` covering write, read, cleanup, edge cases, and integration flow.

See [FR-168](feature-requests/FR-168-cross-graph-session-continuity.md) for full specification.
