### PR TITLE
feat(routing): FR-172 configurable loop exit target

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,7 +270,7 @@ Key flow anchors in code:
 
 ## Capabilities & Requirements Traceability
 
-YAMLGraph implements **55 capabilities** covering **119 requirements**. Each capability maps to specific modules.
+YAMLGraph implements **56 capabilities** covering **120 requirements**. Each capability maps to specific modules.
 
 ### Capability Summary
 
@@ -331,6 +331,7 @@ YAMLGraph implements **55 capabilities** covering **119 requirements**. Each cap
 | 54 | CI Diary Existence Gate | `.github/workflows/commitlint.yml` | REQ-YG-152 |
 | 55 | Chaplain Inbox Documentation | `CLAUDE.md` | REQ-YG-153 |
 | 56 | Verification Gate Pattern | `yamlgraph/verification`, `node_factory/llm_nodes`, `linter/checks_contracts` | REQ-YG-154 |
+| 57 | Configurable Loop Exit Target | `routing`, `edge_compiler`, `graph_loader`, `linter/checks_semantic` | REQ-YG-093 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -816,6 +817,7 @@ Per-node runtime verification with deterministic pattern matching. Checks stated
 |------------|-------------|-------------|
 | REQ-YG-154 | `NodeConfig` accepts optional `verification` field (`VerificationConfig`) with `question` (str, required), `on_fail` (warn\|halt\|retry, default warn), `max_retries` (int, default 1). Runtime evaluator extracts deterministic checks (count_range, non_empty, contains) from question text; unrecognized patterns degrade to annotation. `warn` appends `VerificationViolation` to errors; `halt` raises `VerificationError`; `retry` re-executes then falls to warn. Lint rule W022 warns on `on_error: skip` without verification | `yamlgraph/verification`, `yamlgraph/models/graph_schema`, `yamlgraph/models/schemas`, `yamlgraph/node_factory/llm_nodes`, `yamlgraph/linter/checks_contracts`, `tests/unit/test_verification` |
 | REQ-YG-155 | Count range verification claim parsed into `CountRangeClaim` Pydantic model with `min_count` (int, ge=0), `max_count` (int, ge=0) and `model_validator` enforcing min ≤ max. Inverted ranges raise `ValueError` at parse time. Violation `details` exposes `expected_min`, `expected_max`, `actual_count` for programmatic inspection | `yamlgraph/verification`, `yamlgraph/models/__init__`, `tests/unit/test_verification` |
+| REQ-YG-093 | `loop_exits` graph-level config maps node names to custom exit targets when loop limit is reached. `GraphConfigSchema` validates as `dict[str, str]` with default `{}`. `make_expr_router_fn` accepts optional `loop_exit_target`; when `_loop_limit_reached` is True, returns configured target instead of `END`. Lint rule E009 validates keys exist in `loop_limits` and targets are valid nodes | `yamlgraph/routing`, `yamlgraph/edge_compiler`, `yamlgraph/graph_loader`, `yamlgraph/models/graph_schema`, `yamlgraph/linter/checks_semantic`, `tests/unit/test_loops` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **FR-172 Configurable Loop Exit Target**: Add `loop_exits` graph-level config that maps node names to custom exit targets when loop limits are reached. Expression routers now route to the configured target instead of unconditionally terminating with `END`. Includes lint rule E009 for validation. (REQ-YG-093)
 - **FR-166 CountRangeClaim Pydantic Model**: Replace loose `int` variables in count range verification with a validated `CountRangeClaim` Pydantic model. Inverted ranges (min > max) now fail at parse time. `VerificationViolation.details` populated with structured claim data. (REQ-YG-155)
 - **FR-165 No-Silent-Fallback Lint Rule (W017)**: Add lint rule W017 that flags `on_error: skip` nodes as silent fallback patterns violating Commandment 6. Suggests `on_error: fail` or `on_error: fallback` with explicit fallback node instead. (REQ-YG-114)
 - **FR-164 Verification Gate Pattern**: Add optional `verification` field to node definitions for silent failure detection. LLM states a falsifiable prediction before acting; runtime compares prediction against actual output using cosine similarity. Includes `VerificationConfig` schema, `verification.py` runtime, LLM node integration, linter checks, and demo example. (REQ-YG-064, REQ-YG-065)

--- a/docs/diary/2026-03-09-git-report.md
+++ b/docs/diary/2026-03-09-git-report.md
@@ -15,7 +15,7 @@ The repository shows **intense, focused development** with **7 major features co
 
 #### **1. FR-166: Pydantic Verification Model Enhancement** ✅ COMPLETED
 - **Status:** Completed with all acceptance criteria met
-- **Changes:** 
+- **Changes:**
   - Added `CountRangeClaim` Pydantic model for structured verification claims
   - Fixed bug where `len(BaseModel)` raised TypeError → now properly extracts countable data
   - Implemented `_extract_countable()` helper for single-list field unwrapping

--- a/docs/diary/2026-03-09-reflection-fr-172.md
+++ b/docs/diary/2026-03-09-reflection-fr-172.md
@@ -1,0 +1,17 @@
+# Diary: FR-172 — Configurable Loop Exit Target
+
+**Date:** 2026-03-09
+**FR:** FR-172
+**Trap:** downstream_fix — The hardcoded `END` in `make_expr_router_fn` was a downstream fix for "what happens when a loop exhausts." The real contract belongs at the graph config level.
+
+## Insight
+
+The fix was 4 lines in `routing.py` but required threading a new parameter through 4 modules (schema → config → edge_compiler → routing). This is the cost of clean separation of concerns — but also its benefit: each layer had one clear change, and the lint rule could validate the config independently.
+
+## Heuristic
+
+**Configuration over hardcoding at boundaries.** When a framework behavior is hardcoded at a boundary (router returning `END`), the correct fix is a config field that flows through the compilation pipeline, not a special case at the call site. The `loop_exits` field sits next to `loop_limits` because they govern the same boundary.
+
+## Seed
+
+Could `loop_exits` be generalized to a `on_limit` strategy pattern? Instead of just a target node name, it could support `{action: "route", target: "node"}`, `{action: "retry_with", params: ...}`, or `{action: "escalate"}`. Is there a second use case that would justify this, or is YAGNI the right call?

--- a/examples/demos/reflexion/graph.yaml
+++ b/examples/demos/reflexion/graph.yaml
@@ -56,3 +56,6 @@ edges:
 loop_limits:
   critique: 3
   refine: 3
+
+loop_exits:
+  critique: END  # When critique exhausts limit, end gracefully

--- a/feature-requests/FR-172-loop-exit-target.md
+++ b/feature-requests/FR-172-loop-exit-target.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Judged:** 2026-03-09
 **Requested:** 2026-03-09
@@ -111,23 +111,23 @@ Add a lint rule: every node in `loop_exits` must (a) exist in `nodes`, (b) appea
 
 ## Acceptance Criteria
 
-- [ ] `loop_exits` is a valid top-level graph YAML field (dict[str, str])
-- [ ] `GraphConfigSchema` validates `loop_exits` as `dict[str, str]` with default `{}`
-- [ ] `GraphConfig` stores `loop_exits` from raw config
-- [ ] `make_expr_router_fn` accepts optional `loop_exit_target` parameter
-- [ ] When `_loop_limit_reached` is `True` and a `loop_exit_target` is configured, router returns the target instead of `END`
-- [ ] When `_loop_limit_reached` is `True` and no `loop_exit_target` is configured, router returns `END` (unchanged behavior)
-- [ ] `_add_conditional_edges` passes `loop_exit_target` from `loop_exits` config to the expression router
-- [ ] The loop exit target node is included in the route mapping so LangGraph knows it is a valid destination
-- [ ] Lint rule warns when `loop_exits` key references a node not in `loop_limits`
-- [ ] Lint rule warns when `loop_exits` value references a nonexistent node
-- [ ] Reflexion example (`examples/demos/reflexion/graph.yaml`) updated with `loop_exits` demonstrating the pattern
-- [ ] Tests tagged with `@pytest.mark.req("REQ-YG-093")`
-- [ ] Unit test: expression router returns custom target when loop limit reached
-- [ ] Unit test: expression router returns `END` when loop limit reached and no exit configured
-- [ ] Unit test: end-to-end graph compilation with `loop_exits` config
-- [ ] Unit test: lint detects invalid `loop_exits` references
-- [ ] Documentation updated in `reference/graph-yaml.md`
+- [x] `loop_exits` is a valid top-level graph YAML field (dict[str, str])
+- [x] `GraphConfigSchema` validates `loop_exits` as `dict[str, str]` with default `{}`
+- [x] `GraphConfig` stores `loop_exits` from raw config
+- [x] `make_expr_router_fn` accepts optional `loop_exit_target` parameter
+- [x] When `_loop_limit_reached` is `True` and a `loop_exit_target` is configured, router returns the target instead of `END`
+- [x] When `_loop_limit_reached` is `True` and no `loop_exit_target` is configured, router returns `END` (unchanged behavior)
+- [x] `_add_conditional_edges` passes `loop_exit_target` from `loop_exits` config to the expression router
+- [x] The loop exit target node is included in the route mapping so LangGraph knows it is a valid destination
+- [x] Lint rule warns when `loop_exits` key references a node not in `loop_limits`
+- [x] Lint rule warns when `loop_exits` value references a nonexistent node
+- [x] Reflexion example (`examples/demos/reflexion/graph.yaml`) updated with `loop_exits` demonstrating the pattern
+- [x] Tests tagged with `@pytest.mark.req("REQ-YG-093")`
+- [x] Unit test: expression router returns custom target when loop limit reached
+- [x] Unit test: expression router returns `END` when loop limit reached and no exit configured
+- [x] Unit test: end-to-end graph compilation with `loop_exits` config
+- [x] Unit test: lint detects invalid `loop_exits` references
+- [x] Documentation updated in `reference/graph-yaml.md`
 
 ## Alternatives Considered
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,10 @@ ignore = [
     "E501",   # Line too long (handled by formatter)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# Vulture whitelist uses bare expressions and grouped imports by design
+"vulture_whitelist.py" = ["B018", "E402"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "strict"

--- a/reference/graph-yaml.md
+++ b/reference/graph-yaml.md
@@ -29,6 +29,9 @@ edges:                             # Required: Edge definitions
 loop_limits:                       # Optional: Max iterations per node
   node_name: 3
 
+loop_exits:                        # Optional: Custom exit target when loop limit hit
+  node_name: post_loop_node
+
 exports:                           # Optional: Export configuration
   state_key:
     format: markdown
@@ -1064,6 +1067,23 @@ loop_limits:
 ```
 
 **Note:** Use with `skip_if_exists: false` on loop nodes.
+
+## Loop Exits (FR-172)
+
+By default, when a node hits its `loop_limit`, the expression router terminates the graph (`END`). Use `loop_exits` to route to a specific post-loop node instead:
+
+```yaml
+loop_limits:
+  critique: 3
+
+loop_exits:
+  critique: distill_reflection  # When critique hits limit, go here instead of END
+```
+
+**Rules:**
+- Each key in `loop_exits` must also appear in `loop_limits`
+- Each value must be a valid node name (or `END`)
+- Only applies to expression-based conditional edges (not `type: conditional` router edges)
 
 ---
 

--- a/scripts/req_coverage.py
+++ b/scripts/req_coverage.py
@@ -54,6 +54,7 @@ _ALL_FRAMEWORK_REQS = (
     + [154]  # REQ-YG-154 (CAP-56 Verification Gate Pattern)
     + [114]  # REQ-YG-114 (CAP-57 No-Silent-Fallback Lint W017)
     + [155]  # REQ-YG-155 (CAP-58 Verification Count Range Pydantic)
+    + [93]  # REQ-YG-093 (CAP-59 Configurable Loop Exit Target)
 )
 ALL_REQS = [f"REQ-YG-{i:03d}" for i in _ALL_FRAMEWORK_REQS]
 
@@ -242,6 +243,7 @@ CAPABILITIES: dict[str, tuple[str, list[str]]] = {
     "CAP-55": ("Chaplain Inbox Documentation", ["REQ-YG-153"]),
     "CAP-56": ("Verification Gate Pattern", ["REQ-YG-154"]),
     "CAP-57": ("Verification Count Range Pydantic", ["REQ-YG-155"]),
+    "CAP-59": ("Configurable Loop Exit Target", ["REQ-YG-093"]),
 }
 
 

--- a/tests/unit/test_loops.py
+++ b/tests/unit/test_loops.py
@@ -3,6 +3,7 @@
 TDD tests for expression conditions, loop tracking, and cyclic graphs.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -427,3 +428,276 @@ class TestReflexionDemoGraph:
         config = load_graph_config("examples/demos/reflexion/graph.yaml")
         graph = compile_graph(config)
         assert graph is not None
+
+
+# =============================================================================
+# Test: Loop Exit Target (FR-172)
+# =============================================================================
+
+
+class TestLoopExits:
+    """Tests for configurable loop exit target when loop limit is reached."""
+
+    # --- Schema & Config ---
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_graph_config_schema_accepts_loop_exits(self):
+        """GraphConfigSchema validates loop_exits as dict[str, str]."""
+        from yamlgraph.models.graph_schema import validate_graph_schema
+
+        config = {
+            "nodes": {
+                "draft": {"prompt": "draft"},
+                "critique": {"prompt": "critique"},
+                "distill": {"prompt": "distill"},
+            },
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "critique"},
+                {"from": "critique", "to": "END"},
+            ],
+            "loop_limits": {"critique": 3},
+            "loop_exits": {"critique": "distill"},
+        }
+        schema = validate_graph_schema(config)
+        assert schema.loop_exits == {"critique": "distill"}
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_graph_config_schema_loop_exits_defaults_empty(self):
+        """Missing loop_exits defaults to empty dict."""
+        from yamlgraph.models.graph_schema import validate_graph_schema
+
+        config = {
+            "nodes": {"draft": {"prompt": "draft"}},
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "END"},
+            ],
+        }
+        schema = validate_graph_schema(config)
+        assert schema.loop_exits == {}
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_graph_config_stores_loop_exits(self):
+        """GraphConfig stores loop_exits from raw config."""
+        from yamlgraph.graph_loader import GraphConfig
+
+        config_dict = {
+            "version": "1.0",
+            "name": "test",
+            "nodes": {
+                "draft": {"prompt": "draft"},
+                "critique": {"prompt": "critique"},
+                "distill": {"prompt": "distill"},
+            },
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "critique"},
+                {"from": "critique", "to": "distill"},
+                {"from": "distill", "to": "END"},
+            ],
+            "loop_limits": {"critique": 3},
+            "loop_exits": {"critique": "distill"},
+        }
+        config = GraphConfig(config_dict)
+        assert config.loop_exits == {"critique": "distill"}
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_graph_config_loop_exits_defaults_empty(self):
+        """Missing loop_exits defaults to empty dict."""
+        from yamlgraph.graph_loader import GraphConfig
+
+        config_dict = {
+            "version": "1.0",
+            "name": "test",
+            "nodes": {"node1": {"prompt": "p1"}},
+            "edges": [{"from": "START", "to": "node1"}, {"from": "node1", "to": "END"}],
+        }
+        config = GraphConfig(config_dict)
+        assert config.loop_exits == {}
+
+    # --- Router behavior ---
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_expr_router_returns_custom_target_on_loop_limit(self):
+        """When _loop_limit_reached and loop_exit_target configured, returns target."""
+        from yamlgraph.routing import make_expr_router_fn
+
+        edges = [("score < 0.8", "refine"), ("score >= 0.8", "END")]
+        router = make_expr_router_fn(edges, "critique", loop_exit_target="distill")
+
+        state = {"_loop_limit_reached": True}
+        assert router(state) == "distill"
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_expr_router_returns_end_on_loop_limit_no_exit(self):
+        """When _loop_limit_reached and no exit configured, returns END (unchanged)."""
+        from langgraph.graph import END
+
+        from yamlgraph.routing import make_expr_router_fn
+
+        edges = [("score < 0.8", "refine"), ("score >= 0.8", "END")]
+        router = make_expr_router_fn(edges, "critique")
+
+        state = {"_loop_limit_reached": True}
+        assert router(state) == END
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_expr_router_evaluates_normally_when_no_loop_limit(self):
+        """When _loop_limit_reached is False, router evaluates conditions normally."""
+        from yamlgraph.routing import make_expr_router_fn
+
+        edges = [("score < 0.8", "refine"), ("score >= 0.8", "END")]
+        router = make_expr_router_fn(edges, "critique", loop_exit_target="distill")
+
+        state = {"score": 0.5, "_loop_limit_reached": False}
+        assert router(state) == "refine"
+
+    # --- End-to-end compilation ---
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_compiles_graph_with_loop_exits(self):
+        """Graph with loop_exits compiles to StateGraph successfully."""
+        from yamlgraph.graph_loader import GraphConfig, compile_graph
+
+        config_dict = {
+            "version": "1.0",
+            "name": "test-loop-exits",
+            "nodes": {
+                "draft": {"prompt": "draft", "state_key": "current_draft"},
+                "critique": {"prompt": "critique", "state_key": "critique"},
+                "refine": {"prompt": "refine", "state_key": "current_draft"},
+                "distill": {"prompt": "distill", "state_key": "summary"},
+            },
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "critique"},
+                {
+                    "from": "critique",
+                    "to": "refine",
+                    "condition": "critique.score < 0.8",
+                },
+                {
+                    "from": "critique",
+                    "to": "END",
+                    "condition": "critique.score >= 0.8",
+                },
+                {"from": "refine", "to": "critique"},
+                {"from": "distill", "to": "END"},
+            ],
+            "loop_limits": {"critique": 3},
+            "loop_exits": {"critique": "distill"},
+        }
+        config = GraphConfig(config_dict)
+        graph = compile_graph(config)
+        assert graph is not None
+
+    # --- Lint rules ---
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_lint_loop_exits_key_not_in_loop_limits(self):
+        """Lint warns when loop_exits key not in loop_limits."""
+        # Create a temp fixture with loop_exits key not in loop_limits
+        import tempfile
+
+        import yaml
+
+        from tests.unit.test_linter_fr025 import issue_codes
+        from yamlgraph.linter.checks_semantic import check_cross_references
+
+        graph = {
+            "nodes": {
+                "draft": {"prompt": "draft"},
+                "critique": {"prompt": "critique"},
+                "distill": {"prompt": "distill"},
+            },
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "critique"},
+                {"from": "critique", "to": "END"},
+            ],
+            "loop_exits": {"draft": "distill"},  # draft not in loop_limits
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(graph, f)
+            path = Path(f.name)
+
+        try:
+            issues = check_cross_references(path)
+            codes = issue_codes(issues)
+            assert "E009" in codes
+            e009 = [i for i in issues if i.code == "E009"]
+            assert any("draft" in i.message for i in e009)
+        finally:
+            path.unlink()
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_lint_loop_exits_target_nonexistent(self):
+        """Lint warns when loop_exits value references nonexistent node."""
+        import tempfile
+
+        import yaml
+
+        from tests.unit.test_linter_fr025 import issue_codes
+        from yamlgraph.linter.checks_semantic import check_cross_references
+
+        graph = {
+            "nodes": {
+                "draft": {"prompt": "draft"},
+                "critique": {"prompt": "critique"},
+            },
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "critique"},
+                {"from": "critique", "to": "END"},
+            ],
+            "loop_limits": {"critique": 3},
+            "loop_exits": {"critique": "nonexistent_node"},
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(graph, f)
+            path = Path(f.name)
+
+        try:
+            issues = check_cross_references(path)
+            codes = issue_codes(issues)
+            assert "E009" in codes
+            e009 = [i for i in issues if i.code == "E009"]
+            assert any("nonexistent_node" in i.message for i in e009)
+        finally:
+            path.unlink()
+
+    @pytest.mark.req("REQ-YG-093")
+    def test_lint_loop_exits_valid_no_warning(self):
+        """Valid loop_exits config produces no E009."""
+        import tempfile
+
+        import yaml
+
+        from tests.unit.test_linter_fr025 import issue_codes
+        from yamlgraph.linter.checks_semantic import check_cross_references
+
+        graph = {
+            "nodes": {
+                "draft": {"prompt": "draft"},
+                "critique": {"prompt": "critique"},
+                "distill": {"prompt": "distill"},
+            },
+            "edges": [
+                {"from": "START", "to": "draft"},
+                {"from": "draft", "to": "critique"},
+                {"from": "critique", "to": "END"},
+            ],
+            "loop_limits": {"critique": 3},
+            "loop_exits": {"critique": "distill"},
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(graph, f)
+            path = Path(f.name)
+
+        try:
+            issues = check_cross_references(path)
+            codes = issue_codes(issues)
+            assert "E009" not in codes
+        finally:
+            path.unlink()

--- a/yamlgraph/edge_compiler.py
+++ b/yamlgraph/edge_compiler.py
@@ -116,6 +116,7 @@ def _add_conditional_edges(
     graph: StateGraph,
     router_edges: dict[str, list],
     expression_edges: dict[str, list[tuple[str, str]]],
+    loop_exits: dict[str, str] | None = None,
 ) -> None:
     """Add router and expression conditional edges to graph.
 
@@ -123,6 +124,7 @@ def _add_conditional_edges(
         graph: StateGraph to add edges to
         router_edges: Router-style conditional edges
         expression_edges: Expression-based conditional edges
+        loop_exits: Map of node name to exit target when loop limit reached (FR-172)
     """
     # Add router conditional edges
     for source_node, target_nodes in router_edges.items():
@@ -135,12 +137,15 @@ def _add_conditional_edges(
 
     # Add expression-based conditional edges
     for source_node, expr_edges in expression_edges.items():
+        loop_exit_target = (loop_exits or {}).get(source_node)
         targets = {target for _, target in expr_edges}
         targets.add(END)  # Always include END as fallback
+        if loop_exit_target:
+            targets.add(loop_exit_target)
         route_mapping = {t: (END if t == END else t) for t in targets}
         graph.add_conditional_edges(
             source_node,
-            make_expr_router_fn(expr_edges, source_node),
+            make_expr_router_fn(expr_edges, source_node, loop_exit_target),
             route_mapping,
         )
 

--- a/yamlgraph/graph_loader.py
+++ b/yamlgraph/graph_loader.py
@@ -148,6 +148,7 @@ class GraphConfig:
         self.edges = config.get("edges", [])
         self.tools = config.get("tools", {})
         self.loop_limits = config.get("loop_limits", {})
+        self.loop_exits = config.get("loop_exits", {})
         self.checkpointer = config.get("checkpointer")
         # FR-027: Execution safety config
         graph_level_config = config.get("config", {})
@@ -288,7 +289,7 @@ def compile_graph(config: GraphConfig) -> StateGraph:
         )
 
     # Add conditional edges
-    _add_conditional_edges(graph, router_edges, expression_edges)
+    _add_conditional_edges(graph, router_edges, expression_edges, config.loop_exits)
 
     return graph
 

--- a/yamlgraph/linter/checks_semantic.py
+++ b/yamlgraph/linter/checks_semantic.py
@@ -1,15 +1,4 @@
-"""Semantic & cross-reference linter checks (FR-025, FR-026).
-
-Split from checks.py to keep modules under 400 lines.
-
-Check functions:
-- check_cross_references (E006, E008)
-- check_passthrough_nodes (E601)
-- check_tool_call_nodes (E701, E702)
-- check_expression_syntax (W801, W007, E007)
-- check_error_handling (E010, E011)
-- check_edge_types (E802)
-"""
+"""Semantic & cross-reference linter checks (FR-025, FR-026, FR-172)."""
 
 from __future__ import annotations
 
@@ -26,28 +15,39 @@ _SENTINEL_NODES = {"START", "END"}
 _NON_LLM_NODE_TYPES = {"tool", "python", "tool_call", "passthrough", "interactive_tool"}
 
 
+def _err(code: str, message: str, fix: str) -> LintIssue:
+    """Shorthand for error-severity LintIssue."""
+    return LintIssue(severity="error", code=code, message=message, fix=fix)
+
+
+def _node_fix(node_names: set[str]) -> str:
+    """Build common fix suggestion listing valid node names."""
+    return f"Check spelling; defined nodes: {', '.join(sorted(node_names))}"
+
+
 def check_cross_references(graph_path: Path) -> list[LintIssue]:
-    """Check edge from/to and loop_limits reference existing nodes.
+    """Check edge from/to, loop_limits, and loop_exits reference existing nodes.
 
     E006 — edge endpoint references non-existent node
     E008 — loop_limits key references non-existent node
+    E009 — loop_exits key not in loop_limits or target is invalid (FR-172)
     """
     issues: list[LintIssue] = []
     graph = load_graph(graph_path)
 
     node_names = set(graph.get("nodes", {}).keys())
     valid_targets = node_names | _SENTINEL_NODES
+    fix = _node_fix(node_names)
 
     # E006: edge from/to validation
     for edge in graph.get("edges", []):
         from_node = edge.get("from")
         if from_node and from_node not in valid_targets:
             issues.append(
-                LintIssue(
-                    severity="error",
-                    code="E006",
-                    message=f"Edge 'from' references non-existent node '{from_node}'",
-                    fix=f"Check spelling; defined nodes: {', '.join(sorted(node_names))}",
+                _err(
+                    "E006",
+                    f"Edge 'from' references non-existent node '{from_node}'",
+                    fix,
                 )
             )
         to_value = edge.get("to")
@@ -57,11 +57,10 @@ def check_cross_references(graph_path: Path) -> list[LintIssue]:
         for target in to_targets:
             if target not in valid_targets:
                 issues.append(
-                    LintIssue(
-                        severity="error",
-                        code="E006",
-                        message=f"Edge 'to' references non-existent node '{target}'",
-                        fix=f"Check spelling; defined nodes: {', '.join(sorted(node_names))}",
+                    _err(
+                        "E006",
+                        f"Edge 'to' references non-existent node '{target}'",
+                        fix,
                     )
                 )
 
@@ -69,12 +68,23 @@ def check_cross_references(graph_path: Path) -> list[LintIssue]:
     for key in graph.get("loop_limits", {}):
         if key not in node_names:
             issues.append(
-                LintIssue(
-                    severity="error",
-                    code="E008",
-                    message=f"loop_limits references non-existent node '{key}'",
-                    fix=f"Check spelling; defined nodes: {', '.join(sorted(node_names))}",
+                _err("E008", f"loop_limits references non-existent node '{key}'", fix)
+            )
+
+    # E009: loop_exits validation (FR-172)
+    loop_limits = graph.get("loop_limits", {})
+    for key, target in graph.get("loop_exits", {}).items():
+        if key not in loop_limits:
+            issues.append(
+                _err(
+                    "E009",
+                    f"loop_exits key '{key}' is not in loop_limits",
+                    f"Add '{key}: <limit>' to loop_limits or remove from loop_exits",
                 )
+            )
+        if target != "END" and target not in node_names:
+            issues.append(
+                _err("E009", f"loop_exits target '{target}' is not a valid node", fix)
             )
 
     return issues
@@ -396,39 +406,20 @@ def check_skip_if_exists_in_cycle(graph_path: Path) -> list[LintIssue]:
 def check_dynamic_map_without_max_items(
     node_name: str, node_config: dict, graph_config: dict
 ) -> list[LintIssue]:
-    """Warn when map over: is a dynamic expression without max_items.
-
-    W013 — dynamic fan-out without explicit cap.
-    A dynamic expression is any string containing '{' (state reference).
-    Suppressed when node has max_items or graph config has max_map_items.
-    """
-    issues: list[LintIssue] = []
-
+    """W013: dynamic fan-out without explicit cap."""
     over = node_config.get("over")
     if not isinstance(over, str) or "{" not in over:
-        return issues
-
-    # Suppressed by node-level max_items
-    if "max_items" in node_config:
-        return issues
-
-    # Suppressed by graph-level max_map_items
-    if graph_config.get("max_map_items") is not None:
-        return issues
-
-    issues.append(
+        return []
+    if "max_items" in node_config or graph_config.get("max_map_items") is not None:
+        return []
+    return [
         LintIssue(
             severity="warning",
             code="W013",
-            message=(
-                f"Map node '{node_name}' fans out over dynamic expression "
-                f"'{over}' without max_items"
-            ),
+            message=f"Map node '{node_name}' fans out over dynamic expression '{over}' without max_items",
             fix=f"Add 'max_items: <limit>' to node '{node_name}' or 'max_map_items' to config",
         )
-    )
-
-    return issues
+    ]
 
 
 __all__ = [

--- a/yamlgraph/models/graph_schema.py
+++ b/yamlgraph/models/graph_schema.py
@@ -212,6 +212,10 @@ class GraphConfigSchema(BaseModel):
     edges: list[EdgeConfig] = Field(...)
     tools: dict[str, Any] = Field(default_factory=dict)
     loop_limits: dict[str, int] = Field(default_factory=dict)
+    loop_exits: dict[str, str] = Field(
+        default_factory=dict,
+        description="Map of node name to target node when loop limit is reached",
+    )
     data_files: dict[str, str] = Field(
         default_factory=dict,
         description="External YAML data files to load into state at compile time",

--- a/yamlgraph/routing.py
+++ b/yamlgraph/routing.py
@@ -49,6 +49,7 @@ def make_router_fn(targets: list[str]) -> Callable[[dict], str]:
 def make_expr_router_fn(
     edges: list[tuple[str, str]],
     source_node: str,
+    loop_exit_target: str | None = None,
 ) -> Callable[[GraphState], str]:
     """Create router that evaluates expression conditions.
 
@@ -58,6 +59,7 @@ def make_expr_router_fn(
     Args:
         edges: List of (condition, target) tuples
         source_node: Name of the source node (for logging)
+        loop_exit_target: Target node when loop limit is reached (FR-172)
 
     Returns:
         Router function that evaluates conditions and returns target
@@ -66,6 +68,8 @@ def make_expr_router_fn(
     def expr_router_fn(state: GraphState) -> str:
         # Check loop limit first
         if state.get("_loop_limit_reached"):
+            if loop_exit_target:
+                return loop_exit_target
             return END
 
         for condition, target in edges:


### PR DESCRIPTION
## FR-172 — Configurable Loop Exit Target

Add `loop_exits` graph-level config that maps node names to custom exit targets when loop limits are reached. Previously, expression routers unconditionally returned `END` on loop limit, terminating the entire graph. Now graph authors can route to a post-loop node instead.

### Changes

- **GraphConfigSchema**: `loop_exits` field (`dict[str, str]`, default `{}`)
- **GraphConfig**: stores `loop_exits` from raw config
- **make_expr_router_fn**: accepts optional `loop_exit_target` parameter
- **_add_conditional_edges**: passes `loop_exit_target` from config
- **Lint rule E009**: validates `loop_exits` keys exist as nodes and targets are valid
- **REQ-YG-093 (CAP-59)**: 11 unit tests tagged

### Feature Request

See [feature-requests/FR-172-loop-exit-target.md](feature-requests/FR-172-loop-exit-target.md)

### Diary

See [docs/diary/2026-03-09-reflection-fr-172.md](docs/diary/2026-03-09-reflection-fr-172.md)
