### PR TITLE
feat(doctrine): FR-189 graduate downstream_fix trap description

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,7 +51,7 @@ boundaries:
 traps:
   # Cognitive hazards that lead to bugs and drift
   quick_confidence: "When I feel certain → Judge instead"
-  downstream_fix: "Fix at callsite, not utility → avoid double-stripping"
+  downstream_fix: "Guard added where symptom manifests → normalize at entry boundary instead"
   symptom_patch: "Verify root cause with test before designing fix"
   intent_drift: "Plan says X, code does Y → re-read thrice"
   false_duplicate: "Syntactic similarity ≠ semantic equivalence"

--- a/changelog/unreleased/fr-189-graduate-downstream-fix-trap.md
+++ b/changelog/unreleased/fr-189-graduate-downstream-fix-trap.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: doctrine
+---
+- **FR-189 Graduate `downstream_fix` Trap**: Refined trap description from incident-specific ("Fix at callsite, not utility → avoid double-stripping") to pattern-general ("Guard added where symptom manifests → normalize at entry boundary instead"), based on 3 confirmed diary occurrences.

--- a/docs/diary/2026-03-12-reflection-fr-189.md
+++ b/docs/diary/2026-03-12-reflection-fr-189.md
@@ -1,0 +1,21 @@
+# Diary: FR-189 — Graduate `downstream_fix` Trap Description
+
+**Date:** 2026-03-12
+**FR:** FR-189
+**Type:** Doctrine refinement (Knowledge Graph graduation)
+
+## What Happened
+
+FR-189 graduated the `downstream_fix` trap description based on evidence from 3 diary entries (FR-150, FR-172, FR-166). The old description ("Fix at callsite, not utility → avoid double-stripping") described the cure rather than the trap — a subtle inversion that could mislead agents into thinking the text described what to do, not what goes wrong.
+
+The new description ("Guard added where symptom manifests → normalize at entry boundary instead") follows the established trap format: name the trigger, then redirect to the cure. This matches `quick_confidence: "When I feel certain → Judge instead"`.
+
+## Cognitive Process
+
+The change was mechanically simple (one string edit), but the TDD ceremony revealed value: writing the "no other traps changed" and "no cures changed" tests forced a systematic inventory of every Knowledge Graph entry. This is the `boring_enforcement` pattern — boring means the Judgement was good.
+
+**Trap:** `description_inversion` — A trap description that reads as advice (what to do) instead of a hazard (what goes wrong) silently fails its purpose. The reader follows it as a cure rather than recognizing the cognitive trigger.
+
+**Heuristic:** When writing trap descriptions, verify the sentence answers "what am I catching myself doing?" not "what should I do instead?" The trigger must come first.
+
+**Seed:** Could the Philosopher daemon automatically detect description inversions by checking whether trap text matches the `trigger → redirect` format, flagging entries that read as prescriptive rather than diagnostic?

--- a/feature-requests/FR-189-graduate-downstream-fix-trap.md
+++ b/feature-requests/FR-189-graduate-downstream-fix-trap.md
@@ -2,7 +2,7 @@
 
 **Priority:** LOW
 **Type:** Enhancement
-**Status:** Proposed
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-12
 
@@ -59,10 +59,10 @@ No other Scripture changes are needed. The complementary cure `callsite_fix: "Fi
 
 ## Acceptance Criteria
 
-- [ ] `downstream_fix` description in `.github/copilot-instructions.md` updated to: `"Guard added where symptom manifests → normalize at entry boundary instead"`
-- [ ] No other traps or cures descriptions changed
-- [ ] Pre-commit hooks pass (copilot-instructions content is validated)
-- [ ] Changelog fragment added to `changelog/unreleased/`
+- [x] `downstream_fix` description in `.github/copilot-instructions.md` updated to: `"Guard added where symptom manifests → normalize at entry boundary instead"`
+- [x] No other traps or cures descriptions changed
+- [x] Pre-commit hooks pass (copilot-instructions content is validated)
+- [x] Changelog fragment added to `changelog/unreleased/`
 
 ## Alternatives Considered
 

--- a/tests/unit/test_knowledge_graph_fr189.py
+++ b/tests/unit/test_knowledge_graph_fr189.py
@@ -1,0 +1,99 @@
+"""FR-189: Validate graduated downstream_fix trap description in Scripture.
+
+The Knowledge Graph in .github/copilot-instructions.md contains trap descriptions
+that are compressed signals for cognitive hazards. FR-189 graduates the
+downstream_fix trap based on 3 confirmed diary occurrences, refining the
+description from incident-specific to pattern-general.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COPILOT_INSTRUCTIONS = REPO_ROOT / ".github" / "copilot-instructions.md"
+
+GRADUATED_DESCRIPTION = (
+    'downstream_fix: "Guard added where symptom manifests'
+    ' → normalize at entry boundary instead"'
+)
+
+OLD_DESCRIPTION = (
+    'downstream_fix: "Fix at callsite, not utility → avoid double-stripping"'
+)
+
+
+@pytest.mark.req("REQ-YG-184")
+class TestDownstreamFixGraduation:
+    """Validate the graduated downstream_fix trap in the Knowledge Graph."""
+
+    def test_copilot_instructions_exists(self):
+        assert (
+            COPILOT_INSTRUCTIONS.is_file()
+        ), f"Missing {COPILOT_INSTRUCTIONS.relative_to(REPO_ROOT)}"
+
+    def test_downstream_fix_has_graduated_description(self):
+        content = COPILOT_INSTRUCTIONS.read_text()
+        assert GRADUATED_DESCRIPTION in content, (
+            f"downstream_fix trap not updated to graduated description.\n"
+            f"Expected: {GRADUATED_DESCRIPTION}\n"
+            f"Hint: FR-189 requires updating the trap from incident-specific "
+            f"to pattern-general language."
+        )
+
+    def test_old_description_removed(self):
+        content = COPILOT_INSTRUCTIONS.read_text()
+        assert OLD_DESCRIPTION not in content, (
+            f"Old downstream_fix description still present.\n"
+            f"Found: {OLD_DESCRIPTION}\n"
+            f"FR-189 requires replacing this with the graduated description."
+        )
+
+    def test_no_other_traps_changed(self):
+        """Verify all other trap descriptions remain unchanged."""
+        content = COPILOT_INSTRUCTIONS.read_text()
+        expected_traps = {
+            "quick_confidence": '"When I feel certain → Judge instead"',
+            "symptom_patch": '"Verify root cause with test before designing fix"',
+            "intent_drift": '"Plan says X, code does Y → re-read thrice"',
+            "false_duplicate": '"Syntactic similarity ≠ semantic equivalence"',
+            "regex_fourth_exclusion": '"Fourth special case → switch to proper parser"',
+            "partial_remediation": '"Fix all occurrences, not just cited one"',
+            "audit_as_ritual": '"3+ audits without fix → ritual, not process"',
+            "plausible_wrong_answer": '"Silent fallback harder to catch than crash"',
+            "framework_costume": (
+                '"FSM wearing DAG costume'
+                ' → if <50% nodes use core features, wrong tool"'
+            ),
+            "working_system_inertia": (
+                "\"'It works' blocks seeing it clearly"
+                ' → inventory fit, not function"'
+            ),
+        }
+        for trap_name, description in expected_traps.items():
+            line = f"{trap_name}: {description}"
+            assert line in content, (
+                f"Trap '{trap_name}' description changed unexpectedly.\n"
+                f"Expected line containing: {line}"
+            )
+
+    def test_no_cures_changed(self):
+        """Verify all cure descriptions remain unchanged."""
+        content = COPILOT_INSTRUCTIONS.read_text()
+        expected_cures = {
+            "test_before_reading": '"Write question as test → if passes, stop"',
+            "tolerant_matching": (
+                '"prefix/contains/regex, not exact equality for LLM"'
+            ),
+            "three_reads": ('"surface → deep against code → mechanical simulation"'),
+            "streaming_xray": ('"Real-time constraint exposes implicit assumptions"'),
+            "callsite_fix": ('"Fix at the specific caller, not the shared utility"'),
+            "spec_kill": '"Cheapest bug is the one killed in the spec"',
+            "judge_as_junior_pr": ('"Assume plausible code hides subtle bugs"'),
+        }
+        for cure_name, description in expected_cures.items():
+            line = f"{cure_name}: {description}"
+            assert line in content, (
+                f"Cure '{cure_name}' description changed unexpectedly.\n"
+                f"Expected line containing: {line}"
+            )


### PR DESCRIPTION
## Summary

Graduates the `downstream_fix` trap description in the Scripture's Knowledge Graph, based on evidence from 3 diary entries confirming the pattern.

**Before:** `"Fix at callsite, not utility → avoid double-stripping"` (describes the cure, not the trap)
**After:** `"Guard added where symptom manifests → normalize at entry boundary instead"` (names the cognitive hazard)

## Changes

- **`.github/copilot-instructions.md`**: Updated `downstream_fix` trap wording
- **`tests/unit/test_knowledge_graph_fr189.py`**: 5 tests verifying trap description, knowledge graph structure, and cure cross-references
- **`changelog/unreleased/fr-189-graduate-downstream-fix-trap.md`**: Changelog fragment
- **`docs/diary/2026-03-12-reflection-fr-189.md`**: Metacognitive reflection
- **`feature-requests/FR-189-graduate-downstream-fix-trap.md`**: Status updated to Implemented

## Evidence (3 confirmed occurrences)

| Diary Entry | Domain | Downstream Fix (trap) | Boundary Fix (cure) |
|---|---|---|---|
| `2026-03-08-reflection-fr-150.md` | CI/Git | Adding more PR-level checks | Branch protection at push boundary |
| `2026-03-09-reflection-fr-172.md` | Graph Config | Hardcoded `END` in router function | Config-level `loop_exits` field |
| `2026-03-08-reflection-fr-166.md` | Data Validation | Post-hoc `if min > max` guard | Pydantic validation at parse boundary |

See FR at `feature-requests/FR-189-graduate-downstream-fix-trap.md`
