### PR TITLE
feat(doctrine): FR-191 graduate plausible_wrong_answer trap description

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@ traps:
   regex_fourth_exclusion: "Fourth special case → switch to proper parser"
   partial_remediation: "Fix all occurrences, not just cited one"
   audit_as_ritual: "3+ audits without fix → ritual, not process"
-  plausible_wrong_answer: "Silent fallback harder to catch than crash"
+  plausible_wrong_answer: "Output passes shape check but is semantically wrong → add assertion beyond type validation"
   framework_costume: "FSM wearing DAG costume → if <50% nodes use core features, wrong tool"
   working_system_inertia: "'It works' blocks seeing it clearly → inventory fit, not function"
   infrastructure_self_exempt: "Meta-tooling exempted from gates it enforces → apply same rules to the guardrail as to what it guards"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -344,6 +344,7 @@ Run `python scripts/aggregate_capabilities.py` to regenerate the sections below.
 | 67 | Philosopher Daemon | `examples/philosopher/`, `.chaplain/philosopher.sh` | REQ-YG-184 |
 | 68 | CI Dependency Security Scan | `.github/workflows/security.yml` | REQ-YG-185 |
 | 69 | Knowledge Graph Graduation (FR-190) | `.github/copilot-instructions.md` | REQ-YG-187 |
+| 70 | Knowledge Graph Graduation (FR-191) | `.github/copilot-instructions.md` | REQ-YG-188 |
 
 > Capability numbers are stable identifiers. Retired capabilities (e.g., CAP-29) are removed rather than renumbered to preserve cross-references.
 
@@ -833,6 +834,7 @@ Per-node runtime verification with deterministic pattern matching. Checks stated
 | REQ-YG-185 | **Philosopher copilot nodes**: `analyze` and `reflect` nodes use `type: copilot` (FR-185). Copilot output validated through `Proposal`, `ProposalList`, `DiaryEntry` Pydantic models in `examples/philosopher/models.py`. `extract_json()` strips markdown fences and preamble. `write_proposals()` uses single CopilotResult → Pydantic parse path. No `cli_flags` (pure reasoning nodes) | `examples/philosopher/models.py`, `examples/philosopher/tools.py`, `examples/shared/diary.py` |
 | REQ-YG-186 | **CI dependency security scan**: `.github/workflows/security.yml` runs `pip-audit --strict --desc` on every PR and version tag push. Triggers on `pull_request` (opened, synchronize, reopened) and `push: tags: v*.*.*`. Produces a `security` required status check for branch protection. Uses PyPA-endorsed OSV database — no API keys required | `.github/workflows/security.yml`, `tests/unit/test_ci_security_scan.py` |
 | REQ-YG-187 | **Knowledge Graph graduation (FR-190)**: `infrastructure_self_exempt` trap present in `.github/copilot-instructions.md` traps section with exact text: "Meta-tooling exempted from gates it enforces → apply same rules to the guardrail as to what it guards". No existing traps, cures, or process entries changed. Based on 3 confirmed diary occurrences (audits 94, 95, 97) meeting the `process.graduation` threshold | `.github/copilot-instructions.md`, `tests/unit/test_knowledge_graph_fr190.py` |
+| REQ-YG-188 | **Knowledge Graph graduation (FR-191)**: `plausible_wrong_answer` trap in `.github/copilot-instructions.md` traps section updated to graduated description: "Output passes shape check but is semantically wrong → add assertion beyond type validation". Old description removed. No other traps, cures, or process entries changed. Based on 4 confirmed diary occurrences (FR-165, FR-164, FR-184, FR-185) meeting the `process.graduation` threshold | `.github/copilot-instructions.md`, `tests/unit/test_knowledge_graph_fr191.py` |
 
 <!-- END GENERATED CAPABILITIES -->
 

--- a/capabilities/CAP-70-knowledge-graph-graduation-fr191.yaml
+++ b/capabilities/CAP-70-knowledge-graph-graduation-fr191.yaml
@@ -1,0 +1,20 @@
+id: CAP-70
+name: Knowledge Graph Graduation (FR-191)
+fr: FR-191
+description: >
+  Graduates the plausible_wrong_answer trap in the Scripture Knowledge Graph
+  in .github/copilot-instructions.md, based on 4 confirmed diary occurrences
+  (FR-165, FR-164, FR-184, FR-185). Refines description from variant-specific
+  ("Silent fallback") to pattern-general ("Output passes shape check but is
+  semantically wrong → add assertion beyond type validation").
+modules:
+  - .github/copilot-instructions.md
+requirements:
+  - id: REQ-YG-188
+    description: >
+      plausible_wrong_answer trap present in Scripture traps section with
+      exact text, old description removed, no existing traps/cures/process
+      entries changed
+    modules:
+      - .github/copilot-instructions.md
+      - tests/unit/test_knowledge_graph_fr191.py

--- a/changelog/unreleased/fr-191-graduate-plausible-wrong-answer-trap.md
+++ b/changelog/unreleased/fr-191-graduate-plausible-wrong-answer-trap.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: doctrine
+---
+- **FR-191 Graduate `plausible_wrong_answer` Trap**: Refined trap description from variant-specific ("Silent fallback harder to catch than crash") to pattern-general ("Output passes shape check but is semantically wrong → add assertion beyond type validation"), based on 4 confirmed diary occurrences (FR-165, FR-164, FR-184, FR-185).

--- a/docs/diary/2026-03-12-reflection-fr-191.md
+++ b/docs/diary/2026-03-12-reflection-fr-191.md
@@ -1,0 +1,11 @@
+## 2026-03-12: Reflection — FR-191 Graduate `plausible_wrong_answer` Trap Description
+
+**Context:** Implemented FR-191, refining the `plausible_wrong_answer` trap in the Scripture Knowledge Graph from variant-specific ("Silent fallback harder to catch than crash") to pattern-general ("Output passes shape check but is semantically wrong → add assertion beyond type validation"). The graduation is based on 4 confirmed diary occurrences (FR-165, FR-164, FR-184, FR-185) spanning silent fallbacks, type-valid-but-wrong LLM output, data structure costumes, and LLM-based deterministic matching.
+
+**Process:** This is the third Knowledge Graph graduation (after FR-189 `downstream_fix` and FR-190 `infrastructure_self_exempt`). The pattern is now well-established: TDD with tests asserting graduated text present, old text removed, and no collateral changes to existing entries. Each graduation also requires updating the sibling test files' expected trap sets — the `partial_remediation` trap that FR-190 identified.
+
+**Trap:** `working_system_inertia` — The original description ("Silent fallback harder to catch than crash") was *true* but incomplete. It named one symptom while the underlying trap is broader. The temptation was to keep it because it was already working. The cure was to inventory the diary evidence and recognize the pattern exceeds the description.
+
+**Heuristic:** When a trap description names a specific variant, check whether diary evidence shows broader manifestation. A description that captures only one variant gives agents a false sense of coverage — itself a `plausible_wrong_answer` about what the trap means.
+
+**Seed:** The graduation pipeline now has three precedents with identical structure. Should this become a templated process — a `yamlgraph graph` that takes diary citations and a proposed description, validates against the Knowledge Graph YAML block, and generates the test file and capability registration automatically?

--- a/feature-requests/FR-191-graduate-plausible-wrong-answer-trap.md
+++ b/feature-requests/FR-191-graduate-plausible-wrong-answer-trap.md
@@ -2,7 +2,7 @@
 
 **Priority:** LOW
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-12
 
@@ -61,10 +61,10 @@ The complementary reference in Commandment 6 ("A plausible wrong answer is harde
 
 ## Acceptance Criteria
 
-- [ ] `plausible_wrong_answer` description in `.github/copilot-instructions.md` updated to: `"Output passes shape check but is semantically wrong → add assertion beyond type validation"`
-- [ ] No other traps or cures descriptions changed
-- [ ] Pre-commit hooks pass
-- [ ] Changelog fragment added to `changelog/unreleased/`
+- [x] `plausible_wrong_answer` description in `.github/copilot-instructions.md` updated to: `"Output passes shape check but is semantically wrong → add assertion beyond type validation"`
+- [x] No other traps or cures descriptions changed
+- [x] Pre-commit hooks pass
+- [x] Changelog fragment added to `changelog/unreleased/`
 
 ## Alternatives Considered
 

--- a/tests/unit/test_knowledge_graph_fr189.py
+++ b/tests/unit/test_knowledge_graph_fr189.py
@@ -60,7 +60,10 @@ class TestDownstreamFixGraduation:
             "regex_fourth_exclusion": '"Fourth special case → switch to proper parser"',
             "partial_remediation": '"Fix all occurrences, not just cited one"',
             "audit_as_ritual": '"3+ audits without fix → ritual, not process"',
-            "plausible_wrong_answer": '"Silent fallback harder to catch than crash"',
+            "plausible_wrong_answer": (
+                '"Output passes shape check but is semantically wrong'
+                ' → add assertion beyond type validation"'
+            ),
             "framework_costume": (
                 '"FSM wearing DAG costume'
                 ' → if <50% nodes use core features, wrong tool"'

--- a/tests/unit/test_knowledge_graph_fr191.py
+++ b/tests/unit/test_knowledge_graph_fr191.py
@@ -1,10 +1,10 @@
-"""FR-190: Validate graduated infrastructure_self_exempt trap in Scripture.
+"""FR-191: Validate graduated plausible_wrong_answer trap description in Scripture.
 
 The Knowledge Graph in .github/copilot-instructions.md contains trap descriptions
-that are compressed signals for cognitive hazards. FR-190 graduates the
-infrastructure_self_exempt trap based on 3 confirmed diary occurrences
-(audits 94, 95, 97), naming the cognitive blind spot where meta-tooling
-exempts itself from the quality gates it enforces.
+that are compressed signals for cognitive hazards. FR-191 graduates the
+plausible_wrong_answer trap based on 4 confirmed diary occurrences, refining the
+description from variant-specific ("Silent fallback") to pattern-general
+("Output passes shape check but is semantically wrong").
 """
 
 from pathlib import Path
@@ -14,42 +14,53 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COPILOT_INSTRUCTIONS = REPO_ROOT / ".github" / "copilot-instructions.md"
 
-NEW_TRAP = (
-    'infrastructure_self_exempt: "Meta-tooling exempted from gates it enforces'
-    ' → apply same rules to the guardrail as to what it guards"'
+GRADUATED_DESCRIPTION = (
+    'plausible_wrong_answer: "Output passes shape check but is semantically'
+    ' wrong → add assertion beyond type validation"'
 )
 
+OLD_DESCRIPTION = 'plausible_wrong_answer: "Silent fallback harder to catch than crash"'
 
-@pytest.mark.req("REQ-YG-187")
-class TestInfrastructureSelfExemptGraduation:
-    """Validate the new infrastructure_self_exempt trap in the Knowledge Graph."""
+
+@pytest.mark.req("REQ-YG-188")
+class TestPlausibleWrongAnswerGraduation:
+    """Validate the graduated plausible_wrong_answer trap in the Knowledge Graph."""
 
     def test_copilot_instructions_exists(self):
         assert (
             COPILOT_INSTRUCTIONS.is_file()
         ), f"Missing {COPILOT_INSTRUCTIONS.relative_to(REPO_ROOT)}"
 
-    def test_infrastructure_self_exempt_trap_present(self):
+    def test_plausible_wrong_answer_has_graduated_description(self):
         content = COPILOT_INSTRUCTIONS.read_text()
-        assert NEW_TRAP in content, (
-            f"infrastructure_self_exempt trap not found in Scripture.\n"
-            f"Expected: {NEW_TRAP}\n"
-            f"Hint: FR-190 requires adding this new trap to the traps section."
+        assert GRADUATED_DESCRIPTION in content, (
+            f"plausible_wrong_answer trap not updated to graduated description.\n"
+            f"Expected: {GRADUATED_DESCRIPTION}\n"
+            f"Hint: FR-191 requires updating the trap from variant-specific "
+            f"to pattern-general language."
+        )
+
+    def test_old_description_removed(self):
+        content = COPILOT_INSTRUCTIONS.read_text()
+        assert OLD_DESCRIPTION not in content, (
+            f"Old plausible_wrong_answer description still present.\n"
+            f"Found: {OLD_DESCRIPTION}\n"
+            f"FR-191 requires replacing this with the graduated description."
         )
 
     def test_trap_in_traps_section(self):
-        """Verify the new trap is in the traps: section, not elsewhere."""
+        """Verify the graduated trap is in the traps: section, not elsewhere."""
         content = COPILOT_INSTRUCTIONS.read_text()
         traps_start = content.index("traps:")
         cures_start = content.index("cures:")
         traps_section = content[traps_start:cures_start]
-        assert "infrastructure_self_exempt:" in traps_section, (
-            "infrastructure_self_exempt must be in the traps: section, "
+        assert "plausible_wrong_answer:" in traps_section, (
+            "plausible_wrong_answer must be in the traps: section, "
             "not elsewhere in the file."
         )
 
     def test_no_other_traps_changed(self):
-        """Verify all existing trap descriptions remain unchanged."""
+        """Verify all other trap descriptions remain unchanged."""
         content = COPILOT_INSTRUCTIONS.read_text()
         expected_traps = {
             "quick_confidence": '"When I feel certain → Judge instead"',
@@ -65,10 +76,6 @@ class TestInfrastructureSelfExemptGraduation:
             ),
             "partial_remediation": '"Fix all occurrences, not just cited one"',
             "audit_as_ritual": '"3+ audits without fix → ritual, not process"',
-            "plausible_wrong_answer": (
-                '"Output passes shape check but is semantically wrong'
-                ' → add assertion beyond type validation"'
-            ),
             "framework_costume": (
                 '"FSM wearing DAG costume'
                 ' → if <50% nodes use core features, wrong tool"'
@@ -76,6 +83,11 @@ class TestInfrastructureSelfExemptGraduation:
             "working_system_inertia": (
                 "\"'It works' blocks seeing it clearly"
                 ' → inventory fit, not function"'
+            ),
+            "infrastructure_self_exempt": (
+                '"Meta-tooling exempted from gates it enforces'
+                " → apply same rules to the guardrail"
+                ' as to what it guards"'
             ),
         }
         for trap_name, description in expected_traps.items():
@@ -93,9 +105,9 @@ class TestInfrastructureSelfExemptGraduation:
             "tolerant_matching": (
                 '"prefix/contains/regex, not exact equality for LLM"'
             ),
-            "three_reads": ('"surface → deep against code → mechanical simulation"'),
-            "streaming_xray": ('"Real-time constraint exposes implicit assumptions"'),
-            "callsite_fix": ('"Fix at the specific caller, not the shared utility"'),
+            "three_reads": '"surface → deep against code → mechanical simulation"',
+            "streaming_xray": '"Real-time constraint exposes implicit assumptions"',
+            "callsite_fix": '"Fix at the specific caller, not the shared utility"',
             "spec_kill": '"Cheapest bug is the one killed in the spec"',
             "judge_as_junior_pr": '"Assume plausible code hides subtle bugs"',
         }
@@ -114,7 +126,7 @@ class TestInfrastructureSelfExemptGraduation:
                 '"Heuristic appears twice → create FR;'
                 ' confirmed recurrence → graduate to Scripture"'
             ),
-            "conductor": ('"Parallel viewpoints need Blue hat to sequence"'),
+            "conductor": '"Parallel viewpoints need Blue hat to sequence"',
             "boring_enforcement": (
                 '"Boring = Judgement was good; surprise = spec had gaps"'
             ),


### PR DESCRIPTION
## Summary

Refines the `plausible_wrong_answer` trap in the Scripture Knowledge Graph from variant-specific to pattern-general, based on 4 confirmed diary occurrences.

**Old:** `"Silent fallback harder to catch than crash"`
**New:** `"Output passes shape check but is semantically wrong → add assertion beyond type validation"`

### Changes
- Updated `.github/copilot-instructions.md` with graduated description
- Added `ARCHITECTURE.md` requirement REQ-YG-188
- 6 test assertions in `test_knowledge_graph_fr191.py`
- Updated sibling tests (FR-189, FR-190) with new expected trap set
- Capability registration: CAP-70
- Diary reflection: `docs/diary/2026-03-12-reflection-fr-191.md`

See FR at `feature-requests/FR-191-graduate-plausible-wrong-answer-trap.md`