### PR TITLE
feat(philosopher): FR-197 add distill node with ranked prioritization

### DIFF
--- a/changelog/unreleased/FR-197-philosopher-distill-node.md
+++ b/changelog/unreleased/FR-197-philosopher-distill-node.md
@@ -1,0 +1,6 @@
+---
+type: feat
+scope: philosopher
+req: REQ-YG-193
+---
+- **FR-197 Philosopher Distill Node**: Added `distill` copilot node and `unwrap_distill` Python node to the philosopher graph for ranked prioritization. The distill prompt evaluates graduation candidates on recency, severity, evidence spread, and specificity to select the single strongest candidate. Conditional routing skips `propose` when no candidate survives. (REQ-YG-193)

--- a/docs/diary/2026-03-13-reflection-fr-197.md
+++ b/docs/diary/2026-03-13-reflection-fr-197.md
@@ -1,0 +1,17 @@
+# Diary: FR-197 Philosopher Distill Node
+
+**Date:** 2026-03-13
+**FR:** FR-197
+**Theme:** Boundary-aware JSON parsing
+
+## Reflection
+
+Implementing the distill node revealed a subtle parser boundary issue: `extract_json()` uses an array-first search order (`[` before `{`), which silently extracts inner arrays from objects containing `"files": [...]`. For the analyze node (which outputs arrays), this order is correct. For distill (which outputs objects), it would return the nested `files` array — a plausible wrong answer that passes type checks but is semantically wrong.
+
+**Trap:** `plausible_wrong_answer` — The `extract_json` utility would have returned valid JSON (the files array), and `Proposal.model_validate()` would have failed with a confusing Pydantic error pointing at the wrong location. Without the RED phase catching this immediately, the bug would have been attributed to the Pydantic model or the LLM output format.
+
+**Heuristic:** When reusing a parser across contexts, verify its assumptions hold in the new context. `extract_json` assumed array-first because it was built for the analyze node. The distill node's object-first requirement was invisible until TDD exposed it.
+
+The fix was surgical: `unwrap_distill` does its own `{}`-first extraction instead of calling `extract_json`. This follows the callsite_fix cure — fix at the specific caller, not the shared utility.
+
+**Seed:** Should `extract_json` accept an optional `prefer` parameter (`"object"` vs `"array"`) to make the search order explicit? Or is it cleaner to keep callers responsible for their own parsing boundary?

--- a/feature-requests/FR-197-philosopher-distill-node.md
+++ b/feature-requests/FR-197-philosopher-distill-node.md
@@ -3,7 +3,7 @@
 **FR-197**
 **Priority:** MEDIUM
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 1 day
 **Requested:** 2026-03-13
 
@@ -216,23 +216,23 @@ edges:
 
 ## Acceptance Criteria
 
-- [ ] `distill` copilot node added to philosopher graph between `analyze` and `unwrap_distill`
-- [ ] `distill.yaml` prompt evaluates candidates on recency, severity, evidence spread, and specificity
-- [ ] `distill.yaml` prompt correctly accesses `proposals.output` to resolve the CopilotResult envelope
-- [ ] `distill` prompt outputs single `Proposal` JSON or `{"selected": null}` for no-candidate case
-- [ ] `unwrap_distill` Python tool parses `CopilotResult.output` into validated `Proposal` dict or `None`
-- [ ] `unwrap_distill` handles `{"selected": null}` signal without discarding valid Proposal JSON (key-presence check, not value check)
-- [ ] Null short-circuit: when `top_candidate` is `None`, graph skips `propose` and routes to `reflect`
-- [ ] `write_proposals()` reads `top_candidate` dict when present (single proposal path), falls back to `proposals` key
-- [ ] `distill_result` and `top_candidate` declared in graph state
-- [ ] Tool declaration `unwrap_distill_tool` added to graph YAML
-- [ ] Unit test: `unwrap_distill` with `{"selected": null}` returns `{"top_candidate": None}`
-- [ ] Unit test: `unwrap_distill` with valid proposal JSON returns validated dict
-- [ ] Unit test: `write_proposals` with `top_candidate` dict writes single proposal file
-- [ ] Unit test: conditional routing with `top_candidate != None` reaches `propose`
-- [ ] Unit test: conditional routing with `top_candidate == None` skips to `reflect`
-- [ ] Tests added with `@pytest.mark.req` traceability
-- [ ] Documentation updated (graph description in YAML header reflects distill stage)
+- [x] `distill` copilot node added to philosopher graph between `analyze` and `unwrap_distill`
+- [x] `distill.yaml` prompt evaluates candidates on recency, severity, evidence spread, and specificity
+- [x] `distill.yaml` prompt correctly accesses `proposals.output` to resolve the CopilotResult envelope
+- [x] `distill` prompt outputs single `Proposal` JSON or `{"selected": null}` for no-candidate case
+- [x] `unwrap_distill` Python tool parses `CopilotResult.output` into validated `Proposal` dict or `None`
+- [x] `unwrap_distill` handles `{"selected": null}` signal without discarding valid Proposal JSON (key-presence check, not value check)
+- [x] Null short-circuit: when `top_candidate` is `None`, graph skips `propose` and routes to `reflect`
+- [x] `write_proposals()` reads `top_candidate` dict when present (single proposal path), falls back to `proposals` key
+- [x] `distill_result` and `top_candidate` declared in graph state
+- [x] Tool declaration `unwrap_distill_tool` added to graph YAML
+- [x] Unit test: `unwrap_distill` with `{"selected": null}` returns `{"top_candidate": None}`
+- [x] Unit test: `unwrap_distill` with valid proposal JSON returns validated dict
+- [x] Unit test: `write_proposals` with `top_candidate` dict writes single proposal file
+- [x] Unit test: conditional routing with `top_candidate != None` reaches `propose`
+- [x] Unit test: conditional routing with `top_candidate == None` skips to `reflect`
+- [x] Tests added with `@pytest.mark.req` traceability
+- [x] Documentation updated (graph description in YAML header reflects distill stage)
 
 ## Alternatives Considered
 


### PR DESCRIPTION
feat(philosopher): FR-197 add distill node with ranked prioritization

## Summary

Adds a `distill` copilot node to the philosopher graph that selects the single most pressing graduation candidate from the analyze output, replacing flat listing with weighted ranked prioritization.

## Changes

- **Distill node**: New copilot node in `examples/philosopher/graph.yaml` with `unwrap_distill` router
- **Distill prompt**: `examples/philosopher/prompts/distill.yaml` with structured Pydantic schema for ranked selection
- **Tests**: 11 new tests in `tests/unit/test_philosopher.py` covering graph structure, prompt validation, schema, and integration
- **Requirements**: REQ-YG-162 added to ARCHITECTURE.md
- **Capability**: CAP-73 registered
- **Changelog**: Fragment added per FR-179
- **Diary**: Metacognitive reflection entry

See FR at feature-requests/FR-197-philosopher-distill-node.md
