### PR TITLE
feat(ci): FR-206 add demo proof gate requiring demo-output.log

### DIFF
--- a/.chaplain/graphs/enforce/prompts/enforce-test-demo.yaml
+++ b/.chaplain/graphs/enforce/prompts/enforce-test-demo.yaml
@@ -27,6 +27,12 @@ user: |
      - Create a minimal working example in `examples/demos/<feature>/`
      - Include: graph.yaml, prompts/ folder, README.md
      - Test the example runs: `yamlgraph graph lint <example>/graph.yaml`
+     - **Run the demo and capture proof:**
+       ```
+       yamlgraph graph run examples/demos/<feature>/graph.yaml \
+         --full 2>&1 | tee examples/demos/<feature>/demo-output.log
+       ```
+     - Stage the demo-output.log alongside the demo files
 
   Report:
   - Test results (all passing?)

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -106,6 +106,52 @@ jobs:
           fi
           echo "✅ Release hygiene passed for v${VERSION}"
 
+  demo-gate:
+    name: Demo proof required for changed demos
+    runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.event.pull_request.title, 'feat') ||
+      startsWith(github.event.pull_request.title, 'fix')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify demo output logs exist
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Find demo directories with changed files (excluding the log itself)
+          CHANGED_DEMOS=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | grep -E '^examples/demos/[^/]+/' \
+            | grep -vE 'demo-output\.log$' \
+            | sed 's|examples/demos/\([^/]*\)/.*|\1|' \
+            | sort -u) || true
+
+          if [ -z "$CHANGED_DEMOS" ]; then
+            echo "⏭️ No demo files changed — demo gate skipped"
+            exit 0
+          fi
+
+          MISSING=0
+          for DEMO in $CHANGED_DEMOS; do
+            LOG="examples/demos/${DEMO}/demo-output.log"
+            if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qF "$LOG"; then
+              echo "✅ Demo proof found: $LOG"
+            else
+              echo "::error::Demo '$DEMO' changed but no demo-output.log in diff"
+              MISSING=$((MISSING + 1))
+            fi
+          done
+
+          if [ "$MISSING" -gt 0 ]; then
+            echo ""
+            echo "Run each changed demo and commit the output log:"
+            echo "  yamlgraph graph run examples/demos/<name>/graph.yaml --full 2>&1 | tee examples/demos/<name>/demo-output.log"
+            exit 1
+          fi
+
   diary-gate:
     name: Diary reflection required for feat/fix
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev,digest,websearch]"
 
       - name: Run tests
         run: pytest tests/unit/ -v --cov=yamlgraph --cov-fail-under=80

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ demo/
 
 # Logs
 *.log
+!examples/demos/*/demo-output.log
 examples/*/logs/
 examples/*/*.log
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,6 +156,15 @@ repos:
 
   - repo: local
     hooks:
+      - id: demo-proof-check
+        name: demo-proof-check
+        entry: scripts/check_demo_proof.sh
+        language: script
+        pass_filenames: false
+        stages: [pre-commit]
+
+  - repo: local
+    hooks:
       - id: changelog-release-sync
         name: changelog release sync
         entry: .venv/bin/python scripts/check_changelog_release_sync.py

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -352,6 +352,7 @@ Run `python scripts/aggregate_capabilities.py` to regenerate the sections below.
 | 76 | Horoscope Demo (FR-201) | `examples/demos/horoscope` | REQ-YG-197 |
 | 77 | Image Generation Pipeline (FR-202) | `examples/image_pipeline` | REQ-YG-198 |
 | 78 | .fi Domain Crawl Demo (FR-205) | `examples/demos/fi-domain-crawl` | REQ-YG-199 |
+| 79 | Demo Proof Gate (FR-206) | `scripts/check_demo_proof.sh`, `.github/workflows/commitlint.yml` | REQ-YG-200 |
 
 > Capability numbers are stable identifiers. Gaps (e.g. 27, 29, 52, 58) indicate retired capabilities.
 
@@ -1091,6 +1092,10 @@ Multi-stage pipeline for crawling .fi country-level domains: LLM query planning,
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-199 | .fi domain crawl demo: plan node produces search queries (parse_json), discover node filters to .fi TLD, map node crawls pages in parallel (max_items: 10), summarise node produces sitemap overview. crawl_page handles errors gracefully. No new dependencies. | `examples/demos/fi-domain-crawl`, `tests/unit/test_fi_domain_crawl.py` |
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-200 | `demo-gate` CI job in `commitlint.yml` extracts changed demo directories from `git diff` (excluding `demo-output.log` itself), verifies each has a `demo-output.log` in the diff, exits 1 on missing logs and 0 when no demos changed; job-level `if` condition restricts to `feat`/`fix` PR titles; uses `actions/checkout@v4` with `fetch-depth: 0`; pre-commit hook `demo-proof-check` calls `scripts/check_demo_proof.sh` with identical staged-file logic; `.gitignore` negates `*.log` for `examples/demos/*/demo-output.log`; `CLAUDE.md` documents `demo-gate` in branch protection section; enforcer Phase 2 prompt instructs capturing `demo-output.log` | `scripts/check_demo_proof.sh`, `.github/workflows/commitlint.yml`, `.pre-commit-config.yaml`, `CLAUDE.md`, `tests/unit/test_ci_demo_proof_gate.py` |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ The `main` branch is protected by GitHub branch protection rules (FR-150). These
 |------|---------|---------|
 | Require pull request | Enabled (0 approvals) | No direct pushes to `main` |
 | Squash merge only | Merge commits and rebase disabled | PR title = commit message; enforces Conventional Commits |
-| Required status checks | `commitlint`, `test`, `conflict-check`, `changelog-gate`, `diary-gate`, `security` | PR cannot merge with failing CI |
+| Required status checks | `commitlint`, `test`, `conflict-check`, `changelog-gate`, `demo-gate`, `diary-gate`, `security` | PR cannot merge with failing CI |
 | Require up to date | Enabled | PRs must be rebased on latest `main` before merge |
 
 ### Required status checks
@@ -351,6 +351,7 @@ The `main` branch is protected by GitHub branch protection rules (FR-150). These
 - **`conflict-check`** (`.github/workflows/commitlint.yml`): Fails when unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) are found in tracked files (excluding `.github/`). Complements the local `check-merge-conflict` pre-commit hook which is bypassed by server-side squash merges.
 - **`changelog-gate`** (`.github/workflows/commitlint.yml`): Blocks `feat`/`fix` PRs unless a changelog fragment exists in `changelog/unreleased/` (FR-179).
 - **`diary-gate`** (`.github/workflows/commitlint.yml`): Blocks `feat`/`fix` PRs with `FR-XXX` reference unless a diary reflection file exists in the diff.
+- **`demo-gate`** (`.github/workflows/commitlint.yml`): Blocks `feat`/`fix` PRs that modify files under `examples/demos/<name>/` unless a `demo-output.log` is included in the diff, proving the demo was executed (FR-206).
 - **`security`** (`.github/workflows/security.yml`): Validates installed dependencies have no known vulnerabilities (CVEs) via `pip-audit`.
 
 ### Emergency bypass

--- a/capabilities/CAP-79-demo-proof-gate.yaml
+++ b/capabilities/CAP-79-demo-proof-gate.yaml
@@ -1,0 +1,32 @@
+id: CAP-79
+name: Demo Proof Gate
+description: >
+  CI gate and pre-commit hook requiring demo-output.log artifact when demos
+  are created or modified, proving the demo was actually executed before merge.
+  Enforces Commandment 2 ("demonstrate with example") at the merge boundary.
+modules:
+  - scripts/check_demo_proof.sh
+  - .github/workflows/commitlint.yml
+  - .pre-commit-config.yaml
+requirements:
+  - id: REQ-YG-200
+    description: >
+      demo-gate CI job in commitlint.yml extracts changed demo directories from
+      git diff (excluding demo-output.log itself), verifies each has a
+      demo-output.log in the diff, exits 1 on missing logs and 0 when no demos
+      changed; job-level if condition restricts to feat/fix PR titles; uses
+      actions/checkout@v4 with fetch-depth: 0; pre-commit hook
+      demo-proof-check calls scripts/check_demo_proof.sh which checks staged
+      files with identical logic; .gitignore negates *.log for
+      examples/demos/*/demo-output.log; CLAUDE.md documents demo-gate in
+      branch protection section; enforcer Phase 2 prompt instructs capturing
+      demo-output.log
+    modules:
+      - scripts/check_demo_proof.sh
+      - .github/workflows/commitlint.yml
+      - .pre-commit-config.yaml
+      - .gitignore
+      - CLAUDE.md
+      - .chaplain/graphs/enforce/prompts/enforce-test-demo.yaml
+      - tests/unit/test_ci_demo_proof_gate.py
+fr: FR-206

--- a/changelog/unreleased/FR-206-demo-proof-gate.md
+++ b/changelog/unreleased/FR-206-demo-proof-gate.md
@@ -1,0 +1,6 @@
+---
+type: feat
+scope: ci
+req: REQ-YG-200
+---
+- **FR-206 Demo Proof Gate**: CI `demo-gate` job and pre-commit hook require `demo-output.log` when demos are created or modified, enforcing Commandment 2. (REQ-YG-200)

--- a/docs/diary/2026-03-28-reflection-fr-206.md
+++ b/docs/diary/2026-03-28-reflection-fr-206.md
@@ -1,0 +1,21 @@
+# Reflection: FR-206 Demo Proof Gate
+
+**Date:** 2026-03-28
+**FR:** FR-206 (demo proof gate)
+**Trap:** Incomplete verification
+
+## Context
+
+Added a CI gate requiring `demo-output.log` for PRs that modify demo directories—proving demos were actually executed before merge.
+
+## Insight
+
+The diary-gate itself (FR-150) caught that this feat PR lacked a reflection. Meta-enforcement working as designed: gates guarding gates.
+
+## Heuristic
+
+*Enforcement at merge boundary* — Any PR that touches demo code must prove execution. Advisory documentation insufficient; blocking gate required.
+
+## Seed
+
+Could auto-generate demo proof by running `examples/demos/demo.sh` in CI and comparing output hashes?

--- a/feature-requests/FR-206-demo-proof-gate.md
+++ b/feature-requests/FR-206-demo-proof-gate.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 1–2 days (backfilling ~35 demo directories requires LLM API calls)
 **Judged:** 2026-03-28
 **Requested:** 2026-03-28
@@ -134,15 +134,15 @@ Update `.chaplain/graphs/enforce/prompts/enforce-test-demo.yaml` to capture demo
 
 ## Acceptance Criteria
 
-- [ ] `scripts/check_demo_proof.sh` exists and detects missing demo logs for staged demo changes
-- [ ] Pre-commit hook `demo-proof-check` added to `.pre-commit-config.yaml`
-- [ ] CI job `demo-gate` added to `.github/workflows/commitlint.yml`
+- [x] `scripts/check_demo_proof.sh` exists and detects missing demo logs for staged demo changes
+- [x] Pre-commit hook `demo-proof-check` added to `.pre-commit-config.yaml`
+- [x] CI job `demo-gate` added to `.github/workflows/commitlint.yml`
 - [ ] `demo-gate` added to branch protection required status checks
-- [ ] Enforcer Phase 2 prompt updated to capture demo output to `demo-output.log`
+- [x] Enforcer Phase 2 prompt updated to capture demo output to `demo-output.log`
 - [ ] Existing demos in `examples/demos/` backfilled with `demo-output.log` (via `demo.sh` or manual run)
-- [ ] `demo-output.log` entries added to relevant `.gitignore` exclusions if needed (should NOT be ignored)
-- [ ] Tests: unit test for `check_demo_proof.sh` logic (REQ-YG-XXX)
-- [ ] Documentation: `CLAUDE.md` branch protection table updated with `demo-gate`
+- [x] `demo-output.log` entries added to relevant `.gitignore` exclusions if needed (should NOT be ignored)
+- [x] Tests: unit test for `check_demo_proof.sh` logic (REQ-YG-200)
+- [x] Documentation: `CLAUDE.md` branch protection table updated with `demo-gate`
 
 ## Demo Plan
 

--- a/scripts/check_demo_proof.sh
+++ b/scripts/check_demo_proof.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# scripts/check_demo_proof.sh — Pre-commit hook for FR-206 demo proof gate.
+# Checks staged files: if any examples/demos/<name>/ files are staged
+# (excluding demo-output.log itself), require demo-output.log to also be staged.
+set -euo pipefail
+
+STAGED=$(git diff --cached --name-only)
+
+# Extract demo directory names that have changes (excluding the log itself)
+CHANGED_DEMOS=$(echo "$STAGED" \
+  | grep -E '^examples/demos/[^/]+/' \
+  | grep -vE 'demo-output\.log$' \
+  | sed 's|examples/demos/\([^/]*\)/.*|\1|' \
+  | sort -u) || true
+
+if [ -z "$CHANGED_DEMOS" ]; then
+  exit 0
+fi
+
+MISSING=0
+for DEMO in $CHANGED_DEMOS; do
+  LOG="examples/demos/${DEMO}/demo-output.log"
+  if echo "$STAGED" | grep -qF "$LOG"; then
+    echo "✅ Demo proof found: $LOG"
+  else
+    echo "❌ Demo '$DEMO' changed but no demo-output.log staged"
+    MISSING=$((MISSING + 1))
+  fi
+done
+
+if [ "$MISSING" -gt 0 ]; then
+  echo ""
+  echo "Run each changed demo and stage the output log:"
+  echo "  yamlgraph graph run examples/demos/<name>/graph.yaml --full 2>&1 | tee examples/demos/<name>/demo-output.log"
+  exit 1
+fi

--- a/tests/unit/test_ci_demo_proof_gate.py
+++ b/tests/unit/test_ci_demo_proof_gate.py
@@ -1,0 +1,353 @@
+"""Tests for CI demo proof gate in commitlint.yml (FR-206).
+
+Validates that the `demo-gate` job in `.github/workflows/commitlint.yml`
+blocks PRs that modify demo files without including a `demo-output.log`,
+and that `scripts/check_demo_proof.sh` enforces the same locally via
+pre-commit.
+
+Three test layers:
+1. YAML structure — parse the workflow and verify job config.
+2. Shell logic — run check_demo_proof.sh against temp git repos.
+3. Documentation — CLAUDE.md and .pre-commit-config.yaml updated.
+"""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = ".github/workflows/commitlint.yml"
+PRECOMMIT_PATH = ".pre-commit-config.yaml"
+SCRIPT_PATH = "scripts/check_demo_proof.sh"
+
+
+def _load_workflow() -> dict:
+    """Load and parse the commitlint workflow YAML."""
+    with open(WORKFLOW_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _load_precommit() -> dict:
+    """Load and parse the pre-commit config YAML."""
+    with open(PRECOMMIT_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _setup_git_repo(tmpdir: str) -> None:
+    """Initialize a git repo with basic config in tmpdir."""
+    subprocess.run(["git", "init", "-q"], cwd=tmpdir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmpdir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmpdir,
+        check=True,
+    )
+
+
+def _run_demo_proof_check(
+    staged_files: dict[str, str],
+) -> subprocess.CompletedProcess:
+    """Run check_demo_proof.sh against staged files in a temp git repo.
+
+    Args:
+        staged_files: Mapping of relative path -> file content to stage.
+
+    Returns:
+        CompletedProcess with stdout, stderr, returncode.
+    """
+    script_abs = str(Path(SCRIPT_PATH).resolve())
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_git_repo(tmpdir)
+        tmppath = Path(tmpdir)
+
+        # Create an initial commit so HEAD exists
+        readme = tmppath / "README.md"
+        readme.write_text("init\n")
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "init"],
+            cwd=tmpdir,
+            check=True,
+        )
+
+        # Write and stage the test files
+        for relpath, content in staged_files.items():
+            fpath = tmppath / relpath
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+
+        return subprocess.run(
+            ["bash", script_abs],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+        )
+
+
+# ── YAML Structure Tests ───────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-200")
+class TestDemoGateJobStructure:
+    """Verify the demo-gate job exists with correct configuration."""
+
+    def test_job_exists(self) -> None:
+        """The commitlint workflow must contain a 'demo-gate' job."""
+        wf = _load_workflow()
+        assert "demo-gate" in wf["jobs"], "Missing 'demo-gate' job in commitlint.yml"
+
+    def test_job_name(self) -> None:
+        """The job display name indicates demo proof checking."""
+        wf = _load_workflow()
+        job = wf["jobs"]["demo-gate"]
+        assert "demo" in job["name"].lower(), "Job name must mention demo"
+
+    def test_job_restricted_to_feat_fix(self) -> None:
+        """The job runs only on feat/fix PRs via if condition."""
+        wf = _load_workflow()
+        job = wf["jobs"]["demo-gate"]
+        condition = job.get("if", "")
+        assert "feat" in condition, "Job must filter for feat PRs"
+        assert "fix" in condition, "Job must filter for fix PRs"
+
+    def test_checkout_with_full_history(self) -> None:
+        """The job must check out with fetch-depth: 0 for diff access."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["demo-gate"]["steps"]
+        checkout_steps = [
+            s for s in steps if s.get("uses", "").startswith("actions/checkout")
+        ]
+        assert checkout_steps, "Must have an actions/checkout step"
+        checkout = checkout_steps[0]
+        assert (
+            checkout.get("with", {}).get("fetch-depth") == 0
+        ), "Must use fetch-depth: 0"
+
+    def test_uses_base_head_sha_env(self) -> None:
+        """The verification step must use BASE_SHA and HEAD_SHA env vars."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["demo-gate"]["steps"]
+        verify_steps = [
+            s for s in steps if "run" in s and "demo" in s.get("run", "").lower()
+        ]
+        assert verify_steps, "Must have a step that checks demo output"
+        step = verify_steps[0]
+        env = step.get("env", {})
+        assert "BASE_SHA" in env, "Must set BASE_SHA env var"
+        assert "HEAD_SHA" in env, "Must set HEAD_SHA env var"
+
+    def test_fails_on_missing_log(self) -> None:
+        """The script must exit 1 when demo-output.log is missing."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["demo-gate"]["steps"]
+        verify_steps = [
+            s for s in steps if "run" in s and "demo" in s.get("run", "").lower()
+        ]
+        assert verify_steps, "Must have a demo check step"
+        run_script = verify_steps[0]["run"]
+        assert "exit 1" in run_script, "Must exit 1 on missing demo proof"
+
+    def test_skips_when_no_demos_changed(self) -> None:
+        """The script must skip gracefully when no demo files changed."""
+        wf = _load_workflow()
+        steps = wf["jobs"]["demo-gate"]["steps"]
+        verify_steps = [
+            s for s in steps if "run" in s and "demo" in s.get("run", "").lower()
+        ]
+        assert verify_steps, "Must have a demo check step"
+        run_script = verify_steps[0]["run"]
+        assert "exit 0" in run_script, "Must exit 0 when no demos changed"
+
+
+# ── Shell Script Logic Tests ───────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-200")
+class TestDemoProofShellLogic:
+    """Test check_demo_proof.sh against real temp git repos."""
+
+    def test_script_exists(self) -> None:
+        """The check_demo_proof.sh script must exist."""
+        assert Path(SCRIPT_PATH).exists(), f"Missing {SCRIPT_PATH}"
+
+    def test_script_is_executable(self) -> None:
+        """The script must be executable."""
+        assert os.access(SCRIPT_PATH, os.X_OK), f"{SCRIPT_PATH} must be executable"
+
+    def test_no_demo_files_passes(self) -> None:
+        """When no demo files are staged, the check passes."""
+        result = _run_demo_proof_check({"src/main.py": "print('hello')\n"})
+        assert result.returncode == 0, f"Should pass: {result.stdout}"
+
+    def test_demo_with_log_passes(self) -> None:
+        """When a demo file and its demo-output.log are both staged, passes."""
+        result = _run_demo_proof_check(
+            {
+                "examples/demos/hello/graph.yaml": "nodes: {}\n",
+                "examples/demos/hello/demo-output.log": "output here\n",
+            }
+        )
+        assert result.returncode == 0, f"Should pass with log: {result.stdout}"
+
+    def test_demo_without_log_fails(self) -> None:
+        """When a demo file is staged without demo-output.log, fails."""
+        result = _run_demo_proof_check(
+            {
+                "examples/demos/hello/graph.yaml": "nodes: {}\n",
+            }
+        )
+        assert result.returncode == 1, f"Should fail without log: {result.stdout}"
+        assert (
+            "demo-output.log" in result.stdout.lower()
+            or "demo-output.log" in result.stderr.lower()
+        )
+
+    def test_multiple_demos_all_need_logs(self) -> None:
+        """Each changed demo directory needs its own demo-output.log."""
+        result = _run_demo_proof_check(
+            {
+                "examples/demos/hello/graph.yaml": "nodes: {}\n",
+                "examples/demos/hello/demo-output.log": "output\n",
+                "examples/demos/router/graph.yaml": "nodes: {}\n",
+                # router is missing its log
+            }
+        )
+        assert result.returncode == 1, f"Should fail for router: {result.stdout}"
+
+    def test_only_log_changed_passes(self) -> None:
+        """When only demo-output.log is staged (no other demo files), passes."""
+        result = _run_demo_proof_check(
+            {
+                "examples/demos/hello/demo-output.log": "new output\n",
+            }
+        )
+        assert result.returncode == 0, f"Log-only change should pass: {result.stdout}"
+
+    def test_readme_change_needs_log(self) -> None:
+        """Changing any file in a demo dir (not just graph.yaml) requires log."""
+        result = _run_demo_proof_check(
+            {
+                "examples/demos/hello/README.md": "# Hello\n",
+            }
+        )
+        assert (
+            result.returncode == 1
+        ), f"README change should require log: {result.stdout}"
+
+    def test_nested_demo_file_needs_log(self) -> None:
+        """Changing a file in a subdirectory of a demo requires log."""
+        result = _run_demo_proof_check(
+            {
+                "examples/demos/hello/prompts/main.yaml": "system: hi\n",
+            }
+        )
+        assert (
+            result.returncode == 1
+        ), f"Nested file change should require log: {result.stdout}"
+
+
+# ── Pre-commit Hook Tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-200")
+class TestDemoProofPrecommitHook:
+    """Verify .pre-commit-config.yaml includes demo-proof-check hook."""
+
+    def test_hook_exists(self) -> None:
+        """The pre-commit config must include a demo-proof-check hook."""
+        config = _load_precommit()
+        hook_ids = []
+        for repo in config.get("repos", []):
+            for hook in repo.get("hooks", []):
+                hook_ids.append(hook["id"])
+        assert (
+            "demo-proof-check" in hook_ids
+        ), "Missing 'demo-proof-check' hook in .pre-commit-config.yaml"
+
+    def test_hook_uses_script(self) -> None:
+        """The hook must point to scripts/check_demo_proof.sh."""
+        config = _load_precommit()
+        for repo in config.get("repos", []):
+            for hook in repo.get("hooks", []):
+                if hook["id"] == "demo-proof-check":
+                    assert "check_demo_proof" in hook.get(
+                        "entry", ""
+                    ), "Hook must use check_demo_proof script"
+                    return
+        pytest.fail("Hook not found")
+
+    def test_hook_stage_is_precommit(self) -> None:
+        """The hook must run at pre-commit stage."""
+        config = _load_precommit()
+        for repo in config.get("repos", []):
+            for hook in repo.get("hooks", []):
+                if hook["id"] == "demo-proof-check":
+                    stages = hook.get("stages", [])
+                    assert "pre-commit" in stages, "Hook must run at pre-commit stage"
+                    return
+        pytest.fail("Hook not found")
+
+
+# ── Gitignore Tests ────────────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-200")
+class TestDemoOutputLogNotIgnored:
+    """Verify demo-output.log is explicitly NOT gitignored."""
+
+    def test_gitignore_negation_exists(self) -> None:
+        """The .gitignore must have a negation pattern for demo-output.log."""
+        content = Path(".gitignore").read_text()
+        assert (
+            "!examples/demos/*/demo-output.log" in content
+        ), ".gitignore must negate *.log for demo-output.log files"
+
+
+# ── Documentation Tests ────────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-200")
+class TestDemoGateDocumentation:
+    """Verify CLAUDE.md documents the demo-gate status check."""
+
+    def test_claude_md_lists_demo_gate(self) -> None:
+        """CLAUDE.md branch protection section must list demo-gate."""
+        content = Path("CLAUDE.md").read_text()
+        assert (
+            "demo-gate" in content
+        ), "CLAUDE.md must list demo-gate as a required status check"
+
+    def test_claude_md_describes_demo_gate(self) -> None:
+        """CLAUDE.md must describe what the demo-gate does."""
+        content = Path("CLAUDE.md").read_text()
+        assert (
+            "demo-output.log" in content or "demo proof" in content.lower()
+        ), "CLAUDE.md must describe demo-gate purpose"
+
+
+# ── Enforcer Prompt Tests ──────────────────────────────────────────────────
+
+
+@pytest.mark.req("REQ-YG-200")
+class TestEnforcerPromptUpdated:
+    """Verify Phase 2 enforcer prompt includes demo output capture."""
+
+    def test_enforcer_mentions_demo_output_log(self) -> None:
+        """The enforce-test-demo prompt must instruct capturing demo-output.log."""
+        prompt_path = Path(".chaplain/graphs/enforce/prompts/enforce-test-demo.yaml")
+        if not prompt_path.exists():
+            pytest.skip("Enforcer prompt not found in this worktree")
+        content = prompt_path.read_text()
+        assert (
+            "demo-output.log" in content
+        ), "Enforcer Phase 2 prompt must instruct capturing demo-output.log"


### PR DESCRIPTION
## Summary

Add a CI gate and pre-commit hook that require a `demo-output.log` artifact when demos are created or modified, proving the demo was actually run.

**FR:** `feature-requests/FR-206-demo-proof-gate.md`
**REQ:** REQ-YG-200

### Changes
- **CI gate**: `demo-gate` job in `commitlint.yml` blocks PR merge when demos modified without `demo-output.log`
- **Pre-commit hook**: `check_demo_proof.sh` validates `demo-output.log` presence locally
- **Enforcer prompt**: `enforce-test-demo.yaml` updated to capture demo output to log
- **Tests**: Unit tests for `check_demo_proof.sh` covering all gate scenarios (REQ-YG-200)
- **Docs**: ARCHITECTURE.md and CLAUDE.md updated with demo-gate documentation
- **Capability**: CAP-79-demo-proof-gate registered