### PR TITLE
feat(hooks): FR-212 block AI co-author trailers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -210,6 +210,15 @@ repos:
 
   - repo: local
     hooks:
+      - id: block-ai-coauthor
+        name: "Block AI co-author trailers"
+        entry: .venv/bin/python scripts/block_ai_coauthor.py
+        language: system
+        always_run: true
+        stages: [commit-msg]
+
+  - repo: local
+    hooks:
       - id: absolution
         name: "Absolution"
         entry: .venv/bin/python scripts/absolution.py

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1119,6 +1119,7 @@ Extract governance methodology into standalone template repository (`scripture-d
 | REQ-YG-212 | `task/cancel` cancels running graph execution via `YAMLGraphAgentExecutor.cancel()` emitting `canceled` TaskState | `yamlgraph/a2a_server.py`, `tests/unit/test_a2a_server.py` |
 | REQ-YG-213 | `input-required` state emitted when graph hits `__interrupt__` node | `yamlgraph/a2a_server.py` |
 | REQ-YG-214 | Router conditional edge route mapping redirects interrupt node targets to `{name}_prepare` and subgraph interrupt targets to `{name}__run`, while keeping original names as route labels for `make_router_fn` matching (FR-211) | `yamlgraph/edge_compiler`, `yamlgraph/graph_loader` |
+| REQ-YG-215 | `scripts/block_ai_coauthor.py` commit-msg hook scans `Co-authored-by:` trailers for AI agent patterns (copilot, claude, chatgpt, gemini, gpt-?[0-9]+, github copilot), exits 1 with penance liturgy on match, exits 0 for clean messages and human co-authors; registered as `block-ai-coauthor` in `.pre-commit-config.yaml` at `commit-msg` stage before `absolution` | `scripts/block_ai_coauthor.py`, `.pre-commit-config.yaml`, `tests/unit/test_precommit_hooks.py` |
 
 ---
 

--- a/capabilities/CAP-82-block-ai-coauthor.yaml
+++ b/capabilities/CAP-82-block-ai-coauthor.yaml
@@ -1,0 +1,22 @@
+id: CAP-82
+name: Block AI Co-Author Trailers
+description: >
+  Commit-msg hook that detects and blocks AI agent Co-authored-by trailers
+  (Copilot, Claude, ChatGPT, Gemini, GPT-*) before they enter the repository.
+  Prints the offending line(s) and penance liturgy, then exits 1 to block the
+  commit. Human co-authors and clean messages pass silently.
+modules:
+  - scripts/block_ai_coauthor.py
+  - .pre-commit-config.yaml
+requirements:
+  - id: REQ-YG-215
+    description: >
+      block_ai_coauthor.py commit-msg hook: regex-detects AI agent trailers,
+      exits 1 with offending line + penance liturgy; exits 0 for clean and
+      human-only messages; registered as block-ai-coauthor in pre-commit-config
+      at commit-msg stage before absolution
+    modules:
+      - scripts/block_ai_coauthor.py
+      - .pre-commit-config.yaml
+      - tests/unit/test_precommit_hooks.py
+fr: FR-212

--- a/changelog/unreleased/fr-212-block-ai-coauthor-trailers.md
+++ b/changelog/unreleased/fr-212-block-ai-coauthor-trailers.md
@@ -1,0 +1,6 @@
+---
+type: feat
+scope: hooks
+req: REQ-YG-215
+---
+- **FR-212 Block AI Co-Author Trailers**: `commit-msg` hook `block-ai-coauthor` (`scripts/block_ai_coauthor.py`) rejects commits containing AI agent `Co-authored-by:` trailers (Copilot, Claude, ChatGPT, Gemini, GPT-*) with penance liturgy; human co-authors pass unblocked. (REQ-YG-215)

--- a/docs/diary/2026-03-31-reflection-fr-212-block-ai-coauthor.md
+++ b/docs/diary/2026-03-31-reflection-fr-212-block-ai-coauthor.md
@@ -1,0 +1,21 @@
+# 2026-03-31: FR-212 — Block AI Co-Author Trailers
+
+**Context:** Implemented a `commit-msg` pre-commit hook (`block_ai_coauthor.py`) that
+detects AI agent `Co-authored-by:` trailers and blocks the commit with a penance liturgy.
+Followed strict TDD (RED → GREEN): 12 failing tests written first, then minimal script +
+config change to make them pass.
+
+**Trap:** `infrastructure_self_exempt` — the instruction scaffold (GitHub Copilot CLI) injects
+the very trailer this hook now blocks. This creates a reflexive enforcement loop: the tool
+that helps write the hook also adds the thing the hook forbids. The cure is clarity of
+ownership: the committer edits the message before signing; the hook enforces that contract
+at the boundary.
+
+**Heuristic:** `enforcement_at_merge_boundary` — a local `commit-msg` hook is the earliest
+enforceable gate. By the time a trailer reaches CI, it is already in branch history. The
+`--no-verify` bypass is already forbidden by doctrine; therefore the hook cannot be silently
+skipped. Normalize at the boundary.
+
+**Seed:** Could the hook auto-strip known AI trailers (with a `--fix` flag) rather than
+always blocking? Would silent correction undermine the penance ritual and author-ownership
+principle, or is it pragmatic when working solo?

--- a/feature-requests/FR-212-block-ai-coauthor-trailers.md
+++ b/feature-requests/FR-212-block-ai-coauthor-trailers.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Feature
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-03-31
 
@@ -137,18 +137,18 @@ if __name__ == "__main__":
 
 ## Acceptance Criteria
 
-- [ ] `scripts/block_ai_coauthor.py` exists and is executable
-- [ ] Hook `block-ai-coauthor` is registered in `.pre-commit-config.yaml` at `commit-msg` stage
-- [ ] Commit message containing `Co-authored-by: Copilot <...>` is **rejected** (exit 1)
-- [ ] Commit message containing `Co-authored-by: Claude <...>` is **rejected** (exit 1)
-- [ ] Commit message containing `Co-authored-by: GitHub Copilot <...>` is **rejected** (exit 1)
-- [ ] Commit message with no AI trailer is **accepted** (exit 0)
-- [ ] Human `Co-authored-by:` trailers (e.g., a real team member) are **accepted** (exit 0)
-- [ ] Rejection output includes the offending line(s) and the full penance liturgy
-- [ ] Unit tests added in `tests/unit/test_precommit_hooks.py` covering all cases above
-- [ ] Tests tagged with `@pytest.mark.req("REQ-YG-XXX")` (new requirement added to ARCHITECTURE.md)
-- [ ] Changelog fragment added in `changelog/unreleased/`
-- [ ] Diary reflection added in `docs/diary/`
+- [x] `scripts/block_ai_coauthor.py` exists and is executable
+- [x] Hook `block-ai-coauthor` is registered in `.pre-commit-config.yaml` at `commit-msg` stage
+- [x] Commit message containing `Co-authored-by: Copilot <...>` is **rejected** (exit 1)
+- [x] Commit message containing `Co-authored-by: Claude <...>` is **rejected** (exit 1)
+- [x] Commit message containing `Co-authored-by: GitHub Copilot <...>` is **rejected** (exit 1)
+- [x] Commit message with no AI trailer is **accepted** (exit 0)
+- [x] Human `Co-authored-by:` trailers (e.g., a real team member) are **accepted** (exit 0)
+- [x] Rejection output includes the offending line(s) and the full penance liturgy
+- [x] Unit tests added in `tests/unit/test_precommit_hooks.py` covering all cases above
+- [x] Tests tagged with `@pytest.mark.req("REQ-YG-215")` (new requirement added to ARCHITECTURE.md)
+- [x] Changelog fragment added in `changelog/unreleased/`
+- [x] Diary reflection added in `docs/diary/`
 
 ## Alternatives Considered
 

--- a/scripts/block_ai_coauthor.py
+++ b/scripts/block_ai_coauthor.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Commit-msg hook: block AI agent Co-authored-by trailers.
+
+Pass the commit message file path as the first argument (pre-commit does this
+automatically for commit-msg stage hooks).
+"""
+
+import re
+import sys
+
+AI_PATTERN = re.compile(
+    r"^co-authored-by:.*?(copilot|claude|chatgpt|gemini|gpt-?[0-9]+|github\s+copilot)",
+    re.IGNORECASE,
+)
+
+PENANCE = """
+✗ Co-authored-by AI trailer detected.
+
+  Confession required before this commit may proceed.
+
+  Remove the offending trailer(s), then recite the Agents' Prayer:
+
+    May I fix at the callsite, not the utility.
+    May I kill the cheapest bug — the one in the spec.
+    May I trace the cause before I fix the symptom.
+
+  The author owns the commit. The tool does not.
+  Delete the trailer. Recommit. Absolution follows.
+"""
+
+
+def main() -> int:
+    msg_file = sys.argv[1]
+    with open(msg_file) as f:
+        lines = f.readlines()
+
+    offenders = [line.rstrip() for line in lines if AI_PATTERN.match(line)]
+    if not offenders:
+        return 0
+
+    print("\nOffending trailer(s):")
+    for line in offenders:
+        print(f"  {line}")
+    print(PENANCE)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_precommit_hooks.py
+++ b/tests/unit/test_precommit_hooks.py
@@ -6,7 +6,9 @@ These tests invoke the bash hook entries directly via subprocess
 with temporary commit message files to verify the conditional logic.
 """
 
+import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -376,3 +378,106 @@ class TestFinalizeMergeUnstagedDiary:
         assert (
             "untracked" in content.lower()
         ), "Commit message should mention 'untracked'"
+
+
+# ── FR-212: Block AI Co-Author Trailers ─────────────────────────────────────
+
+BLOCK_AI_COAUTHOR_SCRIPT = Path("scripts/block_ai_coauthor.py")
+
+
+def run_block_ai_coauthor(commit_msg: str) -> subprocess.CompletedProcess:
+    """Run block_ai_coauthor.py with a commit message written to a temp file."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write(commit_msg)
+        f.flush()
+        msg_file = f.name
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(BLOCK_AI_COAUTHOR_SCRIPT), msg_file],
+            capture_output=True,
+            text=True,
+        )
+        return result
+    finally:
+        Path(msg_file).unlink()
+
+
+@pytest.mark.req("REQ-YG-215")
+class TestBlockAICoAuthor:
+    """Tests for block-ai-coauthor commit-msg hook (FR-212)."""
+
+    def test_copilot_trailer_rejected(self) -> None:
+        """Co-authored-by: Copilot trailer must be blocked."""
+        msg = "feat: FR-212 add hook\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 1, "Copilot trailer should fail"
+
+    def test_claude_trailer_rejected(self) -> None:
+        """Co-authored-by: Claude trailer must be blocked."""
+        msg = "fix: correct bug\n\nCo-authored-by: Claude <claude@anthropic.com>\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 1, "Claude trailer should fail"
+
+    def test_github_copilot_trailer_rejected(self) -> None:
+        """Co-authored-by: GitHub Copilot trailer must be blocked."""
+        msg = (
+            "fix: correct bug\n\nCo-authored-by: GitHub Copilot <copilot@github.com>\n"
+        )
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 1, "GitHub Copilot trailer should fail"
+
+    def test_chatgpt_trailer_rejected(self) -> None:
+        """Co-authored-by: ChatGPT trailer must be blocked."""
+        msg = "fix: bug\n\nCo-authored-by: ChatGPT <chatgpt@openai.com>\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 1, "ChatGPT trailer should fail"
+
+    def test_gemini_trailer_rejected(self) -> None:
+        """Co-authored-by: Gemini trailer must be blocked."""
+        msg = "fix: bug\n\nCo-authored-by: Gemini <gemini@google.com>\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 1, "Gemini trailer should fail"
+
+    def test_gpt4_trailer_rejected(self) -> None:
+        """Co-authored-by: GPT-4 trailer must be blocked."""
+        msg = "fix: bug\n\nCo-authored-by: GPT-4 <gpt4@openai.com>\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 1, "GPT-4 trailer should fail"
+
+    def test_clean_commit_accepted(self) -> None:
+        """Commit with no AI trailer must pass."""
+        msg = "feat: FR-212 add hook\n\nAdded enforcement hook.\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 0, f"Clean commit should pass: {result.stdout}"
+
+    def test_human_coauthor_accepted(self) -> None:
+        """Human Co-authored-by trailer must pass."""
+        msg = "feat: FR-212 pair programming\n\nCo-authored-by: Alice Smith <alice@example.com>\n"
+        result = run_block_ai_coauthor(msg)
+        assert result.returncode == 0, f"Human co-author should pass: {result.stdout}"
+
+    def test_rejection_output_contains_offending_line(self) -> None:
+        """Rejection must print the offending trailer line."""
+        msg = "fix: bug\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>\n"
+        result = run_block_ai_coauthor(msg)
+        combined = result.stdout + result.stderr
+        assert "Co-authored-by" in combined, "Output must show offending line"
+
+    def test_rejection_output_contains_penance(self) -> None:
+        """Rejection must include the penance liturgy."""
+        msg = "fix: bug\n\nCo-authored-by: Claude <claude@anthropic.com>\n"
+        result = run_block_ai_coauthor(msg)
+        combined = result.stdout + result.stderr
+        assert "Confession required" in combined, "Penance liturgy must be printed"
+
+    def test_script_exists_and_is_executable(self) -> None:
+        """scripts/block_ai_coauthor.py must exist and be executable."""
+        assert BLOCK_AI_COAUTHOR_SCRIPT.exists(), "Script file must exist"
+        assert os.access(BLOCK_AI_COAUTHOR_SCRIPT, os.X_OK), "Script must be executable"
+
+    def test_hook_registered_in_precommit_config(self) -> None:
+        """block-ai-coauthor hook must be in .pre-commit-config.yaml at commit-msg stage."""
+        config = Path(".pre-commit-config.yaml").read_text()
+        assert "block-ai-coauthor" in config, "Hook ID must be in pre-commit config"
+        assert "commit-msg" in config, "Hook must use commit-msg stage"


### PR DESCRIPTION
See FR at feature-requests/FR-212-block-ai-coauthor-trailers.md

## Summary

Adds a `commit-msg` pre-commit hook (`scripts/block_ai_coauthor.py`) that detects and blocks AI agent co-author trailers (Copilot, Claude, ChatGPT, Gemini, GPT variants) from entering git history.

## Changes

- `scripts/block_ai_coauthor.py`: hook implementation with penance liturgy
- `.pre-commit-config.yaml`: registers `block-ai-coauthor` as `commit-msg` stage hook
- `tests/unit/test_precommit_hooks.py`: unit tests covering pass/block/penance paths
- `capabilities/CAP-82-block-ai-coauthor.yaml`: capability registry entry
- `changelog/unreleased/fr-212-block-ai-coauthor-trailers.md`: changelog fragment
- `docs/diary/2026-03-31-reflection-fr-212-block-ai-coauthor.md`: metacognitive reflection
- `ARCHITECTURE.md`: updated requirements (REQ-YG-164/165)