### PR TITLE
fix(providers): migrate vertex from deprecated ChatVertexAI to ChatGoogleGenerativeAI

### DIFF
--- a/changelog/unreleased/fix-vertex-deprecation-migration.md
+++ b/changelog/unreleased/fix-vertex-deprecation-migration.md
@@ -1,0 +1,6 @@
+---
+type: fix
+scope: providers
+req: REQ-YG-010
+---
+- **Fix Vertex AI Deprecation**: Migrate `provider: vertex` from deprecated `ChatVertexAI` (`langchain-google-vertexai`) to `ChatGoogleGenerativeAI(vertexai=True)` (`langchain-google-genai`). Eliminates deprecation warning and removes the `[vertex]` optional extra since `langchain-google-genai` is already a core dependency. (REQ-YG-010)

--- a/docs/diary/2026-03-31-vertex-deprecation-migration.md
+++ b/docs/diary/2026-03-31-vertex-deprecation-migration.md
@@ -1,0 +1,49 @@
+# Diary: Vertex AI Deprecation Migration
+
+**Date**: 2026-03-31
+**Branch**: fix/vertex-deprecation-migration
+
+## What I Did
+
+Migrated the `vertex` provider from the deprecated `ChatVertexAI` class
+(`langchain-google-vertexai`) to `ChatGoogleGenerativeAI(vertexai=True)`
+(`langchain-google-genai`).
+
+## Cognitive Process
+
+FR-213 was merged hours ago using `ChatVertexAI`. The first smoke test revealed
+a `LangChainDeprecationWarning` stating `ChatVertexAI` was deprecated in
+LangChain 3.2.0 and would be removed in 4.0.0. The recommended replacement
+is `ChatGoogleGenerativeAI` from `langchain-google-genai` — which is already
+a core dependency of YAMLGraph (used by `provider: google`).
+
+Inspecting `ChatGoogleGenerativeAI`'s constructor confirmed it now has
+`vertexai`, `project`, and `location` parameters — the same auth surface
+as `ChatVertexAI`. The migration was a single-function change: set
+`vertexai=True` and use `model=` instead of `model_name=`.
+
+## Traps Encountered
+
+**Trap: downstream_fix**. The initial FR-213 implementation chose
+`langchain-google-vertexai` because that was the "Vertex AI package". But
+the upstream deprecation shows the genai package absorbed that functionality.
+The fix: normalize at the boundary (the import) rather than patching downstream.
+
+**Trap: working_system_inertia**. FR-213 passed all tests and merged cleanly.
+The deprecation warning was easy to ignore since the code functioned. But
+"it works" blocks seeing it clearly — the optional `[vertex]` extra was
+unnecessary complexity since `langchain-google-genai` already handles Vertex AI.
+
+## What Worked
+
+- Checking `ChatGoogleGenerativeAI`'s constructor signature via `inspect`
+  confirmed the migration path before writing any code.
+- Removing the `[vertex]` optional extra simplified the dependency tree.
+- All 4 existing vertex tests adapted cleanly with minimal changes.
+
+## Seed
+
+The `google` and `vertex` providers now share the same underlying class
+(`ChatGoogleGenerativeAI`) — differing only in `vertexai=True` and auth
+mechanism. Could they be consolidated into a single provider with an
+`auth: api_key | adc` parameter, reducing the dispatch surface?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,6 @@ storyboard = [
 replicate = [
     "langchain-litellm>=0.3.0",  # includes litellm as dependency
 ]
-vertex = [
-    "langchain-google-vertexai>=2.0.0",
-]
 redis = [
     "langgraph-checkpoint-redis>=0.3.0",
 ]

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -172,17 +172,18 @@ class TestCreateLLM:
 
     @pytest.mark.req("REQ-YG-010")
     def test_create_llm_vertex(self, monkeypatch):
-        """Vertex provider creates ChatVertexAI with project and location."""
+        """Vertex provider creates ChatGoogleGenerativeAI with vertexai=True."""
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
         monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "europe-west4")
 
-        with patch("yamlgraph.utils.llm_factory.ChatVertexAI") as mock_cls:
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_cls:
             create_llm(provider="vertex", model="gemini-2.0-flash")
             mock_cls.assert_called_once()
             kwargs = mock_cls.call_args[1]
             assert kwargs["project"] == "test-project"
             assert kwargs["location"] == "europe-west4"
-            assert kwargs["model_name"] == "gemini-2.0-flash"
+            assert kwargs["model"] == "gemini-2.0-flash"
+            assert kwargs["vertexai"] is True
 
     @pytest.mark.req("REQ-YG-010")
     def test_vertex_default_location(self, monkeypatch):
@@ -190,7 +191,7 @@ class TestCreateLLM:
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
         monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
 
-        with patch("yamlgraph.utils.llm_factory.ChatVertexAI") as mock_cls:
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_cls:
             create_llm(provider="vertex", model="gemini-2.0-flash")
             kwargs = mock_cls.call_args[1]
             assert kwargs["location"] == "us-central1"
@@ -210,7 +211,7 @@ class TestCreateLLM:
         monkeypatch.setenv("VERTEXAI_PROJECT", "fallback-project")
         monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 
-        with patch("yamlgraph.utils.llm_factory.ChatVertexAI") as mock_cls:
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_cls:
             create_llm(provider="vertex", model="gemini-2.0-flash")
             kwargs = mock_cls.call_args[1]
             assert kwargs["project"] == "fallback-project"

--- a/yamlgraph/utils/llm_factory.py
+++ b/yamlgraph/utils/llm_factory.py
@@ -13,12 +13,6 @@ from langchain_core.language_models.chat_models import BaseChatModel
 
 from yamlgraph.config import DEFAULT_MODELS
 
-# Optional: Google Vertex AI (install with: pip install yamlgraph[vertex])
-try:
-    from langchain_google_vertexai import ChatVertexAI
-except ImportError:
-    ChatVertexAI = None  # type: ignore[assignment,misc]
-
 logger = logging.getLogger(__name__)
 
 # Type alias for supported providers
@@ -376,23 +370,19 @@ def _create_vertex_llm(
 ) -> BaseChatModel:
     """Create Google Vertex AI LLM.
 
+    Uses ChatGoogleGenerativeAI with vertexai=True for GCP ADC authentication.
     Requires GOOGLE_CLOUD_PROJECT (or VERTEXAI_PROJECT) and optionally
-    GOOGLE_CLOUD_LOCATION. Authentication is handled by Application Default
-    Credentials (ADC) or a service account key file pointed to by
-    GOOGLE_APPLICATION_CREDENTIALS.
+    GOOGLE_CLOUD_LOCATION.
     """
-    if ChatVertexAI is None:
-        raise ImportError(
-            "langchain-google-vertexai is not installed. "
-            "Install with: pip install 'yamlgraph[vertex]'"
-        )
+    from langchain_google_genai import ChatGoogleGenerativeAI
 
     project = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("VERTEXAI_PROJECT")
     location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
 
-    return ChatVertexAI(
-        model_name=model,
+    return ChatGoogleGenerativeAI(
+        model=model,
         temperature=temperature,
+        vertexai=True,
         project=project,
         location=location,
         **kwargs,


### PR DESCRIPTION
## Summary

Migrate `provider: vertex` from deprecated `ChatVertexAI` (`langchain-google-vertexai`) to `ChatGoogleGenerativeAI(vertexai=True)` (`langchain-google-genai`).

## Changes

- `yamlgraph/utils/llm_factory.py`: Replace `ChatVertexAI` with `ChatGoogleGenerativeAI(vertexai=True)`, remove module-level try/except import
- `pyproject.toml`: Remove `[vertex]` optional extra (langchain-google-genai is already a core dependency)
- `tests/unit/test_llm_factory.py`: Update mocks to patch `langchain_google_genai.ChatGoogleGenerativeAI`
- Changelog fragment and diary entry

## Motivation

`ChatVertexAI` was deprecated in LangChain 3.2.0 (will be removed in 4.0.0). The replacement `ChatGoogleGenerativeAI` already supports Vertex AI auth via `vertexai=True` parameter.