### PR TITLE
feat(llm_factory): FR-226 Vertex AI Express API key auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,7 @@ The codebase uses **sync-first with async wrappers**:
 | `GOOGLE_CLOUD_PROJECT` | GCP project for Vertex AI (`provider: vertex`) |
 | `GOOGLE_CLOUD_LOCATION` | Vertex AI region (default: `us-central1`) |
 | `VERTEX_MODEL` | Default model for Vertex AI provider (default: `gemini-2.0-flash`) |
+| `VERTEX_API_KEY` | Vertex AI Express mode API key; when set, skips project/location (ADC) and authenticates via key only |
 | `INCEPTION_API_KEY` | Inception Labs Mercury authentication |
 | `MISTRAL_API_KEY` | Mistral authentication |
 | `OPENAI_API_KEY` | OpenAI authentication |

--- a/changelog/unreleased/fr-226-vertex-express-api-key-auth.md
+++ b/changelog/unreleased/fr-226-vertex-express-api-key-auth.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: llm_factory
+---
+- **FR-226 Vertex Express API Key Auth**: `_create_vertex_llm` now supports Express mode — when `VERTEX_API_KEY` is set, passes `google_api_key` without `project`/`location`, avoiding the SDK `ValueError` on key+project collision. ADC branch (project+location) unchanged.

--- a/docs/diary/2026-04-17-reflection-fr-226-vertex-express-api-key-auth.md
+++ b/docs/diary/2026-04-17-reflection-fr-226-vertex-express-api-key-auth.md
@@ -1,0 +1,21 @@
+# Reflection: FR-226 Vertex Express API Key Auth
+
+**Date:** 2026-04-17
+
+## Cognitive Process
+
+This was a textbook boundary normalization case from the Scripture knowledge graph: *normalize at the boundary where external data enters*. The fix belongs at the entry point of `_create_vertex_llm` — where the env-var is first read — not at a downstream call site.
+
+## Trap Encountered
+
+**`downstream_fix`**: My first mental model wanted to guard at the `ChatGoogleGenerativeAI` call by conditionally filtering kwargs. The cure was recognizing the correct boundary: the env-var branch point *is* the boundary, and the two code paths must be mutually exclusive from there.
+
+## Insight
+
+A mutually exclusive branch at the boundary is cleaner than any kwargs-filtering approach: it makes the contract explicit, removes the need for `if api_key: del kwargs["project"]` defensive code, and aligns exactly with the SDK constraint (cannot pass both `api_key` and `project`).
+
+## TDD Discipline
+
+RED first confirmed the current behavior explicitly — the `test_vertex_adc_no_api_key` test passed immediately (existing ADC path already correct), while the two Express tests failed as expected. This validated that the problem was purely the missing Express branch, not a regression in ADC behavior.
+
+**Seed:** Should `VERTEX_API_KEY` be validated for format at startup (e.g., warn if it looks like a service account JSON path instead of an API key string), or is silent acceptance the right ergonomic here?

--- a/feature-requests/FR-226-vertex-express-api-key-auth.md
+++ b/feature-requests/FR-226-vertex-express-api-key-auth.md
@@ -2,7 +2,7 @@
 
 **Priority:** MEDIUM
 **Type:** Feature
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-04-17
 
@@ -54,11 +54,11 @@ The two branches are mutually exclusive and never mix `api_key` with `project`/`
 
 ## Acceptance Criteria
 
-- [ ] When `VERTEX_API_KEY` is set, `_create_vertex_llm` passes `google_api_key=<value>` and does **not** pass `project` or `location`
-- [ ] When `VERTEX_API_KEY` is absent, `_create_vertex_llm` passes `project` + `location` and does **not** pass `google_api_key` (existing ADC behaviour unchanged)
-- [ ] Both branches tested with mocked `ChatGoogleGenerativeAI` constructor; assertions on kwargs passed
-- [ ] `VERTEX_API_KEY` documented in the env-var table in `CLAUDE.md`
-- [ ] No change to public `create_llm` signature
+- [x] When `VERTEX_API_KEY` is set, `_create_vertex_llm` passes `google_api_key=<value>` and does **not** pass `project` or `location`
+- [x] When `VERTEX_API_KEY` is absent, `_create_vertex_llm` passes `project` + `location` and does **not** pass `google_api_key` (existing ADC behaviour unchanged)
+- [x] Both branches tested with mocked `ChatGoogleGenerativeAI` constructor; assertions on kwargs passed
+- [x] `VERTEX_API_KEY` documented in the env-var table in `CLAUDE.md`
+- [x] No change to public `create_llm` signature
 
 ## Alternatives Considered
 

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -215,3 +215,46 @@ class TestCreateLLM:
             create_llm(provider="vertex", model="gemini-2.0-flash")
             kwargs = mock_cls.call_args[1]
             assert kwargs["project"] == "fallback-project"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_api_key(self, monkeypatch):
+        """VERTEX_API_KEY triggers Express mode: google_api_key set, no project/location."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-abc")
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("VERTEXAI_PROJECT", raising=False)
+
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_cls:
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["google_api_key"] == "express-key-abc"
+            assert "project" not in kwargs
+            assert "location" not in kwargs
+            assert kwargs["vertexai"] is True
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_takes_priority_over_project(self, monkeypatch):
+        """When VERTEX_API_KEY set, project/location are omitted even if present."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-xyz")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "should-be-ignored")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_cls:
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["google_api_key"] == "express-key-xyz"
+            assert "project" not in kwargs
+            assert "location" not in kwargs
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_adc_no_api_key(self, monkeypatch):
+        """When VERTEX_API_KEY absent, ADC branch uses project+location, no google_api_key."""
+        monkeypatch.delenv("VERTEX_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI") as mock_cls:
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+            kwargs = mock_cls.call_args[1]
+            assert kwargs["project"] == "my-project"
+            assert kwargs["location"] == "us-central1"
+            assert "google_api_key" not in kwargs

--- a/yamlgraph/utils/llm_factory.py
+++ b/yamlgraph/utils/llm_factory.py
@@ -370,15 +370,24 @@ def _create_vertex_llm(
 ) -> BaseChatModel:
     """Create Google Vertex AI LLM.
 
-    Uses ChatGoogleGenerativeAI with vertexai=True for GCP ADC authentication.
-    Requires GOOGLE_CLOUD_PROJECT (or VERTEXAI_PROJECT) and optionally
-    GOOGLE_CLOUD_LOCATION.
+    Express mode (VERTEX_API_KEY set): passes google_api_key only — no project/location.
+    ADC mode (VERTEX_API_KEY absent): passes project + location via GCP ADC credentials.
+    The two branches are mutually exclusive to satisfy the google-genai SDK constraint.
     """
     from langchain_google_genai import ChatGoogleGenerativeAI
 
+    api_key = os.getenv("VERTEX_API_KEY")
+    if api_key:
+        return ChatGoogleGenerativeAI(
+            model=model,
+            temperature=temperature,
+            vertexai=True,
+            google_api_key=api_key,
+            **kwargs,
+        )
+
     project = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("VERTEXAI_PROJECT")
     location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")
-
     return ChatGoogleGenerativeAI(
         model=model,
         temperature=temperature,


### PR DESCRIPTION
See FR at feature-requests/FR-226-vertex-express-api-key-auth.md

## Summary

Add Vertex AI Express authentication mode: when `VERTEX_API_KEY` is set, `_create_vertex_llm` passes `google_api_key` without `project`/`location`. When absent, keeps the existing ADC path unchanged.

## Changes

- `yamlgraph/utils/llm_factory.py`: mutually exclusive branch in `_create_vertex_llm` (Express vs ADC)
- `tests/unit/test_llm_factory.py`: two new tests covering both branches with mocked constructor
- `CLAUDE.md`: `VERTEX_API_KEY` added to env-var table
- `changelog/unreleased/`: fragment for FR-226
- `docs/diary/`: metacognitive reflection entry