### PR TITLE
fix(llm_factory): FR-227 mask GCP env vars during Vertex Express construction

### DIFF
--- a/changelog/unreleased/fr-227-vertex-express-env-var-masking.md
+++ b/changelog/unreleased/fr-227-vertex-express-env-var-masking.md
@@ -1,0 +1,6 @@
+---
+type: fix
+scope: llm_factory
+req: REQ-YG-010
+---
+- **FR-227 Vertex Express env-var masking**: `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `VERTEXAI_PROJECT` are now temporarily removed from `os.environ` during `ChatGoogleGenerativeAI` construction in Express mode (`VERTEX_API_KEY` set), preventing the google-genai SDK from silently falling back to ADC auth. Env vars are unconditionally restored after construction (including on exception). `_VERTEX_CONSTRUCT_LOCK` and `_masked_env` added to `llm_factory`. (REQ-YG-010)

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -527,6 +527,42 @@ These are E402 suppressions and are acceptable as "glue code" patterns.
 - **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
 - **Penance**: Same as CONF-127.
 
+### CONF-133
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L278)
+- **Code**: ARG001
+- **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
+- **Penance**: Same as CONF-127.
+
+### CONF-134
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L349)
+- **Code**: ARG001
+- **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
+- **Penance**: Same as CONF-127.
+
+### CONF-135
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L374)
+- **Code**: SLF001
+- **Sin**: Accesses `llm_mod._VERTEX_CONSTRUCT_LOCK` directly in test.
+- **Penance**: Test validates the module-level lock exists and is the correct type. No public API to verify this.
+
+### CONF-136
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L392)
+- **Code**: SLF001
+- **Sin**: Calls `llm_mod._masked_env()` directly in test.
+- **Penance**: Tests the private context manager in isolation. No public API wrapping it.
+
+### CONF-137
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L412)
+- **Code**: SLF001
+- **Sin**: Same as CONF-136 — calls `llm_mod._masked_env()` inside `pytest.raises`.
+- **Penance**: Same as CONF-136.
+
+### CONF-138
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L428)
+- **Code**: ARG001
+- **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
+- **Penance**: Same as CONF-127.
+
 ### CONF-208
 - **File**: [scripts/validate_id_registry.py](../scripts/validate_id_registry.py#L28)
 - **Code**: E402

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -491,6 +491,42 @@ These are E402 suppressions and are acceptable as "glue code" patterns.
 - **Sin**: Import `worktree_helpers` functions without using them in Python.
 - **Penance**: Vulture's standard false-positive suppression mechanism. These functions are invoked via `python3 -c` in `scripts/enforce_worktree.sh`, invisible to static analysis. The import makes them visible to Vulture.
 
+### CONF-127
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L275)
+- **Code**: ARG001 (unused function argument)
+- **Sin**: `capture_env(**kwargs)` side-effect helper ignores kwargs; it only captures `os.environ` state.
+- **Penance**: The `**kwargs` signature is required to match `ChatGoogleGenerativeAI`'s constructor call signature. The argument is intentionally unused.
+
+### CONF-128
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L346)
+- **Code**: ARG001
+- **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
+- **Penance**: Same as CONF-127.
+
+### CONF-129
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L371)
+- **Code**: SLF001 (private member accessed)
+- **Sin**: Test accesses `llm_mod._VERTEX_CONSTRUCT_LOCK` to verify it exists and is a `threading.Lock`.
+- **Penance**: The lock is a module-level private attribute deliberately tested as part of FR-227 acceptance criteria. Test access to private implementation details is an accepted pattern here.
+
+### CONF-130
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L389)
+- **Code**: SLF001
+- **Sin**: Test invokes `llm_mod._masked_env(key)` to verify the context manager's remove-and-restore behavior.
+- **Penance**: `_masked_env` is a private implementation helper mandated by FR-227; direct testing of its contract is required.
+
+### CONF-131
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L409)
+- **Code**: SLF001
+- **Sin**: Same as CONF-130 — invokes `llm_mod._masked_env` inside `pytest.raises` to verify restore-on-exception.
+- **Penance**: Same as CONF-130.
+
+### CONF-132
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L425)
+- **Code**: ARG001
+- **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
+- **Penance**: Same as CONF-127.
+
 ### CONF-208
 - **File**: [scripts/validate_id_registry.py](../scripts/validate_id_registry.py#L28)
 - **Code**: E402

--- a/docs/diary/2026-04-17-reflection-fr-227-vertex-express-env-masking.md
+++ b/docs/diary/2026-04-17-reflection-fr-227-vertex-express-env-masking.md
@@ -1,0 +1,43 @@
+# Diary: FR-227 Vertex Express Env Var Masking
+
+**Date:** 2026-04-17
+**FR:** FR-227
+**Type:** Bugfix
+
+## Context
+
+FR-226 added Vertex AI Express mode (API key auth without ADC), but it failed
+when `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` were also set in `.env`.
+
+## Cognitive Process
+
+1. **Symptom**: `DefaultCredentialsError` despite `VERTEX_API_KEY` being set and
+   the Express branch taken in `_create_vertex_llm`.
+2. **Initial hypothesis**: LangChain wrapper ignores `google_api_key` when
+   `GOOGLE_API_KEY` env var exists — partially true.
+3. **Deeper root cause**: The `google-genai` SDK's `BaseApiClient.__init__` reads
+   `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` from `os.environ` directly.
+   Its internal precedence rule: *implicit project/location from env > implicit
+   API key from env* causes it to set `api_key=None` and attempt ADC auth.
+4. **Fix**: Temporarily mask the conflicting env vars during
+   `ChatGoogleGenerativeAI` construction under a threading lock.
+
+## Trap
+
+**downstream_fix** — The symptom (ADC error) manifested inside the SDK, but the
+fix belongs at the yamlgraph boundary where we construct the LLM client. The SDK
+treats environment variables as an implicit input boundary; we must normalize at
+our boundary by controlling what the SDK sees.
+
+## Insight
+
+When a library reads `os.environ` internally with its own precedence logic,
+passing explicit constructor args is insufficient — the env vars themselves must
+be masked. This is a variant of the `normalize at the boundary` principle applied
+to environment-as-input.
+
+## Seed
+
+Could a `provider_env` context manager become a general pattern for all providers
+that read env vars with conflicting precedence (e.g., OpenAI's `OPENAI_API_KEY`
+vs `AZURE_OPENAI_API_KEY`)?

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -173,6 +173,7 @@ class TestCreateLLM:
     @pytest.mark.req("REQ-YG-010")
     def test_create_llm_vertex(self, monkeypatch):
         """Vertex provider creates ChatGoogleGenerativeAI with vertexai=True."""
+        monkeypatch.delenv("VERTEX_API_KEY", raising=False)
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
         monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "europe-west4")
 
@@ -188,6 +189,7 @@ class TestCreateLLM:
     @pytest.mark.req("REQ-YG-010")
     def test_vertex_default_location(self, monkeypatch):
         """Vertex provider defaults location to us-central1 when env var not set."""
+        monkeypatch.delenv("VERTEX_API_KEY", raising=False)
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "test-project")
         monkeypatch.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
 
@@ -207,6 +209,7 @@ class TestCreateLLM:
     @pytest.mark.req("REQ-YG-010")
     def test_vertex_vertexai_project_fallback(self, monkeypatch):
         """Vertex provider falls back to VERTEXAI_PROJECT env var."""
+        monkeypatch.delenv("VERTEX_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
         monkeypatch.setenv("VERTEXAI_PROJECT", "fallback-project")
         monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -258,3 +258,189 @@ class TestCreateLLM:
             assert kwargs["project"] == "my-project"
             assert kwargs["location"] == "us-central1"
             assert "google_api_key" not in kwargs
+
+    # --- FR-227 condemning tests ---
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_masks_gcp_env_vars_during_construction(self, monkeypatch):
+        """FR-227: During Express construction, GOOGLE_CLOUD_PROJECT/LOCATION/VERTEXAI_PROJECT
+        must be absent from os.environ so the SDK cannot fall back to ADC auth."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr227")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-gcp-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+        monkeypatch.setenv("VERTEXAI_PROJECT", "my-vertexai-project")
+
+        env_snapshot: dict[str, str | None] = {}
+
+        def capture_env(**kwargs):  # noqa: ARG001
+            env_snapshot["GOOGLE_CLOUD_PROJECT"] = os.environ.get(
+                "GOOGLE_CLOUD_PROJECT"
+            )
+            env_snapshot["GOOGLE_CLOUD_LOCATION"] = os.environ.get(
+                "GOOGLE_CLOUD_LOCATION"
+            )
+            env_snapshot["VERTEXAI_PROJECT"] = os.environ.get("VERTEXAI_PROJECT")
+            from unittest.mock import MagicMock
+
+            return MagicMock()
+
+        with patch(
+            "langchain_google_genai.ChatGoogleGenerativeAI", side_effect=capture_env
+        ):
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+
+        assert (
+            env_snapshot["GOOGLE_CLOUD_PROJECT"] is None
+        ), "GOOGLE_CLOUD_PROJECT must be absent from os.environ during Express construction"
+        assert (
+            env_snapshot["GOOGLE_CLOUD_LOCATION"] is None
+        ), "GOOGLE_CLOUD_LOCATION must be absent from os.environ during Express construction"
+        assert (
+            env_snapshot["VERTEXAI_PROJECT"] is None
+        ), "VERTEXAI_PROJECT must be absent from os.environ during Express construction"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_restores_env_vars_after_construction(self, monkeypatch):
+        """FR-227: After Express construction, all masked env vars are restored."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr227")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "restore-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-east1")
+        monkeypatch.setenv("VERTEXAI_PROJECT", "restore-vertexai")
+
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI"):
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+
+        assert os.environ.get("GOOGLE_CLOUD_PROJECT") == "restore-project"
+        assert os.environ.get("GOOGLE_CLOUD_LOCATION") == "us-east1"
+        assert os.environ.get("VERTEXAI_PROJECT") == "restore-vertexai"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_restores_env_vars_on_exception(self, monkeypatch):
+        """FR-227: If ChatGoogleGenerativeAI raises, masked env vars are still restored."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr227")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "exc-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+        monkeypatch.setenv("VERTEXAI_PROJECT", "exc-vertexai")
+
+        with (
+            patch(
+                "langchain_google_genai.ChatGoogleGenerativeAI",
+                side_effect=RuntimeError("SDK boom"),
+            ),
+            pytest.raises(RuntimeError, match="SDK boom"),
+        ):
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+
+        assert os.environ.get("GOOGLE_CLOUD_PROJECT") == "exc-project"
+        assert os.environ.get("GOOGLE_CLOUD_LOCATION") == "us-central1"
+        assert os.environ.get("VERTEXAI_PROJECT") == "exc-vertexai"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_vertexai_location_not_masked(self, monkeypatch):
+        """FR-227: VERTEXAI_LOCATION must NOT be removed during Express construction."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr227")
+        monkeypatch.setenv("VERTEXAI_LOCATION", "europe-west4")
+
+        env_snapshot: dict[str, str | None] = {}
+
+        def capture_env(**kwargs):  # noqa: ARG001
+            env_snapshot["VERTEXAI_LOCATION"] = os.environ.get("VERTEXAI_LOCATION")
+            from unittest.mock import MagicMock
+
+            return MagicMock()
+
+        with patch(
+            "langchain_google_genai.ChatGoogleGenerativeAI", side_effect=capture_env
+        ):
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+
+        assert (
+            env_snapshot["VERTEXAI_LOCATION"] == "europe-west4"
+        ), "VERTEXAI_LOCATION must NOT be masked during Express construction"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_construct_lock_exists(self):
+        """FR-227: _VERTEX_CONSTRUCT_LOCK must be a module-level threading.Lock."""
+        import threading
+
+        import yamlgraph.utils.llm_factory as llm_mod
+
+        assert hasattr(
+            llm_mod, "_VERTEX_CONSTRUCT_LOCK"
+        ), "_VERTEX_CONSTRUCT_LOCK must exist as a module-level attribute"
+        assert isinstance(llm_mod._VERTEX_CONSTRUCT_LOCK, type(threading.Lock())), (  # noqa: SLF001
+            "_VERTEX_CONSTRUCT_LOCK must be a threading.Lock instance"
+        )
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_masked_env_context_manager_removes_and_restores(self):
+        """FR-227: _masked_env context manager removes keys and restores them on exit."""
+        import yamlgraph.utils.llm_factory as llm_mod
+
+        assert hasattr(
+            llm_mod, "_masked_env"
+        ), "_masked_env context manager must exist in llm_factory"
+
+        import os as _os
+
+        key = "_FR227_TEST_KEY"
+        _os.environ[key] = "original-value"
+        try:
+            with llm_mod._masked_env(key):  # noqa: SLF001
+                assert key not in _os.environ, "Key must be absent inside _masked_env"
+            assert (
+                _os.environ.get(key) == "original-value"
+            ), "Key must be restored after _masked_env exits"
+        finally:
+            _os.environ.pop(key, None)
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_masked_env_restores_on_exception(self):
+        """FR-227: _masked_env restores env vars even when body raises."""
+        import os as _os
+
+        import yamlgraph.utils.llm_factory as llm_mod
+
+        key = "_FR227_EXC_KEY"
+        _os.environ[key] = "must-be-restored"
+        try:
+            with (
+                pytest.raises(ValueError, match="inner error"),
+                llm_mod._masked_env(key),  # noqa: SLF001
+            ):
+                raise ValueError("inner error")
+            assert _os.environ.get(key) == "must-be-restored"
+        finally:
+            _os.environ.pop(key, None)
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_adc_mode_does_not_mask_env_vars(self, monkeypatch):
+        """FR-227: In ADC mode (no VERTEX_API_KEY), env vars are never removed."""
+        monkeypatch.delenv("VERTEX_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "adc-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+        env_snapshot: dict[str, str | None] = {}
+
+        def capture_env(**kwargs):  # noqa: ARG001
+            env_snapshot["GOOGLE_CLOUD_PROJECT"] = os.environ.get(
+                "GOOGLE_CLOUD_PROJECT"
+            )
+            env_snapshot["GOOGLE_CLOUD_LOCATION"] = os.environ.get(
+                "GOOGLE_CLOUD_LOCATION"
+            )
+            from unittest.mock import MagicMock
+
+            return MagicMock()
+
+        with patch(
+            "langchain_google_genai.ChatGoogleGenerativeAI", side_effect=capture_env
+        ):
+            create_llm(provider="vertex", model="gemini-2.0-flash")
+
+        assert (
+            env_snapshot["GOOGLE_CLOUD_PROJECT"] == "adc-project"
+        ), "ADC mode must not remove GOOGLE_CLOUD_PROJECT"
+        assert (
+            env_snapshot["GOOGLE_CLOUD_LOCATION"] == "us-central1"
+        ), "ADC mode must not remove GOOGLE_CLOUD_LOCATION"

--- a/yamlgraph/utils/llm_factory.py
+++ b/yamlgraph/utils/llm_factory.py
@@ -7,6 +7,7 @@ across different providers (Anthropic, Mistral, OpenAI, Replicate).
 import logging
 import os
 import threading
+from contextlib import contextmanager
 from typing import Literal
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -32,6 +33,19 @@ ProviderType = Literal[
 # Thread-safe cache for LLM instances
 _llm_cache: dict[tuple, BaseChatModel] = {}
 _cache_lock = threading.Lock()
+
+# Serialises Vertex Express construction so env-var masking is race-free
+_VERTEX_CONSTRUCT_LOCK = threading.Lock()
+
+
+@contextmanager
+def _masked_env(*keys: str):  # type: ignore[return]
+    """Temporarily remove *keys* from os.environ, restoring them on exit."""
+    saved = {k: os.environ.pop(k) for k in keys if k in os.environ}
+    try:
+        yield
+    finally:
+        os.environ.update(saved)
 
 
 # --- Provider-specific helper functions ---
@@ -378,13 +392,19 @@ def _create_vertex_llm(
 
     api_key = os.getenv("VERTEX_API_KEY")
     if api_key:
-        return ChatGoogleGenerativeAI(
-            model=model,
-            temperature=temperature,
-            vertexai=True,
-            google_api_key=api_key,
-            **kwargs,
-        )
+        with (
+            _VERTEX_CONSTRUCT_LOCK,
+            _masked_env(
+                "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION", "VERTEXAI_PROJECT"
+            ),
+        ):
+            return ChatGoogleGenerativeAI(
+                model=model,
+                temperature=temperature,
+                vertexai=True,
+                google_api_key=api_key,
+                **kwargs,
+            )
 
     project = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("VERTEXAI_PROJECT")
     location = os.getenv("GOOGLE_CLOUD_LOCATION", "us-central1")


### PR DESCRIPTION
See FR at feature-requests/FR-227-vertex-express-env-var-masking.md

## Summary

When `VERTEX_API_KEY` is set (Express mode), the google-genai SDK falls back to ADC auth if `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are also present in the environment. This fix temporarily masks those env vars during `ChatGoogleGenerativeAI` construction under a threading lock.

## Changes

- Adds `_VERTEX_CONSTRUCT_LOCK` (module-level `threading.Lock`) and `_masked_env` context manager in `llm_factory.py`
- Masks `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `VERTEXAI_PROJECT` during Express-mode LLM construction only
- Adds condemning tests proving the bug and the fix

## Root Cause

`BaseApiClient.__init__` reads `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION` from `os.environ` directly, with internal precedence rule causing it to set `api_key=None` and attempt ADC auth — failing when GCP credentials are absent.

## Tests

Condemning tests in `tests/unit/test_llm_factory.py` prove the fix.