### PR TITLE
fix(vertex): FR-229 mask GOOGLE_API_KEY during Vertex Express construction

### DIFF
--- a/changelog/unreleased/fr-229-vertex-express-mask-google-api-key.md
+++ b/changelog/unreleased/fr-229-vertex-express-mask-google-api-key.md
@@ -1,0 +1,6 @@
+---
+type: fix
+scope: vertex
+req: REQ-YG-010
+---
+- **FR-229 Vertex Express mask GOOGLE_API_KEY**: Added four unit tests condemning the root cause where `GOOGLE_API_KEY` in `os.environ` would override the explicit `google_api_key` kwarg during Vertex Express construction; verifies the fix from commit 557b108 is correctly guarded by `_masked_env`. (REQ-YG-010)

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -563,6 +563,18 @@ These are E402 suppressions and are acceptable as "glue code" patterns.
 - **Sin**: Same as CONF-127 — `capture_env(**kwargs)` ignores kwargs to capture env snapshot.
 - **Penance**: Same as CONF-127.
 
+### CONF-139
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L460)
+- **Code**: ARG001
+- **Sin**: `capture_env(**kwargs)` ignores kwargs to capture env snapshot for FR-229 test.
+- **Penance**: Same as CONF-127 — `ChatGoogleGenerativeAI` is constructed with kwargs; the test only needs to inspect `os.environ`, not the constructor arguments.
+
+### CONF-140
+- **File**: [tests/unit/test_llm_factory.py](../tests/unit/test_llm_factory.py#L514)
+- **Code**: ARG001
+- **Sin**: Same as CONF-139 — `capture_env(**kwargs)` in ADC mode test ignores kwargs.
+- **Penance**: Same as CONF-139.
+
 ### CONF-208
 - **File**: [scripts/validate_id_registry.py](../scripts/validate_id_registry.py#L28)
 - **Code**: E402

--- a/docs/diary/2026-04-17-reflection-fr-229-vertex-express-mask-google-api-key.md
+++ b/docs/diary/2026-04-17-reflection-fr-229-vertex-express-mask-google-api-key.md
@@ -1,0 +1,26 @@
+# Diary: FR-229 — Vertex Express Mask GOOGLE_API_KEY
+
+**Date:** 2026-04-17
+**Branch:** feat/fr-229-vertex-express-mask-google-api-key
+
+## Cognitive Process
+
+The task was immediately clear: production fix already present (commit 557b108); only unit tests were missing. The discipline demanded here was **test-after-fix** — the most cognitively easy but trap-prone form of TDD, because the absence of a RED phase makes verification feel trivially performative.
+
+I confirmed the production code had `"GOOGLE_API_KEY"` in `_masked_env(...)` before writing a single test. This is correct: the FR explicitly stated the fix was present. The tests' role is to condemn the root cause so it cannot regress.
+
+## Traps Encountered
+
+**`patch` target mismatch risk:** The FR-229 specification proposed patching `yamlgraph.utils.llm_factory.ChatGoogleGenerativeAI`, but the actual import is a *local* import inside the function body. The correct patch target is `langchain_google_genai.ChatGoogleGenerativeAI`, matching the FR-227 pattern. Blindly copying the FR spec would have produced tests that pass vacuously (the mock is never invoked, `captured` remains empty, assertion on missing key silently passes as True).
+
+The cure: **read the existing tests before writing new ones** (Commandment 4 — honor existing patterns).
+
+## Insight
+
+A test spec in a Feature Request is a design artifact, not executable code. It describes intent, not implementation. Every test in a spec must be verified against the actual module structure before it is committed. The `patch` target is an implementation detail that the spec author may not know correctly.
+
+## Heuristic
+
+> When a FR provides test code, treat it as pseudocode. Verify every `patch` target against the actual import path before trusting it.
+
+**Seed:** Could the `_masked_env` context manager be generalized to accept a dict of `{key: replacement_value}` instead of only removing keys? This would allow temporarily substituting env vars with test values rather than blanking them — useful for multi-provider isolation scenarios.

--- a/feature-requests/FR-229-vertex-express-mask-google-api-key.md
+++ b/feature-requests/FR-229-vertex-express-mask-google-api-key.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Bug
-**Status:** Approved — implement unit tests
+**Status:** Implemented
 **Effort:** 0.5 days
 **Requested:** 2026-04-17
 
@@ -134,15 +134,15 @@ def test_vertex_adc_does_not_mask_google_api_key(self, monkeypatch):
 
 - [x] `"GOOGLE_API_KEY"` is included in `_masked_env(...)` in the Express branch of
   `_create_vertex_llm` *(already done — commit 557b108)*
-- [ ] Unit test: `GOOGLE_API_KEY` absent from `os.environ` at construction time when both
+- [x] Unit test: `GOOGLE_API_KEY` absent from `os.environ` at construction time when both
   `VERTEX_API_KEY` and `GOOGLE_API_KEY` are set
-- [ ] Unit test: `GOOGLE_API_KEY` restored to original value after successful Express
+- [x] Unit test: `GOOGLE_API_KEY` restored to original value after successful Express
   construction
-- [ ] Unit test: `GOOGLE_API_KEY` restored after Express construction raises an exception
-- [ ] Unit test: ADC mode (no `VERTEX_API_KEY`) does not remove `GOOGLE_API_KEY` from
+- [x] Unit test: `GOOGLE_API_KEY` restored after Express construction raises an exception
+- [x] Unit test: ADC mode (no `VERTEX_API_KEY`) does not remove `GOOGLE_API_KEY` from
   `os.environ` during construction
-- [ ] All FR-227 tests remain green
-- [ ] `pytest tests/unit/test_llm_factory.py -q --no-cov` passes
+- [x] All FR-227 tests remain green
+- [x] `pytest tests/unit/test_llm_factory.py -q --no-cov` passes
 
 ## Alternatives Considered
 

--- a/tests/unit/test_llm_factory.py
+++ b/tests/unit/test_llm_factory.py
@@ -447,3 +447,81 @@ class TestCreateLLM:
         assert (
             env_snapshot["GOOGLE_CLOUD_LOCATION"] == "us-central1"
         ), "ADC mode must not remove GOOGLE_CLOUD_LOCATION"
+
+    # --- FR-229 condemning tests ---
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_masks_google_api_key_during_construction(self, monkeypatch):
+        """FR-229: GOOGLE_API_KEY must be absent from os.environ during Express construction."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr229")
+        monkeypatch.setenv("GOOGLE_API_KEY", "gemini-dev-key")
+        captured: dict[str, bool] = {}
+
+        def capture_env(**kwargs):  # noqa: ARG001
+            captured["GOOGLE_API_KEY_present"] = "GOOGLE_API_KEY" in os.environ
+            from unittest.mock import MagicMock
+
+            return MagicMock()
+
+        with patch(
+            "langchain_google_genai.ChatGoogleGenerativeAI", side_effect=capture_env
+        ):
+            create_llm(provider="vertex")
+
+        assert not captured[
+            "GOOGLE_API_KEY_present"
+        ], "GOOGLE_API_KEY must be absent from os.environ during Express construction"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_restores_google_api_key_after_construction(
+        self, monkeypatch
+    ):
+        """FR-229: GOOGLE_API_KEY must be restored after Express construction."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr229")
+        monkeypatch.setenv("GOOGLE_API_KEY", "gemini-dev-key")
+
+        with patch("langchain_google_genai.ChatGoogleGenerativeAI"):
+            create_llm(provider="vertex")
+
+        assert os.environ.get("GOOGLE_API_KEY") == "gemini-dev-key"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_express_restores_google_api_key_on_exception(self, monkeypatch):
+        """FR-229: GOOGLE_API_KEY must be restored even when construction raises."""
+        monkeypatch.setenv("VERTEX_API_KEY", "express-key-fr229")
+        monkeypatch.setenv("GOOGLE_API_KEY", "gemini-dev-key")
+
+        with (
+            patch(
+                "langchain_google_genai.ChatGoogleGenerativeAI",
+                side_effect=RuntimeError("construction failed"),
+            ),
+            pytest.raises(RuntimeError, match="construction failed"),
+        ):
+            create_llm(provider="vertex")
+
+        assert os.environ.get("GOOGLE_API_KEY") == "gemini-dev-key"
+
+    @pytest.mark.req("REQ-YG-010")
+    def test_vertex_adc_does_not_mask_google_api_key(self, monkeypatch):
+        """FR-229: ADC mode (no VERTEX_API_KEY) must not remove GOOGLE_API_KEY."""
+        monkeypatch.delenv("VERTEX_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "gemini-dev-key")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+        monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+        captured: dict[str, bool] = {}
+
+        def capture_env(**kwargs):  # noqa: ARG001
+            captured["GOOGLE_API_KEY_present"] = "GOOGLE_API_KEY" in os.environ
+            from unittest.mock import MagicMock
+
+            return MagicMock()
+
+        with patch(
+            "langchain_google_genai.ChatGoogleGenerativeAI", side_effect=capture_env
+        ):
+            create_llm(provider="vertex")
+
+        assert captured[
+            "GOOGLE_API_KEY_present"
+        ], "GOOGLE_API_KEY must NOT be masked in ADC mode"


### PR DESCRIPTION
See FR at feature-requests/FR-229-vertex-express-mask-google-api-key.md

## Summary

Adds unit tests that condemn the root cause of silent `401 UNAUTHENTICATED` failures when both `VERTEX_API_KEY` and `GOOGLE_API_KEY` are present in the environment. The production fix (masking `GOOGLE_API_KEY` in `_masked_env(...)`) was already present since commit 557b108 (FR-227); this FR adds the missing test coverage.

## Changes

- **tests**: 4 new `@pytest.mark.req("REQ-YG-010")` tests in `TestVertexProvider`:
  - `test_vertex_express_masks_google_api_key_during_construction` — asserts `GOOGLE_API_KEY` absent at construction time
  - `test_vertex_express_restores_google_api_key_after_construction` — asserts key restored after success
  - `test_vertex_express_restores_google_api_key_on_exception` — asserts key restored after exception
  - `test_vertex_adc_does_not_mask_google_api_key` — asserts ADC mode does not remove `GOOGLE_API_KEY`
- **changelog**: fragment `changelog/unreleased/fr-229-vertex-express-mask-google-api-key.md`
- **diary**: reflection in `docs/diary/`
- **FR**: status updated to Implemented

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>