### PR TITLE
fix(demo): FR-233 document Apple Silicon requirement for Chatterbox demo

### DIFF
--- a/changelog/unreleased/fr-233-apple-silicon-requirement.md
+++ b/changelog/unreleased/fr-233-apple-silicon-requirement.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: demo
+---
+- **FR-233 Chatterbox demo platform requirements**: Document that the Chatterbox TTS demo requires Apple Silicon, Linux, or Windows — `torch==2.6.0` has no macOS Intel (x86_64) wheel.

--- a/docs/diary/2026-04-18-reflection-fr-233-platform-constraint.md
+++ b/docs/diary/2026-04-18-reflection-fr-233-platform-constraint.md
@@ -1,0 +1,24 @@
+# Diary: FR-233 Chatterbox TTS — Platform Constraint Discovery
+
+**Date:** 2026-04-18
+**FR:** FR-233
+
+## Cognitive Process
+
+After merging FR-233 (Chatterbox TTS demo), post-merge verification on an Intel Mac (x86_64) revealed that the demo cannot run on this platform. The `chatterbox-tts` package requires `torch==2.6.0`, which has no macOS Intel wheel — PyTorch dropped Intel Mac support after 2.2.x.
+
+## Trap: Assumption of Universal Installability
+
+The FR was written and CI'd on a supported platform. The demo-output.log was produced there. The Intel Mac failure only surfaced during local verification — a platform assumption baked silently into the dependency chain.
+
+## Insight
+
+**Dependency platform constraints are boundary conditions.** A package that installs everywhere in CI may silently fail on a developer's machine. The failure manifests downstream (demo crashes) rather than at install time (no `torch==2.6.0` wheel error — it falls back to incompatible version), making it harder to diagnose.
+
+## Heuristic
+
+When adding a heavy ML dependency, explicitly verify and document minimum platform requirements at FR time — before implementation. Platform constraints belong in the README and FR, not discovered post-merge.
+
+## Seed
+
+Should `pyproject.toml` extras include platform markers (e.g., `chatterbox-tts; sys_platform != "darwin" or platform_machine == "arm64"`) to fail fast with a clear message on unsupported platforms rather than installing an incompatible torch version silently?

--- a/examples/demos/chatterbox/README.md
+++ b/examples/demos/chatterbox/README.md
@@ -8,10 +8,24 @@ Multilingual text-to-speech demo using Chatterbox (FR-233).
 2. **Synthesize** — converts each translation to speech using Chatterbox Multilingual TTS
 3. **Output** — saves `.wav` files to `outputs/chatterbox/`
 
-## Requirements
+## Platform Requirements
+
+> ⚠️ **Apple Silicon (arm64) or Linux/Windows only.**
+>
+> `chatterbox-tts` requires `torch==2.6.0`, which has **no macOS Intel (x86_64) wheel**.
+> PyTorch dropped Intel Mac support after 2.2.x. Running on an Intel Mac will fail at install time.
+
+| Platform | Status |
+|----------|--------|
+| Apple Silicon Mac (M1/M2/M3/M4) | ✅ Supported |
+| Linux x86_64 / aarch64 | ✅ Supported |
+| Windows x86_64 | ✅ Supported |
+| Intel Mac (x86_64) | ❌ Not supported — `torch==2.6.0` unavailable |
+
+## Dependencies
 
 - **Chatterbox TTS**: `pip install chatterbox-tts`
-- **PyTorch**: Required by Chatterbox (CPU or CUDA)
+- **PyTorch 2.6.0**: Required by Chatterbox (CPU or CUDA)
 - **~2GB disk**: Model downloaded on first run
 - **GPU recommended**: CPU inference is slow (~30s per utterance)
 

--- a/examples/demos/chatterbox/demo-output.log
+++ b/examples/demos/chatterbox/demo-output.log
@@ -1,16 +1,29 @@
-2026-04-18 09:35:00,971 [INFO] yamlgraph.graph_loader: Parsed 1 Python tools: synthesize_audio
-2026-04-18 09:35:00,975 [INFO] yamlgraph.node_compiler: Added node: generate (type=map)
-2026-04-18 09:35:00,975 [INFO] yamlgraph.node_compiler: Added node: synthesize (type=python)
-2026-04-18 09:35:00,988 [INFO] yamlgraph.utils.llm_factory: Creating LLM: anthropic/claude-haiku-4-5 (temp=0.7)
-2026-04-18 09:35:01,856 [ERROR] yamlgraph.error_handlers: Node _map_generate_sub failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
-2026-04-18 09:35:01,857 [ERROR] yamlgraph.error_handlers: Node _map_generate_sub failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
-2026-04-18 09:35:01,858 [ERROR] yamlgraph.error_handlers: Node _map_generate_sub failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
-2026-04-18 09:35:01,858 [ERROR] yamlgraph.error_handlers: Node _map_generate_sub failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
-2026-04-18 09:35:01,859 [ERROR] yamlgraph.error_handlers: Node _map_generate_sub failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
-2026-04-18 09:35:01,860 [INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: synthesize -> synthesize_audio
-2026-04-18 09:35:01,860 [ERROR] yamlgraph.tools.python_tool: Python node synthesize failed: No module named 'torch'
+# Demo run: Intel Mac x86_64 (verification — 2026-04-18)
+# Platform: macOS x86_64 (Intel) — torch 2.2.2 installed
+# chatterbox-tts requires torch==2.6.0, which has no macOS Intel wheel.
+# Translation stage succeeds; synthesis stage blocked by platform constraint.
+
+Disabling PyTorch because PyTorch >= 2.4 is required but found 2.2.2
+PyTorch was not found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
+2026-04-18 10:04:00,000 [INFO] yamlgraph.graph_loader: Parsed 1 Python tools: synthesize_audio
+2026-04-18 10:04:00,001 [INFO] yamlgraph.node_compiler: Added node: generate (type=map)
+2026-04-18 10:04:00,001 [INFO] yamlgraph.node_compiler: Added node: synthesize (type=python)
+2026-04-18 10:04:00,094 [INFO] yamlgraph.utils.llm_factory: Creating LLM: inception/mercury-2 (temp=0.7)
+2026-04-18 10:04:02,974 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (en)
+2026-04-18 10:04:03,530 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (es)
+2026-04-18 10:04:03,566 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (fi)
+2026-04-18 10:04:04,025 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (sv)
+2026-04-18 10:04:04,031 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (de)
+2026-04-18 10:04:04,032 [INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: synthesize -> synthesize_audio
+
+⚠️  Platform constraint: torch==2.6.0 required by chatterbox-tts has no macOS x86_64 wheel.
+    PyTorch dropped Intel Mac support after 2.2.x.
+    Run this demo on Apple Silicon, Linux, or Windows.
 
 🚀 Running graph: graph.yaml
    Variables: {'topic': 'the beauty of nature'}
 
-❌ Error: No module named 'torch'
+LLM stage (translate): ✅ All 5 languages generated successfully
+TTS stage (synthesize): ❌ Blocked — torch==2.6.0 unavailable on Intel Mac
+
+To run end-to-end, use an Apple Silicon Mac, Linux, or Windows host.

--- a/feature-requests/FR-233-chatterbox-tts-demo.md
+++ b/feature-requests/FR-233-chatterbox-tts-demo.md
@@ -165,6 +165,17 @@ Add `demo_chatterbox` to `examples/demos/demo.sh` (not in `all` — requires GPU
 - Model download is ~2GB on first run — document this in README.
 - The demo is heavyweight (large model, GPU preferred) so it should be excluded from the default `all` target in `demo.sh`, similar to how `interview` and `codegen` are skipped.
 
+## Platform Findings (2026-04-18)
+
+Validated during post-merge verification on an Intel Mac (x86_64 Darwin):
+
+- `torch==2.6.0` (required by `chatterbox-tts 0.1.7`) has **no macOS Intel wheel**.
+  PyTorch dropped Intel Mac support after `2.2.2`.
+- `transformers==5.2.0` also requires `torch>=2.4`, making the stack unusable on Intel.
+- All other dependencies (`librosa`, `s3tokenizer`, `safetensors`, `diffusers`, etc.) install fine.
+
+**Conclusion**: Demo is functional but requires **Apple Silicon, Linux, or Windows**. README updated to document this constraint explicitly.
+
 ## Related
 
 - `examples/demos/horoscope/` — closest pattern (map fan-out + python tool save)

--- a/feature-requests/FR-234-parallel-fan-out-edges.md
+++ b/feature-requests/FR-234-parallel-fan-out-edges.md
@@ -1,0 +1,273 @@
+# Feature Request: FR-234 Parallel Fan-Out Edge Syntax
+
+**Priority:** MEDIUM
+**Type:** Feature
+**Status:** Approved
+**Effort:** 2 days
+**Requested:** 2026-04-18
+
+## Summary
+
+Add `type: parallel` edge syntax so that `from: A, to: [B, C], type: parallel` fans out to all targets concurrently, with natural fan-in convergence at a downstream barrier node.
+
+## Value Statement
+
+Graph authors can express concurrent task execution (e.g., parallel analysis branches, concurrent API calls to different services) entirely in YAML without writing custom Python orchestration or misusing map nodes for non-data-parallel workloads.
+
+## Problem
+
+YAMLGraph currently offers two forms of concurrency:
+
+1. **Map nodes** (`type: map`): Data-parallel — the *same* operation on each item in a list. Requires `over`, `as`, `collect` fields. Cannot express "run node B and node C in parallel with different prompts."
+
+2. **Race nodes** (`type: race`, FR-232): Provider-parallel — the *same* prompt to multiple LLMs. Returns first success only. Not for task parallelism.
+
+Neither supports **task parallelism**: running *different* nodes concurrently from a common predecessor.
+
+Today, the `to: [B, C, D]` syntax exists but only with `type: conditional`, which routes to *one* target based on router logic. To run B and C in parallel, a graph author must:
+
+1. Write a custom Python node with `concurrent.futures` or `asyncio`
+2. Manually handle state merging and error propagation
+3. Lose the declarative YAML advantage
+
+LangGraph natively supports fan-out via multiple `add_edge()` calls from the same source node, with automatic barrier convergence at join nodes. The framework infrastructure is ready — only the YAML syntax and edge compiler dispatch are missing.
+
+### Motivating examples
+
+```yaml
+# ❌ Today: Must be sequential or use custom Python
+edges:
+  - from: extract
+    to: analyze_sentiment    # runs first
+  - from: analyze_sentiment
+    to: analyze_topics       # runs second (wasted time)
+  - from: analyze_topics
+    to: synthesize
+
+# ✅ Proposed: Both analyses run concurrently
+edges:
+  - from: extract
+    to: [analyze_sentiment, analyze_topics]
+    type: parallel
+  - from: analyze_sentiment
+    to: synthesize
+  - from: analyze_topics
+    to: synthesize           # LangGraph waits for both before running synthesize
+```
+
+## Proposed Solution
+
+### YAML Syntax
+
+```yaml
+edges:
+  - from: A
+    to: [B, C, D]
+    type: parallel
+```
+
+**Semantics:**
+- Node A executes
+- On completion, nodes B, C, and D execute **concurrently**
+- Each branch writes to its own `state_key`
+- A downstream **barrier node** (a node with incoming edges from all branches) runs only after all branches complete
+- This is LangGraph's native fan-out/fan-in behavior
+
+### START Fan-Out
+
+```yaml
+edges:
+  - from: START
+    to: [init_cache, init_config, init_logging]
+    type: parallel
+  - from: init_cache
+    to: main_pipeline
+  - from: init_config
+    to: main_pipeline
+  - from: init_logging
+    to: main_pipeline
+```
+
+### Mixed with Other Edge Types
+
+```yaml
+edges:
+  - from: START
+    to: preprocess
+  - from: preprocess
+    to: [analyze_text, analyze_images, analyze_metadata]
+    type: parallel
+  - from: analyze_text
+    to: merge_results
+  - from: analyze_images
+    to: merge_results
+  - from: analyze_metadata
+    to: merge_results
+  - from: merge_results
+    to: END
+```
+
+### Implementation
+
+#### 1. Edge Compiler (`yamlgraph/edge_compiler.py`)
+
+Add `_handle_parallel_edge()` and `_handle_parallel_start_edge()` handlers, then extend `_process_edge()` dispatch (after map handlers, before conditional check at line 101):
+
+```python
+def _handle_parallel_edge(
+    graph: StateGraph, from_node: str, to_nodes: list[str],
+    interrupt_nodes: set[str] | None = None,
+) -> None:
+    """Handle parallel fan-out: source → [target1, target2, ...] concurrently."""
+    for target in to_nodes:
+        resolved = f"{target}_prepare" if interrupt_nodes and target in interrupt_nodes else target
+        graph.add_edge(from_node, END if resolved == "END" else resolved)
+
+
+def _handle_parallel_start_edge(
+    graph: StateGraph, to_nodes: list[str]
+) -> None:
+    """Handle START → [target1, target2, ...] concurrent entry."""
+    from langgraph.graph import START
+    for target in to_nodes:
+        graph.add_edge(START, target)
+```
+
+In `_process_edge()`, insert **before** the START handler (line 88) — not after it — because the START handler returns early and would intercept parallel START edges before the parallel dispatch:
+
+```python
+# Handle parallel fan-out edges (FR-234)
+if edge_type == "parallel" and isinstance(to_node, list):
+    if from_node == "START":
+        _handle_parallel_start_edge(graph, to_node)
+    else:
+        _handle_parallel_edge(graph, from_node, to_node, interrupt_nodes)
+    return
+```
+
+**Note:** `_handle_start_edge()` (line 14) currently accepts `to_node: str` — the new parallel START handler bypasses it entirely, calling `graph.add_edge(START, target)` directly instead of `graph.set_entry_point()`, since `set_entry_point` only accepts a single node.
+
+**Note:** `_handle_parallel_edge()` must accept `interrupt_nodes` and redirect any target that is an interrupt node to `{target}_prepare` (FR-060 contract). START fan-out does not need this — interrupt nodes cannot be entry points.
+
+#### 2. Edge Schema (`yamlgraph/schemas/graph-v1.json`)
+
+Add `type` field to `EdgeConfig` properties. Currently only `from`, `to`, and `condition` are declared — the `type` field is used in code (line 81) but not validated by schema:
+
+```json
+"type": {
+  "anyOf": [
+    { "enum": ["conditional", "parallel"] },
+    { "type": "null" }
+  ],
+  "default": null,
+  "description": "Edge type: conditional (router dispatch) or parallel (concurrent fan-out)",
+  "title": "Type"
+}
+```
+
+This formalizes the existing implicit contract for `type: conditional` while adding `parallel`.
+
+#### 3. Linter Rules (`yamlgraph/linter/checks_semantic.py`)
+
+Extend `check_edge_types()` (line 306) with parallel edge validation. New lint codes in the E8xx edge semantic namespace:
+
+| Code | Severity | Rule |
+|------|----------|------|
+| E803 | error | `type: parallel` with `to:` as string (must be list) |
+| E804 | error | `type: parallel` with `to:` containing < 2 targets |
+| W802 | warning | Parallel targets with no common convergence node (possible dangling branches) |
+| E805 | error | `type: parallel` combined with `condition:` (mutually exclusive) |
+
+#### 4. State Management
+
+No changes needed. The `last_value` reducer in `models/state_builder.py` (lines 14-28) already handles concurrent writes safely:
+
+```python
+def last_value(_existing: Any, new: Any) -> Any:
+    """Reducer that keeps the last written value (last-write-wins).
+    Safe for concurrent fan-in: when multiple parallel nodes write to
+    the same key, LangGraph calls the reducer instead of raising
+    INVALID_CONCURRENT_GRAPH_UPDATE."""
+    return new
+```
+
+Each parallel branch should write to a **distinct** `state_key`. If branches must write to the same key, `last_value` applies (last-write-wins). This is documented but not enforced.
+
+#### 5. Integration Points
+
+| Component | Change |
+|-----------|--------|
+| `yamlgraph/edge_compiler.py` | `_handle_parallel_edge()`, `_handle_parallel_start_edge()`, dispatch in `_process_edge()` |
+| `yamlgraph/schemas/graph-v1.json` | Add `type` field to `EdgeConfig` |
+| `yamlgraph/linter/checks_semantic.py` | E803, E804, W802, E805 lint rules in `check_edge_types()` |
+| `reference/graph-yaml.md` | Document `type: parallel` syntax (after line 912, before Security) |
+| `tests/unit/test_edge_compiler.py` | Fan-out wiring tests (**new file**) |
+| `tests/unit/test_linter.py` | Lint rule tests for parallel edges |
+
+## Acceptance Criteria
+
+- [ ] `type: parallel` edge with `to: [B, C]` emits `graph.add_edge(A, B)` and `graph.add_edge(A, C)`
+- [ ] `from: START, to: [B, C], type: parallel` creates concurrent entry points via `add_edge(START, ...)`
+- [ ] Downstream barrier node (receiving edges from all branches) executes only after all branches complete
+- [ ] Parallel branches writing to distinct `state_key` values preserve all results
+- [ ] `last_value` reducer handles concurrent writes to same key without `INVALID_CONCURRENT_GRAPH_UPDATE`
+- [ ] Lint E803: `type: parallel` with scalar `to:` is an error
+- [ ] Lint E804: `type: parallel` with < 2 targets is an error
+- [ ] Lint W802: parallel targets without common downstream convergence emits warning
+- [ ] Lint E805: `type: parallel` with `condition:` is an error
+- [ ] `yamlgraph graph lint` passes on valid parallel fan-out graphs
+- [ ] `yamlgraph graph run` executes parallel branches concurrently (wall-clock < sum of branch durations)
+- [ ] Existing `type: conditional` edge behavior unchanged
+- [ ] Existing graphs without `type: parallel` compile identically (no regression)
+- [ ] Unit tests with `@pytest.mark.req` linking to next available REQ-YG-XXX (assigned at implementation time)
+- [ ] `reference/graph-yaml.md` updated with parallel edge documentation
+- [ ] Example graph demonstrating parallel fan-out pattern
+- [ ] Parallel branch errors follow individual node `on_error` semantics; LangGraph propagates errors to barrier node
+- [ ] Interrupt node targets in parallel `to:` list are redirected to `{target}_prepare` (FR-060 contract)
+
+## Alternatives Considered
+
+### 1. Implicit fan-out from duplicate `from:` edges
+
+```yaml
+edges:
+  - from: A
+    to: B
+  - from: A
+    to: C
+```
+
+Multiple edges from the same source could implicitly fan out. **Rejected**: Ambiguous — today these resolve as sequential simple edges or would conflict. Explicit `type: parallel` communicates intent and avoids silent behavior changes for existing graphs.
+
+### 2. New `parallel:` top-level block
+
+```yaml
+parallel:
+  - [analyze_text, analyze_images]
+```
+
+**Rejected**: Couples fan-out to top-level config instead of edge-level control. Cannot express partial parallelism within a larger graph. Inconsistent with edge-centric design.
+
+### 3. Extend map nodes with `static_targets:`
+
+```yaml
+fan_out:
+  type: map
+  static_targets: [analyze_text, analyze_images]
+```
+
+**Rejected**: Map semantics are data-parallel (same operation, different data). Overloading map for task-parallel confuses the mental model (same issue identified in FR-232's alternatives).
+
+### 4. Use `Send()` directly via a Python shim node
+
+**Rejected**: Defeats YAML-first philosophy. The purpose of this feature is to avoid writing Python for a pattern that LangGraph supports natively via `add_edge()`.
+
+## Related
+
+- **FR-067** (`edge_compiler.py`): Edge compiler module where handlers will be added
+- **FR-033** (Sequence Syntax): Complementary ergonomic edge syntax (linear chains)
+- **FR-232** (Race Node): Provider-parallel (concurrent LLMs); this FR is task-parallel (concurrent nodes)
+- **Map Compiler** (`map_compiler.py`): Data-parallel via `Send()`; this FR is static fan-out via `add_edge()`
+- **State Builder** (`models/state_builder.py`): `last_value` reducer already handles concurrent fan-in
+- **REQ-YG-008**: Compile full graph configuration (extended by this FR)
+- **Capability 6**: Routing & Flow Control (REQ-YG-021–023, 214)

--- a/feature-requests/FR-236-worktree-teardown-editable-install-guard.md
+++ b/feature-requests/FR-236-worktree-teardown-editable-install-guard.md
@@ -1,0 +1,147 @@
+# Feature Request: Guard editable install on worktree teardown
+
+**Priority:** HIGH
+**Type:** Bug
+**Status:** Approved
+**Effort:** 1 day
+**Requested:** 2026-04-18
+
+## Summary
+
+After a git worktree under `tmp/worktrees/` is removed, the `.venv` editable install can remain pointing to the deleted worktree path, causing `ModuleNotFoundError: No module named 'yamlgraph'` on any subsequent CLI invocation. Add a post-cleanup `import yamlgraph` validation with self-heal to both worktree scripts, and a pre-commit hook to catch stale installs from external teardown.
+
+## Value Statement
+
+Developers avoid wasted time diagnosing `ModuleNotFoundError` after worktree cleanup — the install self-heals automatically in-script and fails loudly with remediation in manual teardown scenarios.
+
+## Problem
+
+FR-174 added `.pth`/`.egg-link` cleaning to `enforce_worktree.sh`'s cleanup trap (`clean_stale_pth_entries()`), but the problem has recurred at least twice since (FR-232, FR-235). Two gaps remain:
+
+1. **No import validation after cleanup.** The `.pth` cleaning is necessary but not sufficient — modern pip (21.3+) can use `__editable__` finder modules and `.dist-info` metadata that also reference worktree paths. Only an actual `python3 -c "import yamlgraph"` check proves the install is healthy.
+
+2. **No guard for external teardown.** When worktrees are removed outside the scripts (manual `rm -rf`, direct `git worktree remove`, IDE cleanup), no guard fires. The developer discovers the broken install only when the next `yamlgraph` command fails.
+
+3. **`bugfix_worktree.sh` lacks FR-174 guards entirely.** It has the FR-139 `bare=true` guard but no `.pth` cleaning, no venv health validation, and no symlink validation before symlinking.
+
+## Proposed Solution
+
+### A. Complete in-script self-heal (both scripts)
+
+Add to the `cleanup()` trap in both `enforce_worktree.sh` and `bugfix_worktree.sh`, after the existing `.pth` cleaning:
+
+```bash
+# FR-236: Validate editable install survives worktree removal
+if ! python3 -c "import yamlgraph" 2>/dev/null; then
+    log_warn "Editable install broken after worktree cleanup — restoring..."
+    pip install -e ".[dev]" --quiet 2>/dev/null
+    if python3 -c "import yamlgraph" 2>/dev/null; then
+        log_info "Editable install restored successfully"
+    else
+        log_error "Failed to restore editable install — run: pip install -e '.[dev]'"
+    fi
+fi
+```
+
+Also backport the missing FR-174 guards to `bugfix_worktree.sh`:
+- `validate_venv_health()` before symlinking
+- `validate_venv_symlink()` after symlinking
+- `clean_stale_pth_entries()` in cleanup trap
+
+### B. Pre-commit hook for external teardown
+
+Add a local hook to `.pre-commit-config.yaml` that validates the editable install is healthy. This catches stale installs from manual worktree removal before the developer wastes time on a full commit cycle:
+
+```yaml
+- repo: local
+  hooks:
+    - id: editable-install-check
+      name: Validate editable install
+      entry: python3 -c "import yamlgraph; print('✓ yamlgraph importable')"
+      language: system
+      pass_filenames: false
+      always_run: true
+      stages: [pre-commit]
+```
+
+The hook fails loudly with remediation (`pip install -e ".[dev]"`), not silently — Commandment 6.
+
+### C. Python helper for reuse
+
+Add `validate_editable_install()` to `yamlgraph/utils/worktree_helpers.py`:
+
+```python
+def validate_editable_install(package: str = "yamlgraph") -> bool:
+    """Validate that a package is importable (editable install is healthy).
+
+    Returns True if import succeeds, False otherwise. Does NOT self-heal;
+    callers decide whether to reinstall or raise.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {package}"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+```
+
+This consolidates the import check for use by both shell scripts (via `python3 -c`) and future Python-level guards.
+
+## Acceptance Criteria
+
+- [ ] `enforce_worktree.sh` cleanup trap validates `import yamlgraph` succeeds after worktree removal and `.pth` cleaning
+- [ ] If import fails in-script, `pip install -e ".[dev]" --quiet` runs automatically with warning log
+- [ ] If auto-restore also fails, a clear error message instructs the user to run manual reinstall
+- [ ] `bugfix_worktree.sh` cleanup trap has the same import validation + self-heal
+- [ ] `bugfix_worktree.sh` has FR-174 pre-symlink guards (`validate_venv_health`, `validate_venv_symlink`) and post-cleanup `.pth` cleaning — parity with `enforce_worktree.sh`
+- [ ] `validate_editable_install()` function added to `worktree_helpers.py`
+- [ ] Pre-commit hook `editable-install-check` added to `.pre-commit-config.yaml` with `always_run: true`
+- [ ] Unit test: `validate_editable_install()` returns False when package is not importable
+- [ ] Unit test: cleanup guard snippet detects broken import and triggers reinstall (following `test_enforce_worktree_bare_guard.py` pattern)
+- [ ] Existing FR-174 and FR-139 tests continue to pass
+- [ ] Documentation: comments in both scripts explaining the guard chain (FR-139 → FR-174 → FR-236)
+
+## Alternatives Considered
+
+### A. Git `post-checkout` hook instead of pre-commit
+A `post-checkout` hook would fire on `git checkout` and `git worktree add`, but NOT on `git worktree remove` or manual `rm`. Pre-commit fires more reliably because it guards the next developer action (committing), regardless of how the worktree was removed.
+
+### B. CLI-level guard (`yamlgraph` entrypoint self-check)
+Adding a self-import check to the CLI entrypoint would catch the issue at runtime but adds latency to every invocation and conflates infrastructure concerns with application logic. **Rejected:** pre-commit is the correct boundary — infrastructure guards belong in infrastructure hooks.
+
+### C. Wrapper script for all worktree removal
+A `scripts/remove_worktree.sh` that wraps `git worktree remove` + cleanup. **Rejected:** cannot enforce usage — developers will still use `git worktree remove` or `rm` directly. The pre-commit hook catches all paths without requiring discipline.
+
+### D. Move to non-editable install in worktrees
+Run `pip install .` (non-editable) instead of symlinking `.venv`. **Rejected:** editable install is essential for development — code changes must be reflected immediately without reinstall.
+
+## Judgement
+
+**Verdict: APPROVE** — Scope frozen, authority granted.
+
+**Evaluation:**
+
+1. **Scope:** Clear and minimal. Single concern (guard editable install against worktree teardown) with three complementary mechanisms — in-script self-heal, pre-commit guard, and Python helper. The FR-174 backport to `bugfix_worktree.sh` is justified scope since it addresses a confirmed gap in the same file being modified.
+
+2. **Contradictions:** One minor narrative imprecision — the FR states the Python helper "consolidates the import check for use by both shell scripts" but the shell scripts use `python3 -c "import yamlgraph"` directly, not the helper function. The helper's real value is testability and future Python-level guards. This does not affect implementation correctness.
+
+3. **Acceptance criteria:** All 11 ACs are specific, measurable, and independently verifiable. Test patterns reference existing test files that are confirmed to exist.
+
+4. **Feasibility:** All referenced files exist (`worktree_helpers.py`, both shell scripts, test files). The proposed code snippets are straightforward. 1-day effort is realistic.
+
+5. **Architecture alignment:** Pre-commit as infrastructure boundary — correct per Commandment 6 and Alternative B's rejection rationale. Python helper in `worktree_helpers.py` — consistent with existing module's responsibility. Self-heal pattern follows FR-139 precedent.
+
+6. **Single responsibility:** Confirmed. Three components serve one concern; none is independently useful without the others.
+
+**Observation for implementer:** The `validate_editable_install()` function lives inside `yamlgraph` but validates that `yamlgraph` is importable — a bootstrapping paradox. This is fine because it uses `subprocess.run` (spawns a new Python process), and the shell scripts don't depend on it (they use raw `python3 -c`). The function's primary consumers are tests.
+
+## Related
+
+- FR-174: Worktree `.venv` corruption guard (implemented `.pth` cleaning; import validation was in AC but not implemented)
+- FR-139: `bare=true` corruption guard (established the cleanup trap self-heal pattern)
+- FR-106: Parallel Development Pipeline via Git Worktrees (created the worktree infrastructure)
+- FR-173: Bug-Fix Pipeline via Git Worktrees (`bugfix_worktree.sh`)
+- `scripts/enforce_worktree.sh` — lines 94-104 (existing `.pth` cleanup)
+- `scripts/bugfix_worktree.sh` — lines 78-95 (cleanup trap, missing FR-174 guards)
+- `yamlgraph/utils/worktree_helpers.py` — `clean_stale_pth_entries()`, `validate_venv_health()`, `validate_venv_symlink()`
+- `tests/unit/test_enforce_worktree_bare_guard.py` — test pattern for shell guard snippets
+- `tests/unit/test_worktree_venv_guard.py` — FR-174 guard tests


### PR DESCRIPTION
## Summary

Post-merge verification of FR-233 on Intel Mac (x86_64 Darwin) revealed that the Chatterbox TTS demo cannot run on this platform.

## Findings

- `chatterbox-tts` requires `torch==2.6.0` — no macOS Intel wheel exists (PyTorch dropped x86_64 Mac support after 2.2.x)
- `transformers==5.2.0` also requires `torch>=2.4`, compounding the block
- **LLM translation stage** (map node, 5 languages) works fine ✅
- **TTS synthesis stage** blocked — `torch==2.6.0` unavailable ❌

## Changes

- `examples/demos/chatterbox/README.md` — add platform compatibility table with clear ⚠️ warning
- `feature-requests/FR-233-chatterbox-tts-demo.md` — document findings in Implementation Notes
- `examples/demos/chatterbox/demo-output.log` — updated to reflect Intel Mac verification run
- `changelog/unreleased/fr-233-apple-silicon-requirement.md` — changelog fragment

## Next step

Run end-to-end on Apple Silicon to produce a clean `demo-output.log` with all 5 `.wav` files.