### PR TITLE
fix(worktree): FR-236 clean stale direct_url.json in dist-info after teardown

### DIFF
--- a/changelog/unreleased/fr-236-worktree-teardown-editable-install-guard.md
+++ b/changelog/unreleased/fr-236-worktree-teardown-editable-install-guard.md
@@ -1,0 +1,6 @@
+---
+type: fix
+scope: worktree
+req: REQ-YG-156
+---
+- **FR-236 Worktree Teardown Editable Install Guard**: `clean_stale_pth_entries()` now also removes stale `direct_url.json` inside `*.dist-info/` directories that reference a deleted worktree, preventing pip from reporting phantom editable installs. (REQ-YG-156)

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -137,25 +137,25 @@ Framework suppressions require elevated scrutiny. These live in `yamlgraph/`.
 - **Penance**: Used for YAML prompt template variable extraction, not HTML rendering. Autoescape would corrupt prompt text by escaping `<`, `>`, `&` characters. No web output is generated from this code path.
 
 ### CONF-035
-- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L94)
+- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L95)
 - **Code**: S607
 - **Sin**: `["git", "diff", "--name-only"]` uses partial executable path.
 - **Penance**: `git` is expected on PATH in all development environments. Using absolute path would break portability across OS/distro.
 
 ### CONF-036
-- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L105)
+- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L106)
 - **Code**: S607
 - **Sin**: `["git", "diff", "--cached", "--name-only"]` uses partial executable path.
 - **Penance**: Same as CONF-035.
 
 ### CONF-037
-- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L93)
+- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L94)
 - **Code**: S603
 - **Sin**: `subprocess.run()` called with list argument flagged as untrusted input.
 - **Penance**: Command list is hardcoded `["git", "diff", "--name-only"]` — no user input reaches arguments. Used to detect unstaged changes before worktree operations.
 
 ### CONF-038
-- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L104)
+- **File**: [yamlgraph/utils/worktree_helpers.py](../yamlgraph/utils/worktree_helpers.py#L105)
 - **Code**: S603
 - **Sin**: `subprocess.run()` called with list argument flagged as untrusted input.
 - **Penance**: Same as CONF-037 — hardcoded `["git", "diff", "--cached", "--name-only"]` for staged change detection.

--- a/docs/diary/2026-04-18-reflection-fr-236-worktree-teardown.md
+++ b/docs/diary/2026-04-18-reflection-fr-236-worktree-teardown.md
@@ -1,0 +1,24 @@
+# Diary: FR-236 Worktree Teardown Editable Install Guard
+
+**Date:** 2026-04-18
+**FR:** FR-236 (worktree teardown)
+
+## Cognitive Process
+
+A subtle failure mode surfaced post-teardown: pip trusts `direct_url.json` in `.dist-info/` without verifying the referenced path still exists. After removing a worktree, the stale file causes `ModuleNotFoundError` on subsequent installs, a symptom far removed from its root cause.
+
+## Trap: Downstream Symptom Fix
+
+The immediate symptom is `ModuleNotFoundError`. The naive fix would be to re-run `pip install -e .` unconditionally on each worktree use. The correct fix is to remove the stale `direct_url.json` at teardown — normalizing at the boundary where the invariant is violated.
+
+## Insight
+
+**File system state left by teardown is a boundary condition.** When a worktree is removed, any metadata files referencing it must also be cleaned up. Package managers (pip) trust their own metadata absolutely; stale metadata is worse than missing metadata.
+
+## Heuristic
+
+Treat post-teardown filesystem state as an external input boundary. Any file that encodes a path to a removed resource is stale by definition and must be cleaned at teardown, not lazily discovered at next use.
+
+## Seed
+
+Should the worktree helper expose a `verify_install()` function that checks `direct_url.json` references are still valid, usable as a pre-flight check before any command that depends on the installed package?

--- a/tests/unit/test_worktree_editable_install_guard.py
+++ b/tests/unit/test_worktree_editable_install_guard.py
@@ -1,0 +1,140 @@
+"""Condemning tests for FR-236: worktree teardown editable install guard.
+
+Bug: clean_stale_pth_entries() removes .pth and .egg-link files referencing a
+deleted worktree, but does NOT clean direct_url.json inside *.dist-info/
+directories.  Modern pip (21.3+) editable installs create these files with the
+worktree path, leaving stale metadata after teardown.
+
+After cleanup:
+  - pip show <package> still reports the deleted worktree as Location
+  - pip install -e . from the main repo may skip reinstall because dist-info
+    metadata already exists
+
+These tests MUST FAIL on the unmodified codebase (proving the bug), then PASS
+after the fix.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _make_venv_with_site_packages(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a minimal .venv with lib/python3.XX/site-packages."""
+    venv = tmp_path / ".venv"
+    site_packages = venv / "lib" / "python3.11" / "site-packages"
+    site_packages.mkdir(parents=True)
+    return venv, site_packages
+
+
+@pytest.mark.req("REQ-YG-156")
+class TestCleanStaleDistInfoDirectUrl:
+    """clean_stale_pth_entries must also clean direct_url.json in dist-info."""
+
+    def test_direct_url_json_referencing_worktree_is_cleaned(
+        self, tmp_path: Path
+    ) -> None:
+        """direct_url.json inside dist-info referencing the worktree must be
+        removed (or the entire dist-info directory purged) after cleanup."""
+        from yamlgraph.utils.worktree_helpers import clean_stale_pth_entries
+
+        venv, site_packages = _make_venv_with_site_packages(tmp_path)
+        worktree_dir = "/tmp/worktrees/feat/fr-236-test"
+
+        # Modern pip editable install creates __editable__.pth AND dist-info
+        pth = site_packages / "__editable__.yamlgraph-0.4.68.pth"
+        pth.write_text(f"{worktree_dir}/src\n")
+
+        dist_info = site_packages / "yamlgraph-0.4.68.dist-info"
+        dist_info.mkdir()
+        direct_url = dist_info / "direct_url.json"
+        direct_url.write_text(
+            json.dumps(
+                {
+                    "url": f"file://{worktree_dir}",
+                    "dir_info": {"editable": True},
+                }
+            )
+        )
+
+        removed = clean_stale_pth_entries(venv, worktree_dir)
+
+        # .pth should be cleaned (existing behavior)
+        assert not pth.exists(), ".pth file should have been removed"
+        assert any(p.name.endswith(".pth") for p in removed)
+
+        # BUG: direct_url.json is NOT cleaned by the current implementation
+        # This assertion MUST FAIL on the unmodified codebase.
+        assert not direct_url.exists(), (
+            "direct_url.json still references deleted worktree — "
+            "stale dist-info metadata survives cleanup"
+        )
+
+    def test_dist_info_with_worktree_url_reported_in_removed_list(
+        self, tmp_path: Path
+    ) -> None:
+        """The returned list must include dist-info artifacts that were cleaned."""
+        from yamlgraph.utils.worktree_helpers import clean_stale_pth_entries
+
+        venv, site_packages = _make_venv_with_site_packages(tmp_path)
+        worktree_dir = "/tmp/worktrees/feat/fr-236-test"
+
+        dist_info = site_packages / "yamlgraph-0.4.68.dist-info"
+        dist_info.mkdir()
+        direct_url = dist_info / "direct_url.json"
+        direct_url.write_text(
+            json.dumps(
+                {
+                    "url": f"file://{worktree_dir}",
+                    "dir_info": {"editable": True},
+                }
+            )
+        )
+
+        removed = clean_stale_pth_entries(venv, worktree_dir)
+
+        # BUG: current implementation returns empty list — it doesn't touch
+        # dist-info at all. This MUST FAIL on unmodified code.
+        assert len(removed) > 0, (
+            "clean_stale_pth_entries returned empty list despite stale "
+            "direct_url.json referencing the worktree"
+        )
+
+    def test_unrelated_dist_info_preserved(self, tmp_path: Path) -> None:
+        """dist-info directories for packages NOT pointing at the worktree
+        must be left untouched."""
+        from yamlgraph.utils.worktree_helpers import clean_stale_pth_entries
+
+        venv, site_packages = _make_venv_with_site_packages(tmp_path)
+        worktree_dir = "/tmp/worktrees/feat/fr-236-test"
+
+        # Unrelated package dist-info
+        other_dist = site_packages / "requests-2.31.0.dist-info"
+        other_dist.mkdir()
+        other_url = other_dist / "direct_url.json"
+        other_url.write_text(
+            json.dumps({"url": "https://pypi.org/packages/requests-2.31.0.tar.gz"})
+        )
+
+        # Stale worktree dist-info
+        stale_dist = site_packages / "yamlgraph-0.4.68.dist-info"
+        stale_dist.mkdir()
+        stale_url = stale_dist / "direct_url.json"
+        stale_url.write_text(
+            json.dumps(
+                {
+                    "url": f"file://{worktree_dir}",
+                    "dir_info": {"editable": True},
+                }
+            )
+        )
+
+        clean_stale_pth_entries(venv, worktree_dir)
+
+        # Unrelated package MUST survive
+        assert other_url.exists(), "Unrelated dist-info must not be touched"
+        # Stale package MUST be cleaned — this MUST FAIL on unmodified code
+        assert (
+            not stale_url.exists()
+        ), "Stale direct_url.json referencing worktree survives cleanup"

--- a/yamlgraph/utils/worktree_helpers.py
+++ b/yamlgraph/utils/worktree_helpers.py
@@ -9,6 +9,7 @@ Provides utility functions for git worktree orchestration:
 - clean_stale_pth_entries: Remove dangling .pth/.egg-link files (FR-174)
 """
 
+import json
 import logging
 import os
 import subprocess
@@ -168,11 +169,12 @@ def validate_venv_symlink(symlink_path: Path, target_path: Path) -> None:
 
 
 def clean_stale_pth_entries(venv_path: Path, worktree_dir: str) -> list[Path]:
-    """Remove .pth and .egg-link files that reference a worktree directory.
+    """Remove .pth, .egg-link, and direct_url.json files referencing a worktree.
 
     After a worktree is removed, editable installs (pip install -e .) leave
     dangling .pth/.egg-link files in site-packages pointing to the deleted
-    worktree. This corrupts the main repo's import resolution.
+    worktree. Modern pip (21.3+) also writes direct_url.json inside
+    *.dist-info/ with the worktree path. Both corrupt import resolution.
 
     Args:
         venv_path: Path to the .venv directory.
@@ -206,5 +208,25 @@ def clean_stale_pth_entries(venv_path: Path, worktree_dir: str) -> list[Path]:
                     )
                     pth_file.unlink()
                     removed.append(pth_file)
+
+        # Modern pip (21.3+) editable installs also write direct_url.json
+        # inside *.dist-info/ with a file:// URL pointing at the source tree.
+        for dist_info in site_packages.glob("*.dist-info"):
+            direct_url = dist_info / "direct_url.json"
+            if not direct_url.is_file():
+                continue
+            try:
+                data = json.loads(direct_url.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            url = data.get("url", "")
+            if worktree_dir in url:
+                logger.warning(
+                    "Removing stale %s referencing worktree %s",
+                    direct_url,
+                    worktree_dir,
+                )
+                direct_url.unlink()
+                removed.append(direct_url)
 
     return removed


### PR DESCRIPTION
## FR-236: Worktree Teardown Editable Install Guard

### Problem
After `git worktree remove`, stale `direct_url.json` files in `.dist-info/` cause `pip install -e .` to believe the package is already installed from a now-deleted worktree path. Subsequent imports fail with `ModuleNotFoundError`.

### Root Cause
Worktree teardown cleaned the worktree directory but left behind `direct_url.json` pointing to the removed path. pip's editable-install check trusts this file without verifying the path exists.

### Fix
After worktree removal, scan `.dist-info/direct_url.json` for references to the removed worktree path and delete the stale file, forcing pip to re-evaluate on next install.

### Tests
- Condemning test proves stale `direct_url.json` is detected and cleaned
- See `tests/unit/test_worktree_editable_install_guard.py`

### FR
See `feature-requests/FR-236-worktree-teardown-editable-install-guard.md` (branch-local)
