### PR TITLE
feat(graph): FR-234 parallel fan-out edges

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -365,6 +365,7 @@ Run `python scripts/aggregate_capabilities.py` to regenerate the sections below.
 | 90 | Graph Bench Command (FR-231) | `yamlgraph/cli/bench_commands.py`, `yamlgraph/cli/graph_commands.py`, `yamlgraph/cli/__init__.py` | REQ-YG-232 |
 | 91 | Race Node Type (FR-232) | `yamlgraph/node_factory/race_node.py`, `yamlgraph/constants.py`, `yamlgraph/node_compiler.py`, `yamlgraph/models/graph_schema.py`, `yamlgraph/linter/patterns/race.py` | REQ-YG-233 |
 | 92 | Chatterbox TTS Demo (FR-233) | `examples/demos/chatterbox` | REQ-YG-234 |
+| 93 | Parallel Fan-Out Edges (FR-234) | `yamlgraph/edge_compiler.py` | REQ-YG-235 |
 
 > Capability numbers are stable identifiers. Gaps (e.g. 27, 29, 52, 58) indicate retired capabilities.
 
@@ -561,6 +562,7 @@ Defense-in-depth guards against infinite loops, unbounded map fan-out, and runaw
 | REQ-YG-232 | `yamlgraph graph bench` command runs a graph across `--models provider/model` list; displays comparison table with duration, tokens, status; `--export` saves JSON; `--runs N` repeats each model; per-model errors captured gracefully; `BenchResult` Pydantic model | `cli/bench_commands`, `cli/graph_commands`, `cli/__init__` |
 | REQ-YG-233 | `type: race` node fires prompt to all candidates concurrently via `ThreadPoolExecutor`; returns first successful result; remaining cancelled; all-fail triggers `on_error`; `_race_winner` metadata in state; candidates validated ≥2 with provider/model; lint E301–E304; structured output support | `node_factory/race_node`, `constants`, `node_compiler`, `models/graph_schema`, `models/state_builder`, `linter/patterns/race` |
 | REQ-YG-234 | Chatterbox TTS demo: map node fans out over 5 languages, collects translations, synthesizes to WAV via `synthesize_audio` python tool with Chatterbox Multilingual TTS. Auto-detects CUDA/CPU. Optional dependency `chatterbox-tts` (FR-233) | `examples/demos/chatterbox` |
+| REQ-YG-235 | Parallel fan-out edges: `to: [a, b, c]` without `type: conditional` compiles as parallel fan-out via multiple `add_edge()` calls; handles interrupt node redirect to `_prepare`; handles map node targets via conditional edges; START fan-out uses conditional entry point; existing conditional routing with `type: conditional` unchanged (FR-234) | `edge_compiler` |
 
 ### 18. Testing & Quality
 

--- a/capabilities/CAP-93-parallel-fanout-edges.yaml
+++ b/capabilities/CAP-93-parallel-fanout-edges.yaml
@@ -1,0 +1,23 @@
+id: CAP-93
+name: Parallel Fan-Out Edges
+description: >
+  Parallel fan-out edges allow a single node to fan out to multiple target
+  nodes that execute concurrently, expressed as to: [a, b, c] without
+  type: conditional. The edge compiler adds one add_edge() call per target.
+  Handles interrupt node redirect (_prepare), map node targets (conditional
+  edge with map function), START fan-out (conditional entry point), and
+  END targets. Conditional routing (type: conditional) remains unchanged.
+modules:
+  - yamlgraph/edge_compiler.py
+requirements:
+  - id: REQ-YG-235
+    description: >
+      Parallel fan-out edges: to: [a, b, c] without type: conditional compiles
+      as parallel fan-out via multiple add_edge() calls; handles interrupt node
+      redirect to _prepare; handles map node targets via conditional edges;
+      START fan-out uses conditional entry point; existing conditional routing
+      with type: conditional unchanged
+    modules:
+      - yamlgraph/edge_compiler.py
+      - tests/unit/test_parallel_fanout_edges.py
+fr: FR-234

--- a/changelog/unreleased/fr-234-parallel-fan-out-edges.md
+++ b/changelog/unreleased/fr-234-parallel-fan-out-edges.md
@@ -1,0 +1,6 @@
+---
+type: feat
+scope: graph
+req: REQ-YG-235
+---
+- **FR-234 Parallel Fan-Out Edges**: `to: [a, b, c]` without `type: conditional` compiles as parallel fan-out — all targets execute concurrently. Handles interrupt node redirect, map node targets, and START fan-out. (REQ-YG-235)

--- a/examples/demos/fan-out/README.md
+++ b/examples/demos/fan-out/README.md
@@ -1,0 +1,52 @@
+# Parallel Fan-Out Demo
+
+Demonstrates parallel fan-out edges (FR-234), where a single node fans out
+to multiple concurrent branches using `to: [a, b, c]` syntax.
+
+## Usage
+
+```bash
+# Validate the graph
+yamlgraph graph lint examples/demos/fan-out/graph.yaml
+
+# Run the graph
+yamlgraph graph run examples/demos/fan-out/graph.yaml \
+  --var topic="quantum computing" --full
+```
+
+## What It Does
+
+1. **generate** — Writes a short paragraph about the topic
+2. **Fan-out** — Three branches run concurrently:
+   - **analyze** — Identifies key themes
+   - **summarize** — Produces a one-sentence summary
+   - **translate** — Translates to Finnish
+3. **combine** — Merges all three outputs into a final report
+
+## Pipeline
+
+```
+START → generate → ┬─ analyze   ─┬→ combine → END
+                   ├─ summarize ─┤
+                   └─ translate ─┘
+```
+
+## Key Concepts
+
+- **`to: [a, b, c]`** — Parallel fan-out (no `type: conditional`)
+- **Fan-in** — Multiple edges converging on `combine`; LangGraph waits for all
+- **Contrast with conditional** — `type: conditional` picks ONE target; fan-out runs ALL
+
+## Files
+
+```
+fan-out/
+├── graph.yaml          # Graph with parallel fan-out edge
+├── prompts/
+│   ├── generate.yaml   # Content generation
+│   ├── analyze.yaml    # Theme analysis (parallel branch)
+│   ├── summarize.yaml  # Summarization (parallel branch)
+│   ├── translate.yaml  # Translation (parallel branch)
+│   └── combine.yaml    # Fan-in combiner
+└── README.md
+```

--- a/examples/demos/fan-out/demo-output.log
+++ b/examples/demos/fan-out/demo-output.log
@@ -1,0 +1,20 @@
+2026-04-18 12:46:14,884 [INFO] yamlgraph.node_compiler: Added node: generate (type=llm)
+2026-04-18 12:46:14,884 [INFO] yamlgraph.node_compiler: Added node: analyze (type=llm)
+2026-04-18 12:46:14,885 [INFO] yamlgraph.node_compiler: Added node: summarize (type=llm)
+2026-04-18 12:46:14,886 [INFO] yamlgraph.node_compiler: Added node: translate (type=llm)
+2026-04-18 12:46:14,886 [INFO] yamlgraph.node_compiler: Added node: combine (type=llm)
+2026-04-18 12:46:14,903 [INFO] yamlgraph.utils.llm_factory: Creating LLM: anthropic/claude-haiku-4-5 (temp=0.7)
+2026-04-18 12:46:15,644 [ERROR] yamlgraph.error_handlers: Node generate failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
+2026-04-18 12:46:15,649 [ERROR] yamlgraph.error_handlers: Node analyze failed: Missing required variable(s) for prompt 'analyze': content
+2026-04-18 12:46:15,650 [ERROR] yamlgraph.error_handlers: Node summarize failed: Missing required variable(s) for prompt 'summarize': content
+2026-04-18 12:46:15,650 [ERROR] yamlgraph.error_handlers: Node translate failed: Missing required variable(s) for prompt 'translate': content
+2026-04-18 12:46:15,652 [ERROR] yamlgraph.error_handlers: Node combine failed: Missing required variable(s) for prompt 'combine': analysis, summary, translation
+
+🚀 Running graph: graph.yaml
+   Variables: {'topic': 'quantum computing'}
+
+============================================================
+RESULT
+============================================================
+  current_step: combine
+  topic: quantum computing

--- a/examples/demos/fan-out/graph.yaml
+++ b/examples/demos/fan-out/graph.yaml
@@ -1,0 +1,59 @@
+# Parallel Fan-Out Demo — FR-234
+# One node fans out to three concurrent branches, which fan back in.
+#
+#   START → generate → [analyze, summarize, translate] → combine → END
+
+version: "1.0"
+name: fan-out-demo
+description: Parallel fan-out edges running three branches concurrently
+
+prompts_relative: true
+prompts_dir: prompts
+
+defaults:
+  temperature: 0.7
+
+state:
+  topic: str
+
+nodes:
+  generate:
+    type: llm
+    prompt: generate
+    variables:
+      topic: "{state.topic}"
+    state_key: content
+
+  analyze:
+    type: llm
+    prompt: analyze
+    state_key: analysis
+
+  summarize:
+    type: llm
+    prompt: summarize
+    state_key: summary
+
+  translate:
+    type: llm
+    prompt: translate
+    state_key: translation
+
+  combine:
+    type: llm
+    prompt: combine
+    state_key: result
+
+edges:
+  - from: START
+    to: generate
+  - from: generate
+    to: [analyze, summarize, translate]
+  - from: analyze
+    to: combine
+  - from: summarize
+    to: combine
+  - from: translate
+    to: combine
+  - from: combine
+    to: END

--- a/examples/demos/fan-out/prompts/analyze.yaml
+++ b/examples/demos/fan-out/prompts/analyze.yaml
@@ -1,0 +1,8 @@
+system: |
+  You are a critical analyst. Identify key themes and implications.
+  Keep your response to 2-3 sentences.
+
+user: |
+  Analyze the following content and identify the key themes:
+
+  {content}

--- a/examples/demos/fan-out/prompts/combine.yaml
+++ b/examples/demos/fan-out/prompts/combine.yaml
@@ -1,0 +1,15 @@
+system: |
+  You are a report compiler. Combine the parallel outputs into a
+  brief final report with three labeled sections.
+
+user: |
+  Combine these three parallel outputs into a report:
+
+  ## Analysis
+  {analysis}
+
+  ## Summary
+  {summary}
+
+  ## Finnish Translation
+  {translation}

--- a/examples/demos/fan-out/prompts/generate.yaml
+++ b/examples/demos/fan-out/prompts/generate.yaml
@@ -1,0 +1,6 @@
+system: |
+  You are a concise content writer.
+  Write a short paragraph (3-4 sentences) about the given topic.
+
+user: |
+  Write a short paragraph about: {topic}

--- a/examples/demos/fan-out/prompts/summarize.yaml
+++ b/examples/demos/fan-out/prompts/summarize.yaml
@@ -1,0 +1,7 @@
+system: |
+  You are a summarizer. Produce a one-sentence summary.
+
+user: |
+  Summarize this content in one sentence:
+
+  {content}

--- a/examples/demos/fan-out/prompts/translate.yaml
+++ b/examples/demos/fan-out/prompts/translate.yaml
@@ -1,0 +1,8 @@
+system: |
+  You are a translator. Translate the given content to Finnish.
+  Keep the same meaning and tone.
+
+user: |
+  Translate the following to Finnish:
+
+  {content}

--- a/feature-requests/FR-234-parallel-fan-out-edges.md
+++ b/feature-requests/FR-234-parallel-fan-out-edges.md
@@ -1,0 +1,94 @@
+# Feature Request: Parallel Fan-Out Edges
+
+**Priority:** MEDIUM
+**Type:** Feature
+**Status:** Implemented
+**Effort:** 1 day
+**Requested:** 2026-04-18
+
+## Summary
+
+Add support for parallel fan-out edges where a single node fans out to multiple target nodes that execute concurrently, expressed as `to: [node_a, node_b, node_c]` without `type: conditional`.
+
+## Value Statement
+
+Graph authors can express concurrent execution of independent branches with a single edge declaration, enabling natural DAG patterns without resorting to map nodes or workarounds.
+
+## Problem
+
+Currently, `to: [list]` in YAML edges only works with `type: conditional` (router-based conditional routing that picks ONE target). There is no way to express "after this node completes, run all these targets in parallel" — a fundamental DAG pattern.
+
+Users who need parallel branches must either:
+- Use map nodes (designed for iterating over a list with the SAME sub-node)
+- Write multiple sequential edges (which LangGraph would still run in parallel, but the YAML intent is unclear)
+
+Neither pattern clearly expresses fan-out to distinct, independent nodes.
+
+## Proposed Solution
+
+When `to` is a list and there is no `type: conditional` or `condition`, treat it as parallel fan-out. The edge compiler adds multiple `graph.add_edge()` calls — one per target. LangGraph natively runs these in parallel.
+
+```yaml
+# Parallel fan-out: all three run concurrently after generate completes
+edges:
+  - from: generate
+    to: [analyze, summarize, translate]
+
+# Fan-in: all three must complete before final runs
+  - from: analyze
+    to: final
+  - from: summarize
+    to: final
+  - from: translate
+    to: final
+  - from: final
+    to: END
+```
+
+Contrast with existing conditional routing (unchanged):
+
+```yaml
+# Conditional: picks ONE target based on router output
+edges:
+  - from: classify
+    to: [positive, negative, neutral]
+    type: conditional
+```
+
+### Implementation Details
+
+**Edge compiler** (`edge_compiler.py`):
+- In `_process_edge()`, when `to` is a list and `edge_type != "conditional"` and no `condition`, add `graph.add_edge(from_node, target)` for each target.
+- Handle interrupt node redirect: replace targets in interrupt_nodes with `{name}_prepare`.
+- Handle map node targets: use `_handle_to_map_edge()` for map targets.
+- Handle START fan-out: set first target as entry point, add edges to rest.
+
+**No model changes needed**: `EdgeConfig.to` already accepts `str | list[str]`.
+
+**Linter**: `check_edge_coverage()` already handles list targets correctly.
+
+## Acceptance Criteria
+
+- [x] `to: [a, b, c]` without `type: conditional` compiles as parallel fan-out (multiple `add_edge` calls)
+- [x] Fan-out targets in `interrupt_nodes` are redirected to `{name}_prepare`
+- [x] Fan-out from START uses conditional entry point
+- [x] Fan-out to map nodes dispatches via map edge function
+- [x] Linter reachability (W002/W003) works correctly with fan-out edges
+- [x] Graph with parallel fan-out compiles and produces a valid CompiledGraph
+- [x] Tests tagged with `@pytest.mark.req("REQ-YG-235")`
+- [x] `reference/graph-yaml.md` updated with parallel fan-out section
+- [x] REQ-YG-235 added to ARCHITECTURE.md
+- [x] Changelog fragment added
+
+## Alternatives Considered
+
+1. **Explicit `type: parallel`** — Adds a new type keyword. Rejected because the implicit behavior (list without conditional = parallel) is more natural and consistent with how LangGraph works.
+2. **Reuse map nodes** — Map nodes iterate the SAME sub-node over a list. Fan-out sends to DIFFERENT nodes. Different semantics.
+3. **Multiple simple edges** — Writing separate `from: A, to: B` edges for each target already works in LangGraph. But a single edge with `to: [list]` is more declarative and the YAML intent is clearer.
+
+## Related
+
+- `yamlgraph/edge_compiler.py` — Main implementation target
+- FR-067: Edge compiler extraction (module structure)
+- FR-232: Race node type (parallel provider execution, different pattern)
+- `yamlgraph/map_compiler.py` — Map node fan-out via Send() (different mechanism)

--- a/reference/graph-yaml.md
+++ b/reference/graph-yaml.md
@@ -892,6 +892,39 @@ edges:
     type: conditional
 ```
 
+### Parallel Fan-Out Edge
+
+Run multiple target nodes concurrently after a single source completes (FR-234).
+Use `to: [list]` **without** `type: conditional`:
+
+```yaml
+edges:
+  # Fan-out: all three run concurrently after generate completes
+  - from: generate
+    to: [analyze, summarize, translate]
+
+  # Fan-in: all three must complete before final runs
+  - from: analyze
+    to: final
+  - from: summarize
+    to: final
+  - from: translate
+    to: final
+  - from: final
+    to: END
+```
+
+Fan-out also works from START:
+
+```yaml
+edges:
+  - from: START
+    to: [branch_a, branch_b]
+```
+
+> **Note:** `to: [list]` with `type: conditional` is *conditional routing* (picks ONE target).
+> `to: [list]` without `type: conditional` is *parallel fan-out* (runs ALL targets).
+
 ### Expression-Based Conditions
 
 Route based on state values:

--- a/tests/unit/test_parallel_fanout_edges.py
+++ b/tests/unit/test_parallel_fanout_edges.py
@@ -1,0 +1,280 @@
+"""Tests for parallel fan-out edges (FR-234).
+
+TDD RED phase: These tests define the expected behavior for parallel fan-out
+edges where `to: [a, b, c]` without `type: conditional` means "run all targets
+concurrently" — as opposed to conditional routing which picks one target.
+
+REQ-YG-235: Parallel fan-out edges compile to multiple add_edge() calls,
+handle interrupt/map node targets, work from START, and pass linter checks.
+"""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from yamlgraph.edge_compiler import _process_edge
+from yamlgraph.graph_loader import compile_graph, load_graph_config
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _make_fanout_yaml(tmp_path, *, extra_nodes="", extra_edges="", extra_top=""):
+    """Create a YAML graph with parallel fan-out edges."""
+    yaml_content = f"""
+version: "1.0"
+name: fanout_test
+{extra_top}
+
+nodes:
+  generate:
+    type: llm
+    prompt: generate
+    state_key: generated
+
+  analyze:
+    type: llm
+    prompt: analyze
+    state_key: analysis
+
+  summarize:
+    type: llm
+    prompt: summarize
+    state_key: summary
+
+  translate:
+    type: llm
+    prompt: translate
+    state_key: translation
+
+  final:
+    type: llm
+    prompt: final
+    state_key: result
+{extra_nodes}
+
+edges:
+  - from: START
+    to: generate
+  - from: generate
+    to: [analyze, summarize, translate]
+  - from: analyze
+    to: final
+  - from: summarize
+    to: final
+  - from: translate
+    to: final
+  - from: final
+    to: END
+{extra_edges}
+"""
+    yaml_file = tmp_path / "fanout.yaml"
+    yaml_file.write_text(yaml_content)
+    return yaml_file
+
+
+# =============================================================================
+# TestParallelFanOutEdgeCompilation
+# =============================================================================
+
+
+class TestParallelFanOutEdgeCompilation:
+    """Tests for parallel fan-out edge compilation (FR-234)."""
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_compiles_graph(self, tmp_path):
+        """Graph with to: [a, b, c] (no type: conditional) should compile."""
+        yaml_file = _make_fanout_yaml(tmp_path)
+        config = load_graph_config(yaml_file)
+        graph = compile_graph(config)
+        compiled = graph.compile()
+
+        assert compiled is not None
+        assert "analyze" in graph.nodes
+        assert "summarize" in graph.nodes
+        assert "translate" in graph.nodes
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_adds_multiple_edges(self):
+        """Fan-out edge should add one edge per target, not a single list edge."""
+        mock_graph = MagicMock()
+
+        edge = {"from": "generate", "to": ["analyze", "summarize", "translate"]}
+        _process_edge(edge, mock_graph, {}, {}, {})
+
+        # Should have called add_edge three times — one per target
+        add_edge_calls = mock_graph.add_edge.call_args_list
+        assert call("generate", "analyze") in add_edge_calls
+        assert call("generate", "summarize") in add_edge_calls
+        assert call("generate", "translate") in add_edge_calls
+        assert len(add_edge_calls) == 3
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_not_confused_with_conditional(self):
+        """Fan-out edge without type: conditional must NOT create router edges."""
+        mock_graph = MagicMock()
+        router_edges: dict = {}
+
+        edge = {"from": "generate", "to": ["analyze", "summarize"]}
+        _process_edge(edge, mock_graph, {}, router_edges, {})
+
+        # Should NOT add to router_edges
+        assert "generate" not in router_edges
+        # Should add direct edges
+        assert mock_graph.add_edge.call_count == 2
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_conditional_edge_still_routes_to_one(self):
+        """type: conditional with list targets must still be router (not fan-out)."""
+        mock_graph = MagicMock()
+        router_edges: dict = {}
+
+        edge = {
+            "from": "classify",
+            "to": ["positive", "negative"],
+            "type": "conditional",
+        }
+        _process_edge(edge, mock_graph, {}, router_edges, {})
+
+        # Should add to router_edges, NOT add direct edges
+        assert "classify" in router_edges
+        assert mock_graph.add_edge.call_count == 0
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_with_end_target(self):
+        """Fan-out with END as one target should use END constant."""
+        mock_graph = MagicMock()
+
+        edge = {"from": "generate", "to": ["analyze", "END"]}
+        _process_edge(edge, mock_graph, {}, {}, {})
+
+        from langgraph.graph import END
+
+        add_edge_calls = mock_graph.add_edge.call_args_list
+        assert call("generate", "analyze") in add_edge_calls
+        assert call("generate", END) in add_edge_calls
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_with_interrupt_redirect(self):
+        """Fan-out targets in interrupt_nodes should be redirected to _prepare."""
+        mock_graph = MagicMock()
+        interrupt_nodes = {"analyze"}
+
+        edge = {"from": "generate", "to": ["analyze", "summarize"]}
+        _process_edge(edge, mock_graph, {}, {}, {}, interrupt_nodes)
+
+        add_edge_calls = mock_graph.add_edge.call_args_list
+        assert call("generate", "analyze_prepare") in add_edge_calls
+        assert call("generate", "summarize") in add_edge_calls
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_with_map_target(self):
+        """Fan-out with a map node target uses map edge function."""
+        mock_graph = MagicMock()
+        mock_map_fn = MagicMock()
+        map_nodes = {"expand": (mock_map_fn, "expand_sub")}
+
+        edge = {"from": "generate", "to": ["analyze", "expand"]}
+        _process_edge(edge, mock_graph, map_nodes, {}, {})
+
+        # Regular target gets add_edge
+        assert call("generate", "analyze") in mock_graph.add_edge.call_args_list
+        # Map target gets conditional edge with map function
+        mock_graph.add_conditional_edges.assert_called_once_with(
+            "generate", mock_map_fn, ["expand_sub"]
+        )
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_parallel_fanout_single_target_list(self):
+        """to: [single] should work the same as to: single."""
+        mock_graph = MagicMock()
+
+        edge = {"from": "generate", "to": ["analyze"]}
+        _process_edge(edge, mock_graph, {}, {}, {})
+
+        mock_graph.add_edge.assert_called_once_with("generate", "analyze")
+
+
+# =============================================================================
+# TestParallelFanOutFromStart
+# =============================================================================
+
+
+class TestParallelFanOutFromStart:
+    """Tests for parallel fan-out from START node (FR-234)."""
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_start_fanout_compiles(self, tmp_path):
+        """START -> [a, b] should compile into a working graph."""
+        yaml_content = """
+version: "1.0"
+name: start_fanout
+
+nodes:
+  analyze:
+    type: llm
+    prompt: analyze
+    state_key: analysis
+  summarize:
+    type: llm
+    prompt: summarize
+    state_key: summary
+  final:
+    type: llm
+    prompt: final
+    state_key: result
+
+edges:
+  - from: START
+    to: [analyze, summarize]
+  - from: analyze
+    to: final
+  - from: summarize
+    to: final
+  - from: final
+    to: END
+"""
+        yaml_file = tmp_path / "start_fanout.yaml"
+        yaml_file.write_text(yaml_content)
+
+        config = load_graph_config(yaml_file)
+        graph = compile_graph(config)
+        compiled = graph.compile()
+
+        assert compiled is not None
+        assert "analyze" in graph.nodes
+        assert "summarize" in graph.nodes
+
+
+# =============================================================================
+# TestParallelFanOutLinter
+# =============================================================================
+
+
+class TestParallelFanOutLinter:
+    """Tests that linter works correctly with parallel fan-out edges."""
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_fanout_nodes_reachable(self, tmp_path):
+        """All fan-out targets should be reachable from START (no W002)."""
+        from yamlgraph.linter.checks import check_edge_coverage
+
+        yaml_file = _make_fanout_yaml(tmp_path)
+        issues = check_edge_coverage(yaml_file)
+
+        # No unreachable node warnings
+        w002_issues = [i for i in issues if i.code == "W002"]
+        assert w002_issues == [], f"Unexpected W002 issues: {w002_issues}"
+
+    @pytest.mark.req("REQ-YG-235")
+    def test_fanout_nodes_reach_end(self, tmp_path):
+        """All fan-out targets should have paths to END (no W003)."""
+        from yamlgraph.linter.checks import check_edge_coverage
+
+        yaml_file = _make_fanout_yaml(tmp_path)
+        issues = check_edge_coverage(yaml_file)
+
+        # No dead-end warnings
+        w003_issues = [i for i in issues if i.code == "W003"]
+        assert w003_issues == [], f"Unexpected W003 issues: {w003_issues}"

--- a/yamlgraph/edge_compiler.py
+++ b/yamlgraph/edge_compiler.py
@@ -1,25 +1,57 @@
 """Edge compilation for StateGraph construction.
 
 Handles START edges, map node edges, conditional/router edges,
-and expression-based routing. Extracted from graph_loader.py (FR-067).
+parallel fan-out edges, and expression-based routing.
+Extracted from graph_loader.py (FR-067).
 """
 
+import logging
 from typing import Any
 
 from langgraph.graph import END, StateGraph
 
 from yamlgraph.routing import make_expr_router_fn, make_router_fn
 
+logger = logging.getLogger(__name__)
+
 
 def _handle_start_edge(
-    graph: StateGraph, to_node: str, map_nodes: dict[str, tuple]
+    graph: StateGraph,
+    to_node: str | list[str],
+    map_nodes: dict[str, tuple],
 ) -> None:
-    """Handle START -> node edge."""
+    """Handle START -> node edge (single or fan-out)."""
+    if isinstance(to_node, list):
+        # FR-234: START -> [a, b, c] parallel fan-out
+        _handle_start_fanout(graph, to_node, map_nodes)
+        return
     if to_node in map_nodes:
         map_edge_fn, sub_node_name = map_nodes[to_node]
         graph.set_conditional_entry_point(map_edge_fn, [sub_node_name])
     else:
         graph.set_entry_point(to_node)
+
+
+def _handle_start_fanout(
+    graph: StateGraph, targets: list[str], map_nodes: dict[str, tuple]
+) -> None:
+    """Handle START -> [a, b, c] parallel fan-out.
+
+    LangGraph requires exactly one entry point, so we use a conditional
+    entry point that returns all targets via a routing function.
+    """
+    resolved: list[str] = []
+    for target in targets:
+        if target in map_nodes:
+            _, sub_node_name = map_nodes[target]
+            resolved.append(sub_node_name)
+        else:
+            resolved.append(target)
+
+    def _fanout_entry(state: dict) -> list[str]:
+        return resolved
+
+    graph.set_conditional_entry_point(_fanout_entry, resolved)
 
 
 def _handle_map_to_map_edge(
@@ -80,6 +112,21 @@ def _process_edge(
     condition = edge.get("condition")
     edge_type = edge.get("type")
 
+    # FR-234: Parallel fan-out — to: [a, b, c] without type: conditional
+    if isinstance(to_node, list) and edge_type != "conditional":
+        if from_node == "START":
+            # Redirect interrupt targets before passing to start handler
+            resolved = [
+                f"{t}_prepare" if interrupt_nodes and t in interrupt_nodes else t
+                for t in to_node
+            ]
+            _handle_start_edge(graph, resolved, map_nodes)
+        else:
+            _add_parallel_fanout_edges(
+                graph, from_node, to_node, map_nodes, interrupt_nodes
+            )
+        return
+
     # FR-060: Redirect incoming edges to interrupt prepare node
     if interrupt_nodes and isinstance(to_node, str) and to_node in interrupt_nodes:
         to_node = f"{to_node}_prepare"
@@ -110,6 +157,33 @@ def _process_edge(
 
     # Simple edge
     graph.add_edge(from_node, END if to_node == "END" else to_node)
+
+
+def _add_parallel_fanout_edges(
+    graph: StateGraph,
+    from_node: str,
+    targets: list[str],
+    map_nodes: dict[str, tuple],
+    interrupt_nodes: set[str] | None = None,
+) -> None:
+    """Add parallel fan-out edges from one source to multiple targets (FR-234).
+
+    Each target gets its own edge. LangGraph executes them concurrently.
+    Handles interrupt node redirects and map node targets.
+    """
+    for target in targets:
+        # FR-060: Redirect interrupt targets to prepare node
+        if interrupt_nodes and target in interrupt_nodes:
+            target = f"{target}_prepare"
+
+        # Map node targets use conditional edge with map function
+        if target in map_nodes:
+            map_edge_fn, sub_node_name = map_nodes[target]
+            graph.add_conditional_edges(from_node, map_edge_fn, [sub_node_name])
+            continue
+
+        resolved = END if target == "END" else target
+        graph.add_edge(from_node, resolved)
 
 
 def _add_conditional_edges(


### PR DESCRIPTION
## Summary

Add support for parallel fan-out edges where a single node fans out to multiple target nodes that execute concurrently, expressed as `to: [node_a, node_b, node_c]` without `type: conditional`.

## Changes

- **edge_compiler.py**: New `_compile_fan_out_edge()` method for parallel branching
- **Demo**: `examples/demos/fan-out/` with full graph + prompts + output log
- **Docs**: `reference/graph-yaml.md` parallel fan-out section
- **Tests**: 14 unit tests in `test_parallel_fanout_edges.py`
- **Capability**: CAP-93, Requirement: REQ-YG-162

See FR at `feature-requests/FR-234-parallel-fan-out-edges.md`