### PR TITLE
fix(chatterbox): enable multilingual voice cloning via --ref

### DIFF
--- a/changelog/unreleased/fix-chatterbox-multilingual-voice-cloning.md
+++ b/changelog/unreleased/fix-chatterbox-multilingual-voice-cloning.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: chatterbox
+---
+- **fix(chatterbox): enable multilingual voice cloning via --ref**: `speak.py` CLI now accepts `--ref` for non-English languages, passing `audio_prompt_path` to `ChatterboxMultilingualTTS.generate()` for zero-shot voice cloning in all 23 supported languages.

--- a/examples/demos/chatterbox/README.md
+++ b/examples/demos/chatterbox/README.md
@@ -36,10 +36,11 @@ Two synthesis paths:
 | Path | Flag | Model | `--ref` |
 |------|------|-------|---------|
 | English / Voice Cloning | `--lang en` (default) | `ChatterboxTTS` | **Required** |
-| Multilingual | `--lang fi/sv/de/es/…` | `ChatterboxMultilingualTTS` | **Incompatible** |
+| Multilingual | `--lang fi/sv/de/es/…` | `ChatterboxMultilingualTTS` | Optional (voice cloning) |
 
-> **Voice cloning is English-only.** `--ref` is incompatible with `--lang <non-en>` and
-> raises a clear error. For multilingual synthesis, omit `--ref` and supply a language code.
+> **Voice cloning works in all languages.** For English, `--ref` is required (uses `ChatterboxTTS`).
+> For other languages, `--ref` is optional — when provided, `ChatterboxMultilingualTTS`
+> performs zero-shot voice cloning in the target language.
 
 ## Platform Requirements
 

--- a/examples/demos/chatterbox/demo-output.log
+++ b/examples/demos/chatterbox/demo-output.log
@@ -1,55 +1,13 @@
-# Demo run: Intel Mac x86_64 (verification — 2026-04-18)
-# Platform: macOS x86_64 (Intel) — torch 2.2.2 installed
-# chatterbox-tts requires torch==2.6.0, which has no macOS Intel wheel.
-# Translation stage succeeds; synthesis stage blocked by platform constraint.
-
-Disabling PyTorch because PyTorch >= 2.4 is required but found 2.2.2
-PyTorch was not found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
-2026-04-18 10:04:00,000 [INFO] yamlgraph.graph_loader: Parsed 1 Python tools: synthesize_audio
-2026-04-18 10:04:00,001 [INFO] yamlgraph.node_compiler: Added node: generate (type=map)
-2026-04-18 10:04:00,001 [INFO] yamlgraph.node_compiler: Added node: synthesize (type=python)
-2026-04-18 10:04:00,094 [INFO] yamlgraph.utils.llm_factory: Creating LLM: inception/mercury-2 (temp=0.7)
-2026-04-18 10:04:02,974 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (en)
-2026-04-18 10:04:03,530 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (es)
-2026-04-18 10:04:03,566 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (fi)
-2026-04-18 10:04:04,025 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (sv)
-2026-04-18 10:04:04,031 [INFO] yamlgraph.node_factory.llm_nodes: Node _map_generate_sub completed successfully (de)
-2026-04-18 10:04:04,032 [INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: synthesize -> synthesize_audio
-
-⚠️  Platform constraint: torch==2.6.0 required by chatterbox-tts has no macOS x86_64 wheel.
-    PyTorch dropped Intel Mac support after 2.2.x.
-    Run this demo on Apple Silicon, Linux, or Windows.
-
-# FR-237 consolidated: graph.yaml (multilingual TTS) + clone.yaml (voice cloning) + speak.py (CLI)
-# graph.yaml CI smoke output (no torch / no provider credentials in CI):
-2026-04-19 07:45:00,000 [INFO] yamlgraph.graph_loader: Parsed 2 Python tools: synthesize_audio, synthesize_cloned_audio
-2026-04-19 07:45:00,001 [INFO] yamlgraph.node_compiler: Added node: generate (type=map)
-2026-04-19 07:45:00,001 [INFO] yamlgraph.node_compiler: Added node: synthesize (type=python)
-2026-04-19 07:45:00,005 [INFO] yamlgraph.utils.llm_factory: Creating LLM: anthropic/claude-haiku-4-5 (temp=0.7)
-2026-04-19 07:45:00,650 [ERROR] yamlgraph.error_handlers: Node _map_generate_sub failed: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
-2026-04-19 07:45:00,651 [INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: synthesize -> synthesize_audio
-2026-04-19 07:45:00,651 [ERROR] yamlgraph.tools.python_tool: Python node synthesize failed: No module named 'torch'
-
-🚀 Running graph: graph.yaml
-   Variables: {'topic': 'the beauty of nature'}
-
-❌ Error: No module named 'torch'
-
-# clone.yaml smoke test (graph loads without import error):
-✓ Graph config loaded: chatterbox-voice-clone
-
-# speak.py --ref validation (no real audio required):
-$ python examples/demos/chatterbox/speak.py --ref /nonexistent.wav "Hello"
-Error: reference file not found: /nonexistent.wav
-[exit code 1]
-
-# FR-239: speak.py --lang flag validation (mocked, no chatterbox install required):
-$ python examples/demos/chatterbox/speak.py --lang fi "Hei maailmasta YAMLGraphista"
-# → routes to ChatterboxMultilingualTTS, language_id='fi'
-# outputs/chatterbox/speak.wav
-
-$ python examples/demos/chatterbox/speak.py --lang fi --ref source.wav "Hei"
-# speak.py: error: --ref is only supported with --lang en (voice-cloning path)
-[exit code 2]
-
-# speak.py fix (2026-04-19): --ref validation moved before torch import for CI compatibility
+/Users/sami.j.p.heikkinen/src/yamlgraph/.venv/lib/python3.13/site-packages/perth/perth_net/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
+  from pkg_resources import resource_filename
+Fetching 6 files:   0%|          | 0/6 [00:00<?, ?it/s]Fetching 6 files: 100%|██████████| 6/6 [00:00<00:00, 8522.12it/s]
+/Users/sami.j.p.heikkinen/src/yamlgraph/.venv/lib/python3.13/site-packages/diffusers/models/lora.py:393: FutureWarning: `LoRACompatibleLinear` is deprecated and will be removed in version 1.0.0. Use of `LoRACompatibleLinear` is deprecated. Please switch to PEFT backend by installing PEFT: `pip install peft`.
+  deprecate("LoRACompatibleLinear", "1.0.0", deprecation_message)
+/opt/homebrew/Cellar/python@3.13/3.13.11/Frameworks/Python.framework/Versions/3.13/lib/python3.13/contextlib.py:109: FutureWarning: `torch.backends.cuda.sdp_kernel()` is deprecated. In the future, this context manager will be removed. Please see `torch.nn.attention.sdpa_kernel()` for the new context manager, with updated signature.
+  self.gen = func(*args, **kwds)
+The following generation flags are not valid and may be ignored: ['output_attentions']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
+loaded PerthNet (Implicit) at step 250,000
+Sampling:   0%|          | 0/1000 [00:00<?, ?it/s]Sampling:   0%|          | 1/1000 [00:00<04:42,  3.54it/s]Sampling:   0%|          | 2/1000 [00:00<03:04,  5.41it/s]Sampling:   0%|          | 3/1000 [00:00<02:31,  6.57it/s]Sampling:   0%|          | 4/1000 [00:00<02:14,  7.39it/s]Sampling:   0%|          | 5/1000 [00:00<02:07,  7.80it/s]Sampling:   1%|          | 6/1000 [00:00<02:02,  8.14it/s]Sampling:   1%|          | 7/1000 [00:00<01:58,  8.39it/s]Sampling:   1%|          | 8/1000 [00:01<01:57,  8.46it/s]Sampling:   1%|          | 9/1000 [00:01<01:57,  8.43it/s]Sampling:   1%|          | 10/1000 [00:01<01:55,  8.54it/s]Sampling:   1%|          | 11/1000 [00:01<01:59,  8.26it/s]Sampling:   1%|          | 12/1000 [00:01<01:59,  8.29it/s]Sampling:   1%|▏         | 13/1000 [00:01<02:00,  8.21it/s]Sampling:   1%|▏         | 14/1000 [00:01<02:00,  8.17it/s]Sampling:   2%|▏         | 15/1000 [00:01<01:59,  8.25it/s]Sampling:   2%|▏         | 16/1000 [00:02<02:01,  8.13it/s]Sampling:   2%|▏         | 17/1000 [00:02<02:13,  7.34it/s]Sampling:   2%|▏         | 18/1000 [00:02<02:15,  7.24it/s]Sampling:   2%|▏         | 19/1000 [00:02<02:09,  7.59it/s]Sampling:   2%|▏         | 20/1000 [00:02<02:04,  7.86it/s]Sampling:   2%|▏         | 21/1000 [00:02<02:05,  7.77it/s]Sampling:   2%|▏         | 22/1000 [00:02<02:07,  7.70it/s]Sampling:   2%|▏         | 23/1000 [00:02<02:03,  7.91it/s]Sampling:   2%|▏         | 24/1000 [00:03<02:02,  7.98it/s]Sampling:   2%|▎         | 25/1000 [00:03<02:03,  7.92it/s]Sampling:   3%|▎         | 26/1000 [00:03<02:00,  8.10it/s]Sampling:   3%|▎         | 27/1000 [00:03<02:00,  8.08it/s]Sampling:   3%|▎         | 28/1000 [00:03<02:01,  8.01it/s]Sampling:   3%|▎         | 29/1000 [00:03<02:01,  7.97it/s]Sampling:   3%|▎         | 30/1000 [00:03<02:00,  8.03it/s]Sampling:   3%|▎         | 31/1000 [00:03<02:01,  7.97it/s]Sampling:   3%|▎         | 32/1000 [00:04<02:00,  8.02it/s]Sampling:   3%|▎         | 33/1000 [00:04<01:59,  8.06it/s]Sampling:   3%|▎         | 34/1000 [00:04<01:59,  8.08it/s]Sampling:   4%|▎         | 35/1000 [00:04<01:58,  8.15it/s]Sampling:   4%|▎         | 36/1000 [00:04<01:57,  8.21it/s]Sampling:   4%|▎         | 37/1000 [00:04<01:58,  8.13it/s]Sampling:   4%|▍         | 38/1000 [00:04<01:57,  8.18it/s]Sampling:   4%|▍         | 39/1000 [00:04<01:56,  8.23it/s]Sampling:   4%|▍         | 40/1000 [00:05<01:57,  8.18it/s]Sampling:   4%|▍         | 41/1000 [00:05<01:56,  8.20it/s]Sampling:   4%|▍         | 42/1000 [00:05<01:58,  8.07it/s]Sampling:   4%|▍         | 43/1000 [00:05<01:58,  8.07it/s]Sampling:   4%|▍         | 44/1000 [00:05<01:55,  8.25it/s]Sampling:   4%|▍         | 45/1000 [00:05<01:56,  8.19it/s]Sampling:   5%|▍         | 46/1000 [00:05<01:56,  8.17it/s]Sampling:   5%|▍         | 47/1000 [00:05<01:54,  8.35it/s]Sampling:   5%|▍         | 48/1000 [00:06<01:56,  8.20it/s]Sampling:   5%|▍         | 49/1000 [00:06<01:55,  8.21it/s]Sampling:   5%|▌         | 50/1000 [00:06<01:54,  8.32it/s]Sampling:   5%|▌         | 51/1000 [00:06<01:54,  8.30it/s]Sampling:   5%|▌         | 52/1000 [00:06<01:54,  8.29it/s]WARNING:chatterbox.models.t3.inference.alignment_stream_analyzer:🚨 Detected 2x repetition of token 4218
+WARNING:chatterbox.models.t3.inference.alignment_stream_analyzer:forcing EOS token, long_tail=tensor(False), alignment_repetition=tensor(False), token_repetition=True
+Sampling:   5%|▌         | 52/1000 [00:06<01:59,  7.91it/s]
+outputs/chatterbox/speak.wav

--- a/examples/demos/chatterbox/speak.py
+++ b/examples/demos/chatterbox/speak.py
@@ -1,32 +1,31 @@
-"""CLI tool: synthesise text with an optional voice clone or multilingual model.
+"""CLI tool: synthesise text with an optional voice clone.
 
 Two synthesis paths are available:
 
-**English / Voice Cloning (default, ``--lang en``):**
+**English (default, ``--lang en``):**
     Uses ``ChatterboxTTS`` with a reference WAV clip (``--ref``).
-    Voice timbre transfers from the reference clip.
     ``--ref`` is required for this path.
 
 **Multilingual (``--lang <code>``):**
-    Uses ``ChatterboxMultilingualTTS``.  No reference audio is accepted.
-    Known-good language codes: ``fi``, ``sv``, ``de``, ``es``.
-    ``--ref`` is incompatible with this path.
+    Uses ``ChatterboxMultilingualTTS``.
+    Supports 23 languages including ``fi``, ``sv``, ``de``, ``es``.
+    Optional ``--ref`` enables zero-shot voice cloning in the target language.
 
 Output is always written to ``outputs/chatterbox/speak.wav``.
 
 Usage::
 
-    # English voice cloning (unchanged)
+    # English voice cloning (requires --ref)
     python examples/demos/chatterbox/speak.py \\
         --ref examples/demos/chatterbox/source.wav "Hello world"
 
-    # Finnish via multilingual model
+    # Finnish with default voice
     python examples/demos/chatterbox/speak.py \\
         --lang fi "Hei maailma"
 
-    # Explicit English (same as omitting --lang)
+    # Finnish with voice cloning
     python examples/demos/chatterbox/speak.py \\
-        --lang en --ref source.wav "Hello world"
+        --lang fi --ref source.wav "Hei maailma"
 """
 
 import argparse
@@ -39,7 +38,8 @@ def main() -> None:
         description=(
             "Chatterbox TTS CLI (FR-239). "
             "English path (--lang en, default): ChatterboxTTS + --ref for voice cloning. "
-            "Multilingual path (--lang fi/sv/de/es/…): ChatterboxMultilingualTTS, no --ref."
+            "Multilingual path (--lang fi/sv/de/es/…): ChatterboxMultilingualTTS, "
+            "optional --ref for zero-shot voice cloning."
         )
     )
     parser.add_argument("text", help="Text to synthesise")
@@ -48,7 +48,7 @@ def main() -> None:
         "-r",
         type=Path,
         default=None,
-        help="Path to reference WAV for voice cloning (English path only)",
+        help="Path to reference WAV for voice cloning (all languages)",
     )
     parser.add_argument(
         "--lang",
@@ -56,19 +56,17 @@ def main() -> None:
         default="en",
         help=(
             "Language code (default: en). "
-            "en → ChatterboxTTS (voice cloning, requires --ref). "
-            "Other codes (fi, sv, de, es, …) → ChatterboxMultilingualTTS (no --ref)."
+            "en → ChatterboxTTS (requires --ref). "
+            "Other codes (fi, sv, de, es, …) → ChatterboxMultilingualTTS "
+            "(optional --ref for voice cloning)."
         ),
     )
     args = parser.parse_args()
 
-    if args.lang != "en" and args.ref is not None:
-        parser.error("--ref is only supported with --lang en (voice-cloning path)")
-
     if args.lang == "en" and args.ref is None:
         parser.error("--ref is required for the English voice-cloning path (--lang en)")
 
-    if args.lang == "en" and not args.ref.exists():
+    if args.ref is not None and not args.ref.exists():
         print(f"Error: reference file not found: {args.ref}", file=sys.stderr)
         sys.exit(1)
 
@@ -96,7 +94,8 @@ def main() -> None:
         from chatterbox.mtl_tts import ChatterboxMultilingualTTS
 
         model = ChatterboxMultilingualTTS.from_pretrained(device=device)
-        wav = model.generate(args.text, language_id=args.lang)
+        ref = str(args.ref) if args.ref else None
+        wav = model.generate(args.text, language_id=args.lang, audio_prompt_path=ref)
 
     ta.save(str(output_path), wav, model.sr)
     print(output_path)

--- a/tests/unit/test_chatterbox_demo.py
+++ b/tests/unit/test_chatterbox_demo.py
@@ -600,12 +600,21 @@ class TestSpeakCLIMultilingual:
         with patch("builtins.print"):
             module.main()
 
-        mock_model.generate.assert_called_once_with("Hei maailma", language_id="fi")
+        mock_model.generate.assert_called_once_with(
+            "Hei maailma", language_id="fi", audio_prompt_path=None
+        )
 
-    def test_lang_fi_ref_raises_system_exit(self, tmp_path, monkeypatch):
-        """--lang fi --ref <wav> must raise SystemExit with non-zero code."""
+    def test_lang_fi_ref_passes_audio_prompt(self, tmp_path, monkeypatch):
+        """--lang fi --ref <wav> must pass audio_prompt_path to multilingual model."""
         ref_wav = tmp_path / "ref.wav"
         ref_wav.write_bytes(b"RIFF")
+
+        mock_model = MagicMock()
+        mock_model.sr = 24000
+        mock_model.generate.return_value = MagicMock()
+        _mock_chatterbox_mtl.ChatterboxMultilingualTTS.from_pretrained.return_value = (
+            mock_model
+        )
 
         import sys as _sys
 
@@ -617,10 +626,12 @@ class TestSpeakCLIMultilingual:
         monkeypatch.chdir(tmp_path)
 
         module = self._load_speak_module()
-        with pytest.raises(SystemExit) as exc_info:
+        with patch("builtins.print"):
             module.main()
 
-        assert exc_info.value.code != 0
+        mock_model.generate.assert_called_once_with(
+            "Hei", language_id="fi", audio_prompt_path=str(ref_wav)
+        )
 
     def test_lang_en_explicit_uses_chatterbox_tts(self, tmp_path, monkeypatch):
         """Explicit --lang en must use ChatterboxTTS (voice cloning path)."""


### PR DESCRIPTION
ChatterboxMultilingualTTS.generate() supports audio_prompt_path for zero-shot voice cloning in all 23 languages. The speak.py CLI incorrectly rejected --ref for non-English languages.

- Remove guard that blocked --ref with --lang != en
- Pass audio_prompt_path to multilingual model when --ref provided
- Update docstring and README to reflect correct capabilities
- Update tests to match new behavior