### PR TITLE
docs(a2a): FR-246 A2A server reference documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -375,6 +375,7 @@ Run `python scripts/aggregate_capabilities.py` to regenerate the sections below.
 | 102 | Complete Worktree Teardown Self-Heal (FR-241) | `yamlgraph/utils/worktree_helpers.py`, `scripts/enforce_worktree.sh`, `scripts/bugfix_worktree.sh` | REQ-YG-244 |
 | 101 | A2A Call Node Type (FR-240) | `yamlgraph/node_factory/a2a_nodes.py`, `yamlgraph/constants.py`, `yamlgraph/node_compiler.py`, `yamlgraph/linter/patterns/a2a.py` | REQ-YG-243 |
 | 100 | Chatterbox Multilingual CLI (FR-239) | `examples/demos/chatterbox/speak.py` | REQ-YG-242 |
+| 103 | A2A Server Reference Documentation (FR-246) | `reference/a2a-server.md`, `reference/cli.md` | REQ-YG-245 |
 
 > Capability numbers are stable identifiers. Gaps (e.g. 27, 29, 52, 58) indicate retired capabilities.
 
@@ -549,6 +550,7 @@ Defense-in-depth guards against infinite loops, unbounded map fan-out, and runaw
 | REQ-YG-238 | Chatterbox speak CLI: `speak.py` accepts `--ref` (reference WAV path, required) and positional text; validates ref exists (exit 1 on missing); calls `ChatterboxTTS.generate()` without `language_id`; writes to `outputs/chatterbox/speak.wav`; prints output path to stdout (FR-237) | `examples/demos/chatterbox` |
 | REQ-YG-243 | `type: a2a_call` node sends Jinja2-templated message to external A2A agent URL via HTTP JSON-RPC `tasks/send`; extracts text artifacts from response; stores in `state_key`; supports `timeout`, `on_error` (skip/fail/retry/fallback), `variables`; `NodeType.A2A_CALL` in constants; registered in `NODE_TYPE_HANDLERS`; linter validates required fields (`agent_url`, `message`, `state_key`) via E901–E903; `check_a2a_call_patterns()` in graph linter; does not require prompt field; uses httpx for HTTP transport (FR-240) | `yamlgraph/node_factory/a2a_nodes.py`, `yamlgraph/constants.py`, `yamlgraph/node_compiler.py`, `yamlgraph/linter/patterns/a2a.py` |
 | REQ-YG-242 | Chatterbox multilingual CLI: `speak.py --lang <code>` routes to `ChatterboxMultilingualTTS` for non-English codes (fi, sv, de, es, …); `--ref` incompatible with non-English lang (parser.error); `--lang en` (default) preserves voice-cloning path requiring `--ref`; output always `outputs/chatterbox/speak.wav` (FR-239) | `examples/demos/chatterbox` |
+| REQ-YG-245 | `reference/a2a-server.md` created with 10 sections: Quickstart, CLI Commands, Agent Card Generation, Message-to-State Mapping, Task Lifecycle, Error Mapping, Interrupt/Human-in-Loop, Authentication, Deployment Patterns, Relationship to MCP Server; `reference/cli.md` updated with `a2a serve` and `a2a card` subcommands; `reference/README.md` links to `a2a-server.md`; all examples verified against `a2a_server.py`, `a2a_message.py`, `cli/a2a_commands.py` (FR-246) | `reference/a2a-server.md`, `reference/cli.md` |
 
 ### 93. Per-Node Timeout
 

--- a/capabilities/CAP-103-a2a-server-reference-docs.yaml
+++ b/capabilities/CAP-103-a2a-server-reference-docs.yaml
@@ -1,0 +1,24 @@
+id: CAP-103
+name: A2A Server Reference Documentation
+description: >
+  User-facing reference documentation for the A2A protocol server (FR-208/209/225, CAP-81).
+  Covers quickstart, CLI commands, Agent Card generation, message parsing, task lifecycle,
+  error mapping, interrupts, authentication, deployment patterns, and MCP relationship.
+  Also updates reference/cli.md with a2a subcommands and reference/README.md index.
+modules:
+  - reference/a2a-server.md
+  - reference/cli.md
+requirements:
+  - id: REQ-YG-245
+    description: >
+      reference/a2a-server.md created with 10 sections: Quickstart, CLI Commands,
+      Agent Card Generation, Message-to-State Mapping, Task Lifecycle, Error Mapping,
+      Interrupt/Human-in-Loop, Authentication, Deployment Patterns, Relationship to
+      MCP Server; reference/cli.md updated with a2a serve and a2a card subcommands;
+      reference/README.md links to a2a-server.md; all examples verified against
+      a2a_server.py, a2a_message.py, cli/a2a_commands.py
+    modules:
+      - reference/a2a-server.md
+      - reference/cli.md
+      - tests/unit/test_a2a_server_docs.py
+fr: FR-246

--- a/feature-requests/FR-246-a2a-server-reference-docs.md
+++ b/feature-requests/FR-246-a2a-server-reference-docs.md
@@ -2,7 +2,7 @@
 
 **Priority:** MEDIUM
 **Type:** Enhancement
-**Status:** Approved
+**Status:** Implemented
 **Effort:** 1 day
 **Requested:** 2026-04-19
 **Judged:** 2026-04-19
@@ -124,13 +124,13 @@ Add the `a2a` subcommands to the commands overview table and add a `yamlgraph a2
 
 ## Acceptance Criteria
 
-- [ ] REQ-YG-245 added to `ARCHITECTURE.md` capabilities table and requirement descriptions (reference doc for A2A server)
-- [ ] `reference/a2a-server.md` created with all 10 sections above (REQ-YG-245)
-- [ ] Quickstart example is copy-pasteable and works with the hello graph
-- [ ] `reference/cli.md` updated to include `a2a serve` and `a2a card` commands
-- [ ] `reference/README.md` updated to link to `a2a-server.md` (if it maintains a doc index)
-- [ ] No new Python code — documentation only
-- [ ] All code examples verified against current implementation in `a2a_server.py`, `a2a_message.py`, `cli/a2a_commands.py`
+- [x] REQ-YG-245 added to `ARCHITECTURE.md` capabilities table and requirement descriptions (reference doc for A2A server)
+- [x] `reference/a2a-server.md` created with all 10 sections above (REQ-YG-245)
+- [x] Quickstart example is copy-pasteable and works with the hello graph
+- [x] `reference/cli.md` updated to include `a2a serve` and `a2a card` commands
+- [x] `reference/README.md` updated to link to `a2a-server.md` (if it maintains a doc index)
+- [x] No new Python code — documentation only
+- [x] All code examples verified against current implementation in `a2a_server.py`, `a2a_message.py`, `cli/a2a_commands.py`
 
 ## Alternatives Considered
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -50,6 +50,7 @@ See [CHANGELOG.md](../CHANGELOG.md) for version history.
 | [LangSmith Tools & Tracing](langsmith-tools.md) | Trace URLs, public sharing, and observability tools |
 | [Prompt Deployment](prompt-deployment.md) | Patterns for updating prompts without rebuild |
 | [MCP Server](mcp-server.md) | Expose graphs as Copilot/MCP tools |
+| [A2A Server](a2a-server.md) | Expose graphs as A2A protocol agents |
 | [Contrib Utilities](contrib.md) | Shared utilities for map results and serialization |
 | [Scheduling Agents](scheduling-agents.md) | Run graphs on schedule (launchd, cron, CI) |
 

--- a/reference/a2a-server.md
+++ b/reference/a2a-server.md
@@ -1,0 +1,376 @@
+# A2A Server
+
+Expose YAMLGraph graphs as [A2A (Agent-to-Agent)](https://google.github.io/A2A/) protocol agents. Clients can discover graphs via Agent Cards, send tasks, stream responses, and handle interrupts — all over HTTP JSON-RPC.
+
+## Quickstart
+
+### 1. Install A2A dependency
+
+```bash
+pip install -e ".[a2a]"
+```
+
+### 2. Start the server with the hello graph
+
+```bash
+yamlgraph a2a serve examples/demos/hello/ --port 9090
+```
+
+### 3. Fetch the Agent Card
+
+```bash
+curl http://localhost:9090/.well-known/agent-card.json
+```
+
+### 4. Send a task
+
+```bash
+curl -X POST http://localhost:9090/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0", "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "messageId": "msg-1",
+        "parts": [{"kind": "text", "text": "name=World style=casual"}]
+      }
+    }
+  }'
+```
+
+The hello graph requires `name` and `style` variables. The message text uses `key=value` format, which the server parses automatically.
+
+---
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `yamlgraph a2a serve [path] --host --port` | Start A2A server exposing discovered graphs |
+| `yamlgraph a2a card [path] --host --port` | Print Agent Card JSON without starting server |
+
+### a2a serve
+
+Start the A2A HTTP server.
+
+```bash
+yamlgraph a2a serve <graph_path> [options]
+```
+
+**Arguments:**
+- `graph_path` — Path to a graph YAML file or directory. Defaults to discovering graphs from `examples/demos/*/` and `examples/*/`.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Server bind address |
+| `--port` | `8080` | Server port |
+
+**Examples:**
+
+```bash
+# Serve a single graph
+yamlgraph a2a serve examples/demos/hello/graph.yaml --port 9090
+
+# Serve all graphs in a directory
+yamlgraph a2a serve examples/demos/hello/ --port 9090
+
+# Serve all discovered graphs (default patterns)
+yamlgraph a2a serve
+```
+
+### a2a card
+
+Print the Agent Card JSON for discovered graphs without starting the server.
+
+```bash
+yamlgraph a2a card <graph_path> [options]
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `localhost` | Hostname for Agent Card URL |
+| `--port` | `8080` | Port for Agent Card URL |
+
+**Example:**
+
+```bash
+yamlgraph a2a card examples/demos/hello/ --port 9090
+```
+
+---
+
+## Agent Card Generation
+
+`build_agent_card()` maps graph YAML metadata to an A2A `AgentCard`. Each discovered graph becomes a skill:
+
+| Graph YAML field | Agent Card field | Description |
+|-----------------|-----------------|-------------|
+| `name` | `skills[].id`, `skills[].name` | Graph name becomes skill identifier |
+| `description` | `skills[].description` | Graph description becomes skill description |
+| presence of `nodes` | included in discovery | Only YAML files with `nodes` key are treated as graphs |
+| `state` keys | `required_vars` | Used at message parse time to validate input |
+
+**Example Agent Card** (for the hello graph):
+
+```json
+{
+  "name": "YAMLGraph A2A Server",
+  "description": "YAMLGraph graphs exposed as A2A agents",
+  "url": "http://localhost:9090/",
+  "version": "0.4.63",
+  "skills": [
+    {
+      "id": "hello-world",
+      "name": "hello-world",
+      "description": "Simple greeting generator demonstrating basic LLM usage",
+      "tags": ["yamlgraph"]
+    }
+  ],
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "capabilities": {
+    "streaming": true
+  }
+}
+```
+
+All Agent Cards are generated with `authentication: null`. See [Authentication](#authentication) for production patterns.
+
+---
+
+## Message-to-State Mapping
+
+`parse_a2a_message()` converts A2A message text into graph input variables. It tries four parsing modes in order:
+
+### 1. JSON mode
+
+If the text is valid JSON object, keys map directly to variables.
+
+```json
+{"name": "World", "style": "casual"}
+```
+
+### 2. key_value mode
+
+If the text contains `=`, it is parsed as space-separated `key=value` pairs (using `shlex.split` for proper quoting).
+
+```
+name=World style=casual
+```
+
+Quoted values work: `name="Hello World" style=casual`
+
+### 3. single_input mode
+
+If the graph has exactly one required variable, the entire text is assigned to it.
+
+```
+Hello World
+```
+
+→ `{"input": "Hello World"}` (if the only required var is `input`)
+
+### 4. Fallback
+
+If none of the above match, the entire text is assigned to the `input` key.
+
+```
+some free-form text
+```
+
+→ `{"input": "some free-form text"}`
+
+**Validation:** After parsing, `_validate_required_vars()` checks that all required variables (from graph `state` keys) are present. Missing variables raise `ValueError` with code `missing_variables`.
+
+---
+
+## Task Lifecycle
+
+The A2A server maps graph execution to the A2A task lifecycle:
+
+| A2A Method | YAMLGraph Behaviour |
+|------------|---------------------|
+| `message/send` | Compile and invoke graph synchronously, return result as artifact |
+| `message/stream` | SSE event stream: `working` → `artifact` → `completed` |
+| `task/cancel` | Cancel running asyncio task |
+
+### State Transitions
+
+```
+submitted → working → completed
+                    → failed
+                    → input-required (interrupt)
+                    → canceled
+```
+
+### message/send
+
+1. Server emits `TaskStatusUpdateEvent` with state `working`
+2. Message text is parsed into variables via `parse_a2a_message()`
+3. Graph is compiled and invoked in a thread pool (`ThreadPoolExecutor`)
+4. Result is formatted and emitted as `TaskArtifactUpdateEvent`
+5. Final `TaskStatusUpdateEvent` with state `completed` is emitted
+
+### message/stream (SSE)
+
+Same as `message/send`, but events are delivered as Server-Sent Events in real-time. The SSE stream emits:
+
+1. `TaskStatusUpdateEvent` — state: `working`
+2. `TaskArtifactUpdateEvent` — graph output
+3. `TaskStatusUpdateEvent` — state: `completed` (final=true)
+
+### task/cancel
+
+Cancels a running graph execution. The server cancels the asyncio task and emits `TaskStatusUpdateEvent` with state `canceled`.
+
+---
+
+## Error Mapping
+
+`map_pipeline_error()` converts `PipelineError` types to A2A error types:
+
+| PipelineError type | A2A error | Semantics |
+|--------------------|-----------|-----------|
+| `LLM_ERROR` | `InternalError` | LLM provider failure |
+| `STATE_ERROR` | `InternalError` | State management error |
+| `UNKNOWN_ERROR` | `InternalError` | Unexpected failure |
+| `VALIDATION_ERROR` | `InvalidParamsError` | Input validation failure |
+| `PROMPT_ERROR` | `InvalidParamsError` | Prompt template error |
+| `VERIFICATION_ERROR` | `InvalidParamsError` | Output verification failure |
+
+When a `PipelineError` occurs, the error is mapped to the appropriate A2A error type. The error data includes:
+
+```json
+{
+  "node": "node_name",
+  "retryable": false,
+  "error_type": "LLM_ERROR"
+}
+```
+
+Non-`PipelineError` exceptions result in a `failed` task state with the exception message.
+
+---
+
+## Interrupt / Human-in-Loop
+
+When a graph hits an `interrupt_before` or `interrupt_after` node, the server detects the `__interrupt__` marker in the result and emits `TaskState.input_required`.
+
+**Detection:** `_detect_interrupt(result)` checks for the `__interrupt__` key in the graph result dict. LangGraph sets this key when a node with interrupt configuration triggers.
+
+**Server response:** When an interrupt is detected:
+1. `TaskStatusUpdateEvent` with state `input_required` is emitted
+2. The message reads "Graph requires additional input"
+3. The event is **not** marked final — the task stays open for continuation
+
+**Client action:** The client should send a follow-up `message/send` with the required input to resume the graph.
+
+---
+
+## Authentication
+
+**Status:** Not implemented in the A2A server itself.
+
+Agent Cards are generated with `authentication: null`. For production deployments, use a reverse proxy to add authentication:
+
+- **nginx**: Basic auth, JWT validation, or OAuth2 proxy
+- **Caddy**: Automatic TLS + built-in auth middleware
+- **Traefik**: Forward auth middleware
+
+The recommended deployment pattern is:
+
+```
+Client → Reverse Proxy (TLS + Auth) → yamlgraph a2a serve (localhost)
+```
+
+See [Deployment Patterns](#deployment-patterns) for full examples.
+
+---
+
+## Deployment Patterns
+
+### Standalone (development)
+
+Run the server directly for local development and testing:
+
+```bash
+yamlgraph a2a serve examples/demos/hello/ --port 9090
+```
+
+### Behind Reverse Proxy (production)
+
+For production, place the A2A server behind a reverse proxy that handles TLS termination and authentication:
+
+```nginx
+# nginx example
+server {
+    listen 443 ssl;
+    server_name a2a.example.com;
+
+    ssl_certificate /etc/ssl/cert.pem;
+    ssl_certificate_key /etc/ssl/key.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+### Container
+
+```dockerfile
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install -e ".[a2a]"
+EXPOSE 8080
+CMD ["yamlgraph", "a2a", "serve", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+---
+
+## Relationship to MCP Server
+
+YAMLGraph exposes graphs through two protocol servers that share the same discovery layer:
+
+| Aspect | MCP (`yamlgraph mcp serve`) | A2A (`yamlgraph a2a serve`) |
+|--------|-----|-----|
+| Transport | stdio | HTTP (JSON-RPC) |
+| Discovery | Shared `discovery.py` | Shared `discovery.py` |
+| Model | Tools | Agent Skills |
+| Streaming | No | SSE |
+| Auth | None (IDE-controlled) | None (use reverse proxy) |
+| Use case | IDE integration (Copilot, Claude) | Agent-to-agent communication |
+
+Both servers use `discover_graphs()` from `discovery.py` to scan the same glob patterns:
+
+- `examples/demos/*/*.yaml`
+- `examples/*/*.yaml`
+
+The MCP server exposes graphs as tools (`yamlgraph_list_graphs`, `yamlgraph_run_graph`). The A2A server exposes graphs as agent skills with the A2A JSON-RPC protocol.
+
+---
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `ImportError: A2A SDK not installed` | `pip install -e ".[a2a]"` |
+| `uvicorn not installed` | `pip install uvicorn` |
+| No graphs found | Verify path matches a graph YAML with `nodes` key |
+| `missing_variables` error | Message text must include all required state variables |
+| Server not responding | Check host/port; default binds to `0.0.0.0:8080` |
+
+## Related
+
+- [`reference/mcp-server.md`](mcp-server.md) — MCP server reference
+- [`examples/demos/a2a_server/`](../examples/demos/a2a_server/) — A2A server demo
+- [`examples/demos/a2a_call/`](../examples/demos/a2a_call/) — A2A call consumer demo

--- a/reference/cli.md
+++ b/reference/cli.md
@@ -5,12 +5,13 @@ Complete command reference for the `yamlgraph` CLI.
 ## Commands Overview
 
 ```
-yamlgraph [-h] {list-runs,resume,trace,export,graph} ...
+yamlgraph [-h] {list-runs,resume,trace,export,graph,a2a} ...
 ```
 
 | Command | Description |
 |---------|-------------|
 | `graph` | Run graphs, list, validate, lint, generate diagrams |
+| `a2a` | A2A protocol server: serve graphs as agents, print Agent Cards |
 | `list-runs` | List recent pipeline runs |
 | `resume` | Resume a paused pipeline |
 | `trace` | Show execution trace (requires LangSmith) |
@@ -110,6 +111,63 @@ yamlgraph graph lint <graph_paths...>
 **Example:**
 ```bash
 yamlgraph graph lint examples/demos/yamlgraph/graph.yaml examples/demos/router/graph.yaml
+```
+
+---
+
+## yamlgraph a2a
+
+A2A protocol server commands. See [A2A Server Reference](a2a-server.md) for full documentation.
+
+```
+yamlgraph a2a {serve,card} ...
+```
+
+### a2a serve
+
+Start an A2A HTTP server exposing discovered graphs as agent skills.
+
+```bash
+yamlgraph a2a serve <graph_path> [options]
+```
+
+**Arguments:**
+- `graph_path` — Path to a graph YAML file or directory (optional; defaults to auto-discovery)
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `0.0.0.0` | Server bind address |
+| `--port` | `8080` | Server port |
+
+**Examples:**
+```bash
+# Serve the hello graph
+yamlgraph a2a serve examples/demos/hello/ --port 9090
+
+# Serve all discovered graphs
+yamlgraph a2a serve
+```
+
+### a2a card
+
+Print the Agent Card JSON for discovered graphs without starting the server.
+
+```bash
+yamlgraph a2a card <graph_path> [options]
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--host` | `localhost` | Hostname for Agent Card URL |
+| `--port` | `8080` | Port for Agent Card URL |
+
+**Example:**
+```bash
+yamlgraph a2a card examples/demos/hello/
 ```
 
 ---

--- a/tests/unit/test_a2a_server_docs.py
+++ b/tests/unit/test_a2a_server_docs.py
@@ -63,7 +63,7 @@ class TestA2AServerRefQuickstart:
         assert "## Quickstart" in self.content or "## Setup" in self.content
 
     def test_quickstart_pip_install(self):
-        assert 'pip install' in self.content and 'a2a' in self.content
+        assert "pip install" in self.content and "a2a" in self.content
 
     def test_quickstart_serve_command(self):
         assert "yamlgraph a2a serve" in self.content
@@ -108,7 +108,9 @@ class TestA2AServerRefAgentCard:
         self.content = A2A_SERVER_REF.read_text()
 
     def test_agent_card_heading(self):
-        assert "## Agent Card" in self.content or "Agent Card Generation" in self.content
+        assert (
+            "## Agent Card" in self.content or "Agent Card Generation" in self.content
+        )
 
     def test_build_agent_card_referenced(self):
         assert "build_agent_card" in self.content
@@ -135,7 +137,10 @@ class TestA2AServerRefMessageParsing:
         assert "key_value" in self.content or "key=value" in self.content
 
     def test_single_input_mode_documented(self):
-        assert "single_input" in self.content or "single required var" in self.content.lower()
+        assert (
+            "single_input" in self.content
+            or "single required var" in self.content.lower()
+        )
 
     def test_fallback_mode_documented(self):
         assert "fallback" in self.content.lower()
@@ -218,7 +223,9 @@ class TestA2AServerRefAuthentication:
         assert "Authentication" in self.content
 
     def test_reverse_proxy_mentioned(self):
-        assert "reverse proxy" in self.content.lower() or "nginx" in self.content.lower()
+        assert (
+            "reverse proxy" in self.content.lower() or "nginx" in self.content.lower()
+        )
 
 
 @pytest.mark.req("REQ-YG-245")
@@ -233,7 +240,10 @@ class TestA2AServerRefDeployment:
         assert "Deployment" in self.content
 
     def test_standalone_pattern(self):
-        assert "standalone" in self.content.lower() or "development" in self.content.lower()
+        assert (
+            "standalone" in self.content.lower()
+            or "development" in self.content.lower()
+        )
 
     def test_container_pattern(self):
         assert "container" in self.content.lower() or "docker" in self.content.lower()

--- a/tests/unit/test_a2a_server_docs.py
+++ b/tests/unit/test_a2a_server_docs.py
@@ -1,0 +1,315 @@
+"""Tests for FR-246: A2A Server Reference Documentation.
+
+Verifies that reference/a2a-server.md exists with all 10 required sections,
+reference/cli.md includes a2a subcommands, and reference/README.md links
+to the new doc. Documentation-only FR — no Python code changes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+A2A_SERVER_REF = REPO_ROOT / "reference" / "a2a-server.md"
+CLI_REF = REPO_ROOT / "reference" / "cli.md"
+REF_README = REPO_ROOT / "reference" / "README.md"
+ARCHITECTURE = REPO_ROOT / "ARCHITECTURE.md"
+
+
+# ---------------------------------------------------------------------------
+# AC-1: REQ-YG-245 in ARCHITECTURE.md
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestArchitectureRequirement:
+    """Verify REQ-YG-245 is registered in ARCHITECTURE.md."""
+
+    def test_req_in_capabilities_table(self):
+        content = ARCHITECTURE.read_text()
+        assert (
+            "REQ-YG-245" in content
+        ), "ARCHITECTURE.md must include REQ-YG-245 in capabilities table"
+
+    def test_req_description_exists(self):
+        content = ARCHITECTURE.read_text()
+        assert (
+            "REQ-YG-245" in content and "a2a-server.md" in content
+        ), "ARCHITECTURE.md must have REQ-YG-245 description referencing a2a-server.md"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: reference/a2a-server.md exists with all 10 sections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefExists:
+    """Verify reference/a2a-server.md exists."""
+
+    def test_file_exists(self):
+        assert A2A_SERVER_REF.exists(), "reference/a2a-server.md must exist"
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefQuickstart:
+    """Section 1: Quickstart."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_quickstart_heading(self):
+        assert "## Quickstart" in self.content or "## Setup" in self.content
+
+    def test_quickstart_pip_install(self):
+        assert 'pip install' in self.content and 'a2a' in self.content
+
+    def test_quickstart_serve_command(self):
+        assert "yamlgraph a2a serve" in self.content
+
+    def test_quickstart_agent_card_curl(self):
+        assert "agent-card.json" in self.content
+
+    def test_quickstart_message_send(self):
+        assert "message/send" in self.content
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefCLI:
+    """Section 2: CLI Commands."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_cli_commands_heading(self):
+        assert "## CLI Commands" in self.content
+
+    def test_serve_command_documented(self):
+        assert "a2a serve" in self.content
+
+    def test_card_command_documented(self):
+        assert "a2a card" in self.content
+
+    def test_port_flag(self):
+        assert "--port" in self.content
+
+    def test_host_flag(self):
+        assert "--host" in self.content
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefAgentCard:
+    """Section 3: Agent Card Generation."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_agent_card_heading(self):
+        assert "## Agent Card" in self.content or "Agent Card Generation" in self.content
+
+    def test_build_agent_card_referenced(self):
+        assert "build_agent_card" in self.content
+
+    def test_skills_mapping_documented(self):
+        assert "skills" in self.content.lower()
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefMessageParsing:
+    """Section 4: Message-to-State Mapping."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_message_parsing_heading(self):
+        assert "Message" in self.content and "Mapping" in self.content
+
+    def test_json_mode_documented(self):
+        assert "JSON" in self.content
+
+    def test_key_value_mode_documented(self):
+        assert "key_value" in self.content or "key=value" in self.content
+
+    def test_single_input_mode_documented(self):
+        assert "single_input" in self.content or "single required var" in self.content.lower()
+
+    def test_fallback_mode_documented(self):
+        assert "fallback" in self.content.lower()
+
+    def test_parse_a2a_message_referenced(self):
+        assert "parse_a2a_message" in self.content
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefTaskLifecycle:
+    """Section 5: Task Lifecycle."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_task_lifecycle_heading(self):
+        assert "Task Lifecycle" in self.content
+
+    def test_message_send_method(self):
+        assert "message/send" in self.content
+
+    def test_message_stream_method(self):
+        assert "message/stream" in self.content
+
+    def test_task_states_documented(self):
+        for state in ["working", "completed", "failed"]:
+            assert state in self.content, f"Task state '{state}' must be documented"
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefErrorMapping:
+    """Section 6: Error Mapping."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_error_mapping_heading(self):
+        assert "Error Mapping" in self.content
+
+    def test_internal_error_documented(self):
+        assert "InternalError" in self.content
+
+    def test_invalid_params_documented(self):
+        assert "InvalidParamsError" in self.content or "InvalidParams" in self.content
+
+    def test_pipeline_error_types_documented(self):
+        assert "LLM_ERROR" in self.content
+        assert "VALIDATION_ERROR" in self.content
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefInterrupt:
+    """Section 7: Interrupt / Human-in-Loop."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_interrupt_heading(self):
+        assert "Interrupt" in self.content or "Human-in-Loop" in self.content
+
+    def test_interrupt_marker_documented(self):
+        assert "__interrupt__" in self.content
+
+    def test_input_required_state(self):
+        assert "input_required" in self.content or "input-required" in self.content
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefAuthentication:
+    """Section 8: Authentication."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_authentication_heading(self):
+        assert "Authentication" in self.content
+
+    def test_reverse_proxy_mentioned(self):
+        assert "reverse proxy" in self.content.lower() or "nginx" in self.content.lower()
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefDeployment:
+    """Section 9: Deployment Patterns."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_deployment_heading(self):
+        assert "Deployment" in self.content
+
+    def test_standalone_pattern(self):
+        assert "standalone" in self.content.lower() or "development" in self.content.lower()
+
+    def test_container_pattern(self):
+        assert "container" in self.content.lower() or "docker" in self.content.lower()
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestA2AServerRefMCPRelationship:
+    """Section 10: Relationship to MCP Server."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = A2A_SERVER_REF.read_text()
+
+    def test_mcp_comparison_heading(self):
+        assert "MCP" in self.content
+
+    def test_transport_comparison(self):
+        assert "stdio" in self.content and "HTTP" in self.content
+
+    def test_shared_discovery(self):
+        assert "discovery.py" in self.content or "discover_graphs" in self.content
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Quickstart example verified against implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestQuickstartMatchesImplementation:
+    """Verify quickstart examples match the actual hello graph."""
+
+    def test_hello_graph_vars_in_doc(self):
+        """Doc quickstart must use variables from the hello graph."""
+        hello = (REPO_ROOT / "examples" / "demos" / "hello" / "graph.yaml").read_text()
+        content = A2A_SERVER_REF.read_text()
+        # hello graph requires name and style
+        assert "name" in hello and "style" in hello
+        # doc must show these variables
+        assert "name" in content and "style" in content
+
+
+# ---------------------------------------------------------------------------
+# AC-4: reference/cli.md updated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestCliRefUpdated:
+    """Verify reference/cli.md includes a2a subcommands."""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.content = CLI_REF.read_text()
+
+    def test_a2a_in_commands_overview(self):
+        assert "a2a" in self.content, "cli.md must mention a2a commands"
+
+    def test_a2a_serve_documented(self):
+        assert "a2a serve" in self.content
+
+    def test_a2a_card_documented(self):
+        assert "a2a card" in self.content
+
+
+# ---------------------------------------------------------------------------
+# AC-5: reference/README.md links to a2a-server.md
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.req("REQ-YG-245")
+class TestRefReadmeUpdated:
+    """Verify reference/README.md links to a2a-server.md."""
+
+    def test_a2a_server_link(self):
+        content = REF_README.read_text()
+        assert (
+            "a2a-server.md" in content
+        ), "reference/README.md must link to a2a-server.md"


### PR DESCRIPTION
## FR-246: A2A Server Reference Documentation

See [feature-requests/FR-246-a2a-server-reference-docs.md](feature-requests/FR-246-a2a-server-reference-docs.md)

### Changes
- Create `reference/a2a-server.md` with all 10 sections: Quickstart, CLI Commands, Agent Card Generation, Message-to-State Mapping, Task Lifecycle, Error Mapping, Interrupt/Human-in-Loop, Authentication, Deployment Patterns, Relationship to MCP Server
- Update `reference/cli.md` with `a2a serve` and `a2a card` commands
- Update `reference/README.md` index with a2a-server.md link
- Add REQ-YG-245 to ARCHITECTURE.md capabilities table
- Add CAP-103 to capability registry
- 46 tests covering all documentation sections (REQ-YG-245)