### PR TITLE
fix(worktree): FR-265 create_worktree drafts ignore fix

### DIFF
--- a/.chaplain/lib/worktree.py
+++ b/.chaplain/lib/worktree.py
@@ -1,0 +1,103 @@
+"""Worktree creation tool for Chaplain copilot pipeline (FR-260, FR-265).
+
+Graph tool function ``create_worktree(state)`` commits a draft FR from
+``.chaplain/drafts/`` to main and creates an isolated git worktree for
+the enforce pipeline.
+
+FR-265 fixes:
+- Uses ``git add -f`` to stage drafts under gitignored paths.
+- Raises ``ValueError`` when multiple drafts exist (deterministic selection).
+- Handles ``nothing to commit`` idempotently; raises on other commit errors.
+"""
+
+import logging
+import subprocess  # noqa: S404
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def create_worktree(state: dict) -> dict:
+    """Commit FR draft to main and create worktree for acceptance tests.
+
+    Uses existing helpers from ``yamlgraph.utils.worktree_helpers``.
+    Returns ``worktree_dir`` and ``branch`` as state update.
+
+    Args:
+        state: Graph state dict with ``drafts_dir`` key.
+
+    Returns:
+        Dict with ``worktree_dir`` and ``branch`` keys.
+
+    Raises:
+        FileNotFoundError: No draft files found in ``drafts_dir``.
+        ValueError: Multiple draft files found (nondeterministic).
+        RuntimeError: ``git commit`` failed for reasons other than
+            "nothing to commit".
+    """
+    from yamlgraph.utils.worktree_helpers import (
+        construct_worktree_path,
+        derive_branch_name,
+        validate_venv_health,
+        validate_venv_symlink,
+    )
+
+    drafts_dir = Path(state["drafts_dir"])
+
+    # --- Deterministic draft selection (FR-265 AC-03) ---
+    fr_files = sorted(drafts_dir.glob("*.md"))
+    if not fr_files:
+        raise FileNotFoundError(f"No draft files found in {drafts_dir}")
+    if len(fr_files) > 1:
+        candidates = [str(f) for f in fr_files]
+        raise ValueError(f"Multiple draft files found in {drafts_dir}: {candidates}")
+
+    draft_path = fr_files[0]
+    logger.info("Staging draft: %s", draft_path)
+
+    # --- Force-add to handle .gitignore (FR-265 AC-01) ---
+    subprocess.run(  # noqa: S603
+        ["git", "add", "-f", str(draft_path)],  # noqa: S607
+        check=True,
+    )
+
+    # --- Idempotent commit (FR-265 AC-05/AC-06) ---
+    result = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "git",
+            "commit",
+            "--no-verify",
+            "-m",
+            f"docs(FR): stage draft {draft_path.name}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        combined = result.stdout + result.stderr
+        if "nothing to commit" in combined:
+            logger.info("Draft already committed (nothing to commit)")
+        else:
+            raise RuntimeError(f"git commit failed: {result.stderr}")
+
+    # --- Derive branch and worktree path ---
+    branch = derive_branch_name(str(draft_path))
+    worktree_dir = construct_worktree_path(branch)
+
+    # --- Create worktree with parent dirs ---
+    Path(worktree_dir).parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(  # noqa: S603
+        ["git", "worktree", "add", worktree_dir, "-b", branch, "main"],  # noqa: S607
+        check=True,
+    )
+
+    # --- Symlink .venv (FR-174: validate BEFORE symlinking) ---
+    main_venv = Path(".venv")
+    validate_venv_health(main_venv)
+
+    wt_venv = Path(worktree_dir) / ".venv"
+    wt_venv.symlink_to(main_venv.resolve())
+    validate_venv_symlink(wt_venv, main_venv)
+
+    logger.info("Worktree ready: %s (branch: %s)", worktree_dir, branch)
+    return {"worktree_dir": worktree_dir, "branch": branch}

--- a/changelog/unreleased/fr-265-create-worktree-drafts-ignore-fix.md
+++ b/changelog/unreleased/fr-265-create-worktree-drafts-ignore-fix.md
@@ -1,6 +1,5 @@
 ---
 type: fix
 scope: worktree
-req: REQ-YG-263
 ---
-- **FR-265 create_worktree drafts ignore fix**: Fix Chaplain pipeline failure where `create_worktree()` ran `git add` on drafts under `.chaplain/drafts/` (excluded by `.gitignore`). Now uses `git add --force` and treats "nothing to commit" as success. (REQ-YG-263)
+- **FR-265 create_worktree drafts ignore fix**: Fix Chaplain pipeline failure where `create_worktree()` ran `git add` on drafts under `.chaplain/drafts/` (excluded by `.gitignore`). Now uses `git add --force` and treats "nothing to commit" as success.

--- a/feature-requests/FR-265-create-worktree-drafts-ignore-fix.md
+++ b/feature-requests/FR-265-create-worktree-drafts-ignore-fix.md
@@ -1,0 +1,123 @@
+# Feature Request: FR-265 create_worktree drafts ignore fix
+
+**Priority:** HIGH
+**Type:** Bug
+**Status:** Implemented
+**Effort:** 0.5 days
+**Requested:** 2026-04-21
+
+## Summary
+
+Fix Chaplain copilot pipeline failure where `.chaplain/lib/worktree.py` runs `git add` on a draft under `.chaplain/drafts/`, but repository `.gitignore` excludes that directory. The python node fails with exit code `1`, stopping the pipeline before acceptance tests and judge complete.
+
+## Value Statement
+
+Chaplain pipeline operators get reliable Plan → Research → Worktree → Acceptance Tests → Judge execution without manual recovery when draft FRs are under ignored paths.
+
+## Problem
+
+`create_worktree()` currently does:
+
+- Locate first `*.md` in `{drafts_dir}` via glob
+- Run `git add <draft_path>`
+- Run `git commit --no-verify ...`
+
+This breaks because root `.gitignore` contains:
+
+- `.chaplain/drafts/`
+
+Observed behavior:
+
+- `git add .chaplain/drafts/<file>.md` returns exit code `1`
+- stderr: "The following paths are ignored by one of your .gitignore files: .chaplain/drafts"
+- Copilot graph node `create_worktree` fails and aborts workflow
+
+Secondary issue: selecting `fr_files[0]` from a glob is nondeterministic when multiple drafts exist.
+
+## Proposed Solution
+
+Update `.chaplain/lib/worktree.py` to make staging deterministic and robust for ignored draft paths.
+
+1. Add explicit staging for ignored path:
+
+```bash
+git add -f <draft_path>
+```
+
+2. Keep commit behavior idempotent:
+
+- If `git commit` returns non-zero with "nothing to commit", continue
+- Any other git failure should raise
+
+3. Remove nondeterministic draft selection:
+
+- If no draft files: raise `FileNotFoundError` (existing behavior)
+- If multiple draft files: raise a clear `ValueError` naming candidates
+- If exactly one: proceed
+
+4. Add focused unit tests for the tool behavior using subprocess mocks.
+
+## Acceptance Criteria
+
+- [x] **AC-01:** `create_worktree()` stages draft FR file with forced add (`git add -f <draft_path>`)
+- [x] **AC-02:** Pipeline no longer fails when draft file is under ignored `.chaplain/drafts/`
+- [x] **AC-03:** `create_worktree()` fails fast with clear `ValueError` when multiple draft files exist
+- [x] **AC-04:** Existing single-draft happy path still succeeds
+- [x] **AC-05:** If `git commit` fails with "nothing to commit", pipeline continues (idempotent)
+- [x] **AC-06:** If `git commit` fails for other reasons (not "nothing to commit"), node raises with clear message
+- [x] **AC-07:** Unit tests added for ignored-path staging, multi-draft guard, and commit idempotency
+- [x] **AC-08:** No changes to `watch.sh` orchestration contract
+- [x] **AC-09:** Draft file remains on disk in `.chaplain/drafts/` after commit (downstream nodes read it)
+
+## Alternatives Considered
+
+### 1) Remove `.chaplain/drafts/` from `.gitignore`
+
+Rejected. Draft and inbox directories are intentionally ignored to avoid committing volatile planning artifacts.
+
+### 2) Copy/move draft into `feature-requests/` before worktree creation
+
+Rejected for this fix. It changes pipeline semantics and interferes with `watch.sh` "new FR detection" timing and judge/amend flow.
+
+### 3) Pass explicit draft path through graph state and stop globbing
+
+Valid follow-up hardening, but not required for the immediate failure. This FR keeps scope to the concrete git-ignore failure plus deterministic selection guard.
+
+## Related
+
+- Issue: `https://github.com/sheikkinen/yamlgraph/issues/148`
+- `.chaplain/lib/worktree.py`
+- `.chaplain/graphs/copilot/graph.yaml`
+- `.chaplain/watch.sh`
+- `feature-requests/FR-260-acceptance-tests-before-enforce.md`
+
+## Judge Verdict
+
+**APPROVE** — scope frozen, authority granted.
+
+### Evaluation
+
+1. **Scope clear and minimal?** Yes. Single root cause (`git add` on ignored path), single file to change, with two defensive hardening items (multi-draft guard, commit idempotency) that are tightly coupled.
+
+2. **Contradictions or ambiguities?** None after amendments. Three gaps identified and resolved:
+   - **AC gap (commit idempotency):** Proposed solution mentioned handling "nothing to commit" but ACs didn't cover it. Added AC-05 and AC-06.
+   - **AC gap (draft file survival):** `write_acceptance_tests` and `judge` nodes both read from `{drafts_dir}` after `create_worktree` commits. The fix must not delete or move the draft. Added AC-09.
+   - **AC numbering:** Added explicit AC-XX IDs for traceability.
+
+3. **Acceptance criteria measurable?** Yes — each AC maps to a specific assertion in unit tests.
+
+4. **Implementation approach feasible?** Yes. Three-line change (`git add` → `git add -f`, multi-draft guard, commit stderr inspection). No new modules or dependencies.
+
+5. **Alignment with architecture?** Yes. Follows boundary normalization principle — fixing at the entry point (`git add`) rather than downstream.
+
+6. **Single responsibility?** Yes. All three changes address the same root cause: `create_worktree()` fragility when operating on ignored paths.
+
+7. **Classification:** Bug fix on existing infrastructure. Not a framework primitive, not a pattern — a concrete defect in the Chaplain pipeline.
+
+### Risks verified
+
+| Risk | Status |
+|------|--------|
+| `git add -f` causes file accumulation on main | Acceptable — judge verdicts move/delete drafts; procedural, not technical |
+| Moving draft to `feature-requests/` earlier would be cleaner | Rejected — breaks `write_acceptance_tests` and `judge` prompts that read from `{drafts_dir}` |
+| `feature-requests/` path in `enforce_worktree.sh` has same bug | Confirmed NOT affected — `feature-requests/` is not in `.gitignore` |

--- a/tests/unit/test_acceptance_tests_before_enforce.py
+++ b/tests/unit/test_acceptance_tests_before_enforce.py
@@ -367,7 +367,9 @@ class TestCreateWorktreeToolUnit:
         monkeypatch.setattr(subprocess, "run", mock_run)
 
         # Mock os.symlink to avoid actual symlink creation
-        monkeypatch.setattr("os.symlink", lambda src, dst: None)
+        monkeypatch.setattr(
+            "os.symlink", lambda src, dst, target_is_directory=False: None
+        )
 
         # Mock venv validators to avoid filesystem checks
         import yamlgraph.utils.worktree_helpers as wh

--- a/tests/unit/test_create_worktree.py
+++ b/tests/unit/test_create_worktree.py
@@ -1,0 +1,215 @@
+"""Unit tests for .chaplain/lib/worktree.py create_worktree() (FR-265).
+
+Tests force-add staging, multi-draft guard, commit idempotency,
+and draft file survival using mocked subprocess + real tmp_path filesystem.
+"""
+
+import importlib.util
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Load create_worktree from non-package .chaplain/lib/worktree.py
+_WORKTREE_PY = (
+    Path(__file__).resolve().parent.parent.parent / ".chaplain" / "lib" / "worktree.py"
+)
+
+
+def _load_create_worktree():
+    """Import create_worktree via importlib (non-package path)."""
+    spec = importlib.util.spec_from_file_location("chaplain_worktree", _WORKTREE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.create_worktree
+
+
+@contextmanager
+def _mock_git_and_venv(run_side_effect):
+    """Patch subprocess.run, Path.symlink_to, and venv validators."""
+    with (
+        patch("subprocess.run", side_effect=run_side_effect),
+        patch.object(Path, "symlink_to"),
+        patch("yamlgraph.utils.worktree_helpers.validate_venv_health"),
+        patch("yamlgraph.utils.worktree_helpers.validate_venv_symlink"),
+    ):
+        yield
+
+
+def _ok_run(cmd, **kwargs):
+    """Default mock returning success for all subprocess calls."""
+    return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+
+@pytest.mark.req("REQ-YG-106")
+class TestCreateWorktreeForceAdd:
+    """AC-01: create_worktree() stages draft FR file with git add -f."""
+
+    def test_force_adds_draft_file(self, tmp_path):
+        """git add -f is called, not plain git add."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        draft = drafts / "FR-100-test-feature.md"
+        draft.write_text("# FR-100 Test Feature\n")
+
+        calls_made = []
+
+        def mock_run(cmd, **kwargs):
+            calls_made.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        with _mock_git_and_venv(mock_run):
+            create_worktree({"drafts_dir": str(drafts)})
+
+        # Find the git add (not git worktree add) call
+        add_calls = [c for c in calls_made if c[:2] == ["git", "add"]]
+        assert len(add_calls) == 1, f"Expected one git add call, got: {add_calls}"
+        assert "-f" in add_calls[0], f"Expected -f flag: {add_calls[0]}"
+
+
+@pytest.mark.req("REQ-YG-106")
+class TestCreateWorktreeMultiDraftGuard:
+    """AC-03: create_worktree() fails fast with ValueError for multiple drafts."""
+
+    def test_raises_on_multiple_drafts(self, tmp_path):
+        """Multiple draft files raise ValueError naming candidates."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        (drafts / "FR-100-first.md").write_text("# First\n")
+        (drafts / "FR-101-second.md").write_text("# Second\n")
+
+        with pytest.raises(ValueError, match="Multiple draft files"):
+            create_worktree({"drafts_dir": str(drafts)})
+
+    def test_raises_on_no_drafts(self, tmp_path):
+        """No draft files raise FileNotFoundError."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+
+        with pytest.raises(FileNotFoundError, match="No draft files"):
+            create_worktree({"drafts_dir": str(drafts)})
+
+
+@pytest.mark.req("REQ-YG-106")
+class TestCreateWorktreeHappyPath:
+    """AC-04: Single-draft happy path succeeds and returns correct dict."""
+
+    def test_single_draft_returns_worktree_dir_and_branch(self, tmp_path):
+        """Returns dict with worktree_dir and branch keys."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        draft = drafts / "FR-100-test-feature.md"
+        draft.write_text("# FR-100 Test Feature\n")
+
+        with _mock_git_and_venv(_ok_run):
+            result = create_worktree({"drafts_dir": str(drafts)})
+
+        assert "worktree_dir" in result
+        assert "branch" in result
+        assert result["branch"] == "feat/fr-100-test-feature"
+        assert "tmp/worktrees/" in result["worktree_dir"]
+
+
+@pytest.mark.req("REQ-YG-106")
+class TestCreateWorktreeCommitIdempotency:
+    """AC-05/AC-06: Commit idempotency and error handling."""
+
+    def test_nothing_to_commit_in_stdout_continues(self, tmp_path):
+        """git commit returning 'nothing to commit' in stdout does not raise."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        (drafts / "FR-100-test.md").write_text("# Test\n")
+
+        def mock_run(cmd, **kwargs):
+            if "commit" in list(cmd):
+                return subprocess.CompletedProcess(
+                    cmd,
+                    returncode=1,
+                    stdout="On branch main\nnothing to commit, working tree clean\n",
+                    stderr="",
+                )
+            return _ok_run(cmd, **kwargs)
+
+        with _mock_git_and_venv(mock_run):
+            result = create_worktree({"drafts_dir": str(drafts)})
+
+        assert result["branch"] == "feat/fr-100-test"
+
+    def test_nothing_to_commit_in_stderr_continues(self, tmp_path):
+        """git commit returning 'nothing to commit' in stderr does not raise."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        (drafts / "FR-100-test.md").write_text("# Test\n")
+
+        def mock_run(cmd, **kwargs):
+            if "commit" in list(cmd):
+                return subprocess.CompletedProcess(
+                    cmd,
+                    returncode=1,
+                    stdout="",
+                    stderr="nothing to commit\n",
+                )
+            return _ok_run(cmd, **kwargs)
+
+        with _mock_git_and_venv(mock_run):
+            result = create_worktree({"drafts_dir": str(drafts)})
+
+        assert result["branch"] == "feat/fr-100-test"
+
+    def test_other_commit_error_raises(self, tmp_path):
+        """git commit failure (not 'nothing to commit') raises RuntimeError."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        (drafts / "FR-100-test.md").write_text("# Test\n")
+
+        def mock_run(cmd, **kwargs):
+            if "commit" in list(cmd):
+                return subprocess.CompletedProcess(
+                    cmd,
+                    returncode=128,
+                    stdout="",
+                    stderr="fatal: not a git repository\n",
+                )
+            return _ok_run(cmd, **kwargs)
+
+        with (
+            patch("subprocess.run", side_effect=mock_run),
+            pytest.raises(RuntimeError, match="git commit failed"),
+        ):
+            create_worktree({"drafts_dir": str(drafts)})
+
+
+@pytest.mark.req("REQ-YG-106")
+class TestCreateWorktreeDraftSurvival:
+    """AC-09: Draft file remains on disk after commit."""
+
+    def test_draft_file_not_deleted(self, tmp_path):
+        """After create_worktree(), draft file still exists on disk."""
+        create_worktree = _load_create_worktree()
+
+        drafts = tmp_path / "drafts"
+        drafts.mkdir()
+        draft = drafts / "FR-100-test.md"
+        draft.write_text("# FR-100 Test\n")
+
+        with _mock_git_and_venv(_ok_run):
+            create_worktree({"drafts_dir": str(drafts)})
+
+        assert draft.exists(), "Draft file should still exist after create_worktree()"
+        assert draft.read_text() == "# FR-100 Test\n"


### PR DESCRIPTION
## Summary

Fix Chaplain pipeline failure where `create_worktree()` runs `git add` on drafts under `.chaplain/drafts/`, but `.gitignore` excludes that directory — causing exit code 1 and pipeline halt.

### Changes
- Use `git add --force` to override `.gitignore` for draft FR files
- Idempotent commit: treat 'nothing to commit' as success (exit 1 with empty diff)
- Tests: 6 unit tests covering force-add, idempotent commit, error paths

See FR at `feature-requests/FR-265-create-worktree-drafts-ignore-fix.md`