### PR TITLE
feat(cli): FR-269 add --import-state and --export-state flags

### DIFF
--- a/.chaplain/drafts/FR-269-cli-inter-run-state-chaining.md
+++ b/.chaplain/drafts/FR-269-cli-inter-run-state-chaining.md
@@ -1,0 +1,192 @@
+# Feature Request: FR-269 CLI Inter-Run State Chaining (`--import-state` / `--export-state`)
+
+**Priority:** MEDIUM
+**Type:** Feature
+**Status:** Proposed
+**Effort:** 1 day
+**Requested:** 2026-04-22
+
+## Summary
+
+Add `--export-state <path>` and `--import-state <path>` flags to `yamlgraph graph run`, enabling external orchestrators to chain separate graph invocations across shell boundaries while preserving state — including `CopilotResult.session_id` for copilot session resume.
+
+## Value Statement
+
+Pipeline authors can chain independent `yamlgraph graph run` calls across shell boundaries without losing state, enabling patterns like plan → shell tests → enforce with session continuity.
+
+## Problem
+
+Each `yamlgraph graph run` invocation is stateless — state produced by one run is unavailable to the next. External orchestrators (shell scripts, CI pipelines) that execute commands between graph invocations have no mechanism to hand off state explicitly.
+
+The concrete pain point is the watcher2 pipeline:
+
+1. Run a `plan` graph → produces `CopilotResult` with a `session_id`
+2. Run shell commands between graph invocations (`pytest`, `git commit`, `pre-commit`)
+3. Run an `enforce` graph → must resume the prior copilot session by reading `session_id`
+
+Currently step 3 has no access to state from step 1.
+
+Passing `session_id` via `--var` is fragile: callers must know the key name and parse it from the previous run's stdout, coupling the caller to output format.
+
+## Proposed Solution
+
+Two new flags on `yamlgraph graph run`:
+
+### `--export-state <path>`
+
+Writes the full post-run graph state as JSON to the explicit path provided.
+
+```bash
+yamlgraph graph run plan.yaml \
+  --var topic_file="$TOPIC" \
+  --export-state tmp/state.json \
+  --full
+```
+
+- Serializes the entire state dict using the existing `_serialize_state()` logic (Pydantic models via `.model_dump()`)
+- Writes to the explicit path (not a timestamped auto-generated name)
+- Creates parent directories if they do not exist
+- Distinct from the existing `--export` flag, which exports specific fields via the graph's `exports:` YAML config
+
+### `--import-state <path>`
+
+Loads a previously exported state JSON as the base initial state before the run.
+
+```bash
+yamlgraph graph run enforce.yaml \
+  --import-state tmp/state.json \
+  --full
+```
+
+Merge priority (highest last wins):
+
+```
+imported JSON state < --var-file values < --var CLI values
+```
+
+Combined chaining example:
+
+```bash
+# Step 1: Plan graph — export state
+yamlgraph graph run plan.yaml --var topic_file="$TOPIC" --export-state tmp/state.json --full
+
+# Step 2: Shell scripts run between graph invocations
+pytest tests/ -x --no-cov -q
+git add -A && git commit -m "..."
+
+# Step 3: Enforce graph — import prior state (session_id available for resume)
+yamlgraph graph run enforce.yaml --import-state tmp/state.json --full
+```
+
+### Round-trip fidelity
+
+`CopilotResult` objects serialize to plain dicts via `.model_dump()`. On import they remain plain dicts. The existing `resolve_state_expression()` in `expressions.py` handles both dict key access and object attribute access (`isinstance(value, dict)` checked first), so `{state.prev_result.session_id}` resolves correctly from either form.
+
+## Acceptance Criteria
+
+- [ ] `--export-state <path>` writes the full post-run state to `<path>` as JSON
+- [ ] `--export-state` creates parent directories if they are missing
+- [ ] `--import-state <path>` loads state from `<path>` and uses it as the base initial state
+- [ ] Merge order: imported state < `--var-file` < `--var` (CLI vars always win)
+- [ ] `--import-state` combined with `--var` overrides: `--var` values overwrite matching imported keys
+- [ ] Round-trip: `CopilotResult.session_id` survives export → import and is accessible via `{state.prev_result.session_id}` in graph YAML
+- [ ] Both flags are independent (usable alone or together)
+- [ ] `--import-state` with a non-existent file prints a clear error message and exits 1
+- [ ] `--export-state` failure (permissions, invalid path) prints a clear error message and exits 1
+- [ ] Tests cover: export then import round-trip, merge precedence (imported < var-file < var), missing file error
+- [ ] `yamlgraph graph run --help` shows both new flags with description
+- [ ] REQ-YG-267 and REQ-YG-268 added to `ARCHITECTURE.md` capabilities table
+
+## Implementation Approach
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `yamlgraph/cli/__init__.py` | Add `--export-state` and `--import-state` argument definitions to `graph_run_parser` |
+| `yamlgraph/cli/graph_commands.py` | In `cmd_graph_run()`: load imported state before `_build_run_config()`; call export after successful run |
+| `yamlgraph/storage/export.py` | Add `export_state_to_path(state, path)` writing to an explicit filepath (wraps `_serialize_state()`) |
+| `ARCHITECTURE.md` | Add REQ-YG-267 and REQ-YG-268 to capabilities table |
+
+### Argument definitions (`cli/__init__.py`)
+
+```python
+graph_run_parser.add_argument(
+    "--import-state",
+    type=str,
+    default=None,
+    dest="import_state",
+    help="Load initial state from JSON file exported by --export-state",
+)
+graph_run_parser.add_argument(
+    "--export-state",
+    type=str,
+    default=None,
+    dest="export_state",
+    help="Write full state JSON to this path after run (for inter-run chaining)",
+)
+```
+
+### State merge in `cmd_graph_run()` (`graph_commands.py`)
+
+```python
+# After parse_vars / var_file loading, before _build_run_config:
+if args.import_state:
+    import_path = Path(args.import_state)
+    if not import_path.exists():
+        print(f"❌ --import-state file not found: {import_path}")
+        sys.exit(1)
+    from yamlgraph.storage.export import load_export
+    imported = load_export(import_path)
+    initial_state = {**imported, **file_vars, **cli_vars}
+else:
+    initial_state = {**file_vars, **cli_vars}
+```
+
+### New export helper (`storage/export.py`)
+
+```python
+def export_state_to_path(state: dict, path: str | Path) -> Path:
+    """Export full pipeline state to an explicit file path.
+
+    Used by --export-state CLI flag for inter-run state chaining.
+    """
+    filepath = Path(path)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with open(filepath, "w") as f:
+        json.dump(_serialize_state(state), f, indent=2, default=str)
+    return filepath
+```
+
+### Export call in `cmd_graph_run()` (after result)
+
+```python
+if getattr(args, "export_state", None):
+    from yamlgraph.storage.export import export_state_to_path
+    p = export_state_to_path(result, args.export_state)
+    print(f"\n💾 State exported: {p}")
+```
+
+## Constraints
+
+- `--export-state` is **distinct** from the existing `--export` flag (field-level YAML `exports:` config). No change to existing `--export` behavior.
+- Imported state is shallow-merged at the top level only. Deep merging of nested dicts is out of scope.
+- No type reconstruction on import: Pydantic models remain plain dicts after round-trip. Graph YAML must use dict-compatible state expressions — already satisfied by `resolve_state_expression()`.
+- No schema validation of the imported JSON against the graph's state class — out of scope.
+
+## Alternatives Considered
+
+- **Extend `--export` to accept a path**: `--export` is currently `action="store_true"` and semantically refers to field-level YAML exports. Overloading it would be confusing and break existing behavior.
+- **Checkpoint/resume via LangGraph checkpointer**: Requires matching `thread_id` and a persistent checkpointer (SQLite/Redis). Too heavy for shell-script orchestration. Complements but does not replace this feature.
+- **Pass `session_id` via `--var`**: Requires callers to know the key name and parse it from the previous run's stdout. Fragile and couples the caller to output format.
+
+## Related
+
+- `yamlgraph/storage/export.py` — `export_state()`, `load_export()`, `_serialize_state()`
+- `yamlgraph/cli/__init__.py` — argument parser
+- `yamlgraph/cli/graph_commands.py` — `cmd_graph_run()`, `_build_run_config()`
+- `yamlgraph/utils/expressions.py` — `resolve_state_expression()` (handles dict + object access)
+- `yamlgraph/models/schemas.py` — `CopilotResult` (session_id field)
+- `docs/refactoring-watcher-pipeline-v3.md` section 7 — design rationale
+- REQ-YG-267: `--import-state` loads exported JSON as initial graph state
+- REQ-YG-268: `--export-state` writes full run state to an explicit JSON path

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -391,6 +391,7 @@ Run `python scripts/aggregate_capabilities.py` to regenerate the sections below.
 | 117 | Race Node parse_json & Content Normalization | `yamlgraph/node_factory/race_node.py`, `yamlgraph/utils/content.py` | REQ-YG-264 |
 | 118 | Copilot Node Model Selection (FR-266) | `yamlgraph/models/graph_schema.py`, `yamlgraph/node_compiler.py`, `yamlgraph/node_factory/copilot_node.py` | REQ-YG-265 |
 | 119 | Race Node Timeout Fix (FR-267) | `yamlgraph/node_factory/race_node.py`, `yamlgraph/node_compiler.py` | REQ-YG-266 |
+| 120 | CLI Inter-Run State Chaining (FR-269) | `yamlgraph/cli/__init__.py`, `yamlgraph/cli/graph_commands.py`, `yamlgraph/storage/export.py` | REQ-YG-267, REQ-YG-268 |
 
 | 116 | Acceptance Tests Before Enforce | `.chaplain/graphs/copilot/graph.yaml`, `.chaplain/graphs/copilot/prompts/write-acceptance-tests.yaml`, `.chaplain/graphs/copilot/prompts/judge.yaml`, `.chaplain/graphs/enforce/prompts/enforce-implement.yaml`, … | REQ-YG-263 |
 
@@ -1561,6 +1562,17 @@ Race node applies exactly one timeout mechanism — its native `as_completed(tim
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
 | REQ-YG-266 | Race node applies exactly one timeout mechanism — its native `as_completed(timeout=...)`; `_compile_race_node` must NOT call `_maybe_wrap_timeout`; on timeout expiry (no candidate succeeds within deadline), race node produces `PipelineError(TIMEOUT_ERROR)` and respects `on_error` config; without `on_error`, raises `AllCandidatesFailedError`; race `timeout` is total race deadline, not per-candidate | `yamlgraph/node_factory/race_node.py`, `yamlgraph/node_compiler.py`, `tests/unit/test_race_node.py` |
+
+### 120. CLI Inter-Run State Chaining (FR-269)
+
+`--import-state` and `--export-state` flags for `yamlgraph graph run` enabling external orchestrators to chain graph invocations across shell boundaries while preserving state.
+
+**Feature Request:** FR-269
+
+| Requirement | Description | Key Modules |
+|------------|-------------|-------------|
+| REQ-YG-267 | `--import-state <path>` loads exported JSON as initial graph state; merge order is `graph_config.data < imported < --var-file < --var`; missing file prints clear error and exits 1; malformed JSON prints clear error and exits 1 | `yamlgraph/cli/__init__.py`, `yamlgraph/cli/graph_commands.py`, `tests/unit/test_cli_inter_run_state_chaining.py` |
+| REQ-YG-268 | `--export-state <path>` writes full post-run state to explicit JSON path using `_serialize_state()`; creates parent directories; write failures print clear error and exit 1; `CopilotResult.session_id` survives round-trip and resolves via `resolve_state_expression()` | `yamlgraph/cli/graph_commands.py`, `yamlgraph/storage/export.py`, `tests/unit/test_cli_inter_run_state_chaining.py` |
 
 <!-- END GENERATED CAPABILITIES -->
 

--- a/capabilities/CAP-120-cli-inter-run-state-chaining.yaml
+++ b/capabilities/CAP-120-cli-inter-run-state-chaining.yaml
@@ -1,0 +1,36 @@
+id: CAP-120
+name: CLI Inter-Run State Chaining
+description: >
+  --import-state and --export-state flags for yamlgraph graph run
+  enabling external orchestrators to chain graph invocations across
+  shell boundaries while preserving state, including
+  CopilotResult.session_id for copilot session resume.
+modules:
+  - yamlgraph/cli/__init__.py
+  - yamlgraph/cli/graph_commands.py
+  - yamlgraph/cli/helpers.py
+  - yamlgraph/storage/export.py
+requirements:
+  - id: REQ-YG-267
+    description: >
+      --import-state loads exported JSON as initial graph state;
+      merge order is graph_config.data < imported < --var-file < --var;
+      missing file prints clear error and exits 1; malformed JSON
+      prints clear error and exits 1
+    modules:
+      - yamlgraph/cli/__init__.py
+      - yamlgraph/cli/graph_commands.py
+      - yamlgraph/cli/helpers.py
+      - tests/unit/test_cli_inter_run_state_chaining.py
+  - id: REQ-YG-268
+    description: >
+      --export-state writes full post-run state to explicit JSON path
+      using _serialize_state(); creates parent directories; write
+      failures print clear error and exit 1; CopilotResult.session_id
+      survives round-trip and resolves via resolve_state_expression()
+    modules:
+      - yamlgraph/cli/graph_commands.py
+      - yamlgraph/cli/helpers.py
+      - yamlgraph/storage/export.py
+      - tests/unit/test_cli_inter_run_state_chaining.py
+fr: FR-269

--- a/changelog/unreleased/fr-269-cli-inter-run-state-chaining.md
+++ b/changelog/unreleased/fr-269-cli-inter-run-state-chaining.md
@@ -1,0 +1,6 @@
+---
+type: feat
+scope: cli
+req: REQ-YG-267
+---
+- **FR-269 CLI Inter-Run State Chaining**: `--import-state` and `--export-state` flags for `yamlgraph graph run` enable external orchestrators to chain graph invocations across shell boundaries while preserving state, including `CopilotResult.session_id` for copilot session resume. (REQ-YG-267, REQ-YG-268)

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -113,7 +113,7 @@ Framework suppressions require elevated scrutiny. These live in `yamlgraph/`.
 - **Penance**: These are public re-exports for backward compatibility — tests and external consumers import from `yamlgraph.a2a_server`. The actual logic lives in `yamlgraph.a2a_message` after the module split to stay under 450 lines.
 
 ### CONF-005
-- **File**: [yamlgraph/cli/__init__.py](../yamlgraph/cli/__init__.py#L258)
+- **File**: [yamlgraph/cli/__init__.py](../yamlgraph/cli/__init__.py#L272)
 - **Code**: S104
 - **Sin**: A2A server CLI default host is `0.0.0.0` (binds to all interfaces).
 - **Penance**: Intentional for server CLI commands. Users override via `--host`. Binding to all interfaces is the standard default for development servers.

--- a/docs/diary/2026-04-22-reflection-fr-269-cli-inter-run-state-chaining.md
+++ b/docs/diary/2026-04-22-reflection-fr-269-cli-inter-run-state-chaining.md
@@ -1,0 +1,25 @@
+# Reflection: FR-269 CLI Inter-Run State Chaining
+
+**Date:** 2026-04-22
+**FR:** FR-269
+**Branch:** feat/fr-269-cli-inter-run-state-chaining
+
+## What Was Done
+
+Added `--import-state` and `--export-state` flags to `yamlgraph graph run`, enabling external orchestrators (shell scripts, CI pipelines) to chain graph invocations across shell boundaries while preserving state — including `CopilotResult.session_id` for copilot session resume.
+
+Implementation: `export_state_to_path()` in `storage/export.py`, `load_imported_state()` and `handle_state_export()` in `cli/helpers.py`, parser arguments in `cli/__init__.py`, and wiring in `cmd_graph_run()`. Merge precedence: `graph_config.data < imported < var-file < var`.
+
+## Cognitive Trap: Infrastructure Self-Exempt
+
+The enforcement infrastructure itself (pre-commit hooks, capability registry, confession tracking, file-size gates) consumed more implementation effort than the actual feature. The feature was ~30 lines of logic; the compliance artifacts (CAP-120, CONF-005 line shift, REQ-YG-267/268 tags, changelog fragment) required ~5 separate iterations to satisfy all gates.
+
+This isn't a complaint — it's the **infrastructure_self_exempt** trap in reverse: the gates work exactly because they're strict. But the cognitive risk is losing sight of the feature while chasing hook compliance. The cure is to treat gate satisfaction as a predictable post-implementation checklist, not a discovery process.
+
+## Heuristic
+
+**Gate compliance is a checklist, not a debugging session**: After implementing any `feat` change, mechanically walk the gate list before the first commit attempt: (1) capability YAML, (2) req tags on tests, (3) changelog fragment with valid `req:` front-matter, (4) ARCHITECTURE.md entries, (5) confession updates for shifted noqa lines, (6) file-size check. Running `pre-commit run --all-files` first (before `git commit`) surfaces all failures in one pass rather than iteratively through failed commit attempts.
+
+## Seed
+
+Could the acceptance test writer (`.chaplain/graphs/copilot/prompts/write-acceptance-tests.yaml`) be extended to also generate a gate-compliance skeleton — the CAP YAML, changelog fragment, and ARCHITECTURE.md entries — as part of the RED commit? This would shift gate compliance left, making it part of the test contract rather than a post-implementation discovery.

--- a/feature-requests/FR-269-cli-inter-run-state-chaining.md
+++ b/feature-requests/FR-269-cli-inter-run-state-chaining.md
@@ -1,0 +1,203 @@
+# Feature Request: FR-269 CLI Inter-Run State Chaining (`--import-state` / `--export-state`)
+
+**Priority:** MEDIUM
+**Type:** Feature
+**Status:** Implemented
+**Effort:** 1 day
+**Requested:** 2026-04-22
+
+## Summary
+
+Add `--export-state <path>` and `--import-state <path>` flags to `yamlgraph graph run`, enabling external orchestrators to chain separate graph invocations across shell boundaries while preserving state — including `CopilotResult.session_id` for copilot session resume.
+
+## Value Statement
+
+Pipeline authors can chain independent `yamlgraph graph run` calls across shell boundaries without losing state, enabling patterns like plan → shell tests → enforce with session continuity.
+
+## Problem
+
+Each `yamlgraph graph run` invocation is stateless — state produced by one run is unavailable to the next. External orchestrators (shell scripts, CI pipelines) that execute commands between graph invocations have no mechanism to hand off state explicitly.
+
+The concrete pain point is the watcher2 pipeline:
+
+1. Run a `plan` graph → produces `CopilotResult` with a `session_id`
+2. Run shell commands between graph invocations (`pytest`, `git commit`, `pre-commit`)
+3. Run an `enforce` graph → must resume the prior copilot session by reading `session_id`
+
+Currently step 3 has no access to state from step 1.
+
+Passing `session_id` via `--var` is fragile: callers must know the key name and parse it from the previous run's stdout, coupling the caller to output format.
+
+## Proposed Solution
+
+Two new flags on `yamlgraph graph run`:
+
+### `--export-state <path>`
+
+Writes the full post-run graph state as JSON to the explicit path provided.
+
+```bash
+yamlgraph graph run plan.yaml \
+  --var topic_file="$TOPIC" \
+  --export-state tmp/state.json \
+  --full
+```
+
+- Serializes the entire state dict using the existing `_serialize_state()` logic (Pydantic models via `.model_dump()`)
+- Writes to the explicit path (not a timestamped auto-generated name)
+- Creates parent directories if they do not exist
+- Distinct from the existing `--export` flag, which exports specific fields via the graph's `exports:` YAML config
+
+### `--import-state <path>`
+
+Loads a previously exported state JSON as the base initial state before the run.
+
+```bash
+yamlgraph graph run enforce.yaml \
+  --import-state tmp/state.json \
+  --full
+```
+
+Merge priority (highest last wins):
+
+```
+graph_config.data < imported JSON state < --var-file values < --var CLI values
+```
+
+`graph_config.data` is the graph YAML's `data:` section, merged as the base by `_build_run_config()`. The imported state sits above it so explicit prior-run values override graph defaults.
+
+Combined chaining example:
+
+```bash
+# Step 1: Plan graph — export state
+yamlgraph graph run plan.yaml --var topic_file="$TOPIC" --export-state tmp/state.json --full
+
+# Step 2: Shell scripts run between graph invocations
+pytest tests/ -x --no-cov -q
+git add -A && git commit -m "..."
+
+# Step 3: Enforce graph — import prior state (session_id available for resume)
+yamlgraph graph run enforce.yaml --import-state tmp/state.json --full
+```
+
+### Round-trip fidelity
+
+`CopilotResult` objects serialize to plain dicts via `.model_dump()`. On import they remain plain dicts. The existing `resolve_state_expression()` in `expressions.py` handles both dict key access and object attribute access (`isinstance(value, dict)` checked first), so `{state.prev_result.session_id}` resolves correctly from either form.
+
+## Acceptance Criteria
+
+- [ ] `--export-state <path>` writes the full post-run state to `<path>` as JSON
+- [ ] `--export-state` creates parent directories if they are missing
+- [ ] `--import-state <path>` loads state from `<path>` and uses it as the base initial state
+- [ ] Merge order: imported state < `--var-file` < `--var` (CLI vars always win)
+- [ ] `--import-state` combined with `--var` overrides: `--var` values overwrite matching imported keys
+- [ ] Round-trip: `CopilotResult.session_id` survives export → import and is accessible via `{state.prev_result.session_id}` in graph YAML
+- [ ] Both flags are independent (usable alone or together)
+- [ ] `--import-state` with a non-existent file prints a clear error message and exits 1
+- [ ] `--import-state` with malformed JSON prints a clear error message and exits 1
+- [ ] `--export-state` failure (permissions, invalid path, directory collision) prints a clear error message and exits 1
+- [ ] Tests cover: export then import round-trip, merge precedence (imported < var-file < var), missing file error
+- [ ] `yamlgraph graph run --help` shows both new flags with description
+- [ ] REQ-YG-267 and REQ-YG-268 added to `ARCHITECTURE.md` capabilities table
+
+## Implementation Approach
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `yamlgraph/cli/__init__.py` | Add `--export-state` and `--import-state` argument definitions to `graph_run_parser` |
+| `yamlgraph/cli/graph_commands.py` | In `cmd_graph_run()`: load imported state before `_build_run_config()`; call export after successful run |
+| `yamlgraph/storage/export.py` | Add `export_state_to_path(state, path)` writing to an explicit filepath (wraps `_serialize_state()`) |
+| `ARCHITECTURE.md` | Add REQ-YG-267 and REQ-YG-268 to capabilities table |
+
+### Argument definitions (`cli/__init__.py`)
+
+```python
+graph_run_parser.add_argument(
+    "--import-state",
+    type=str,
+    default=None,
+    dest="import_state",
+    help="Load initial state from JSON file exported by --export-state",
+)
+graph_run_parser.add_argument(
+    "--export-state",
+    type=str,
+    default=None,
+    dest="export_state",
+    help="Write full state JSON to this path after run (for inter-run chaining)",
+)
+```
+
+### State merge in `cmd_graph_run()` (`graph_commands.py`)
+
+```python
+# After parse_vars / var_file loading, before _build_run_config:
+if args.import_state:
+    import_path = Path(args.import_state)
+    if not import_path.exists():
+        print(f"❌ --import-state file not found: {import_path}")
+        sys.exit(1)
+    from yamlgraph.storage.export import load_export
+    try:
+        imported = load_export(import_path)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"❌ --import-state invalid JSON: {import_path}\n  {e}")
+        sys.exit(1)
+    initial_state = {**imported, **file_vars, **cli_vars}
+else:
+    initial_state = {**file_vars, **cli_vars}
+```
+
+### New export helper (`storage/export.py`)
+
+```python
+def export_state_to_path(state: dict, path: str | Path) -> Path:
+    """Export full pipeline state to an explicit file path.
+
+    Used by --export-state CLI flag for inter-run state chaining.
+    """
+    filepath = Path(path)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with open(filepath, "w") as f:
+        json.dump(_serialize_state(state), f, indent=2, default=str)
+    return filepath
+```
+
+### Export call in `cmd_graph_run()` (after result)
+
+```python
+if getattr(args, "export_state", None):
+    from yamlgraph.storage.export import export_state_to_path
+    try:
+        p = export_state_to_path(result, args.export_state)
+        print(f"\n💾 State exported: {p}")
+    except (OSError, IsADirectoryError) as e:
+        print(f"\n❌ --export-state error writing {args.export_state}\n  {e}")
+        sys.exit(1)
+```
+
+## Constraints
+
+- `--export-state` is **distinct** from the existing `--export` flag (field-level YAML `exports:` config). No change to existing `--export` behavior.
+- Imported state is shallow-merged at the top level only. Deep merging of nested dicts is out of scope.
+- No type reconstruction on import: Pydantic models remain plain dicts after round-trip. Graph YAML must use dict-compatible state expressions — already satisfied by `resolve_state_expression()`.
+- No schema validation of the imported JSON against the graph's state class — out of scope.
+
+## Alternatives Considered
+
+- **Extend `--export` to accept a path**: `--export` is currently `action="store_true"` and semantically refers to field-level YAML exports. Overloading it would be confusing and break existing behavior.
+- **Checkpoint/resume via LangGraph checkpointer**: Requires matching `thread_id` and a persistent checkpointer (SQLite/Redis). Too heavy for shell-script orchestration. Complements but does not replace this feature.
+- **Pass `session_id` via `--var`**: Requires callers to know the key name and parse it from the previous run's stdout. Fragile and couples the caller to output format.
+
+## Related
+
+- `yamlgraph/storage/export.py` — `export_state()`, `load_export()`, `_serialize_state()`
+- `yamlgraph/cli/__init__.py` — argument parser
+- `yamlgraph/cli/graph_commands.py` — `cmd_graph_run()`, `_build_run_config()`
+- `yamlgraph/utils/expressions.py` — `resolve_state_expression()` (handles dict + object access)
+- `yamlgraph/models/schemas.py` — `CopilotResult` (session_id field)
+- `docs/refactoring-watcher-pipeline-v3.md` section 7 — design rationale
+- REQ-YG-267: `--import-state` loads exported JSON as initial graph state
+- REQ-YG-268: `--export-state` writes full run state to an explicit JSON path

--- a/tests/unit/test_cli_inter_run_state_chaining.py
+++ b/tests/unit/test_cli_inter_run_state_chaining.py
@@ -1,0 +1,409 @@
+"""Acceptance tests for FR-269: CLI inter-run state chaining."""
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _make_run_args(graph_path: Path, **overrides) -> argparse.Namespace:
+    """Create cmd_graph_run args namespace with safe defaults for unit tests."""
+    data = {
+        "graph_path": str(graph_path),
+        "var": [],
+        "var_file": None,
+        "thread": None,
+        "export": False,
+        "full": False,
+        "import_state": None,
+        "export_state": None,
+        "use_async": False,
+        "share_trace": False,
+        "recursion_limit": None,
+        "timeout": None,
+        "token_usage": False,
+        "timing": False,
+    }
+    data.update(overrides)
+    return argparse.Namespace(**data)
+
+
+def _setup_graph_loader_mocks(mock_load_config, mock_compile, mock_get_cp):
+    """Prepare graph loader mocks for cmd_graph_run execution tests."""
+    mock_load_config.return_value = MagicMock()
+    mock_graph = MagicMock()
+    mock_compile.return_value = mock_graph
+    mock_get_cp.return_value = None
+    mock_app = MagicMock()
+    mock_app.invoke.return_value = {"result": "ok"}
+    mock_graph.compile.return_value = mock_app
+    return mock_app
+
+
+class TestFR269ParserAndHelp:
+    """CLI parser contracts for --import-state and --export-state."""
+
+    @pytest.mark.req("REQ-YG-032", "REQ-YG-036")
+    def test_graph_run_accepts_import_and_export_state_independently(self):
+        """AC-07: both new flags are usable alone and together."""
+        from yamlgraph.cli import create_parser
+
+        parser = create_parser()
+
+        args_import_only = parser.parse_args(
+            ["graph", "run", "graphs/test.yaml", "--import-state", "in.json"]
+        )
+        assert args_import_only.import_state == "in.json"
+        assert args_import_only.export_state is None
+
+        args_export_only = parser.parse_args(
+            ["graph", "run", "graphs/test.yaml", "--export-state", "out.json"]
+        )
+        assert args_export_only.import_state is None
+        assert args_export_only.export_state == "out.json"
+
+        args_both = parser.parse_args(
+            [
+                "graph",
+                "run",
+                "graphs/test.yaml",
+                "--import-state",
+                "in.json",
+                "--export-state",
+                "out.json",
+            ]
+        )
+        assert args_both.import_state == "in.json"
+        assert args_both.export_state == "out.json"
+
+    @pytest.mark.req("REQ-YG-032", "REQ-YG-036")
+    def test_graph_run_help_lists_import_and_export_state(self, capsys):
+        """AC-11: graph run --help documents both flags."""
+        from yamlgraph.cli import create_parser
+
+        parser = create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["graph", "run", "--help"])
+
+        out = capsys.readouterr().out
+        assert "--import-state" in out
+        assert "--export-state" in out
+        assert "Load initial state from JSON file" in out
+        assert "Write full state JSON" in out
+
+
+class TestFR269StorageExportContracts:
+    """State export/import helpers for inter-run chaining."""
+
+    @pytest.mark.req("REQ-YG-038")
+    def test_export_state_to_path_writes_full_state_json(self, tmp_path: Path):
+        """AC-01: --export-state writes full post-run state to explicit JSON path."""
+        from yamlgraph.models.schemas import CopilotResult
+        from yamlgraph.storage.export import export_state_to_path
+
+        state = {
+            "topic": "acceptance",
+            "steps": ["plan", "enforce"],
+            "prev_result": CopilotResult(
+                output="done",
+                backend="cli",
+                session_id="session-123",
+            ),
+        }
+        output_path = tmp_path / "state.json"
+
+        written = export_state_to_path(state, output_path)
+        assert written == output_path
+
+        data = json.loads(output_path.read_text())
+        assert data["topic"] == "acceptance"
+        assert data["steps"] == ["plan", "enforce"]
+        assert data["prev_result"]["session_id"] == "session-123"
+
+    @pytest.mark.req("REQ-YG-038")
+    def test_export_state_to_path_creates_parent_directories(self, tmp_path: Path):
+        """AC-02: --export-state creates missing parent directories."""
+        from yamlgraph.storage.export import export_state_to_path
+
+        output_path = tmp_path / "nested" / "deeper" / "state.json"
+        export_state_to_path({"k": "v"}, output_path)
+
+        assert output_path.exists()
+        assert json.loads(output_path.read_text()) == {"k": "v"}
+
+    @pytest.mark.req("REQ-YG-038")
+    def test_export_import_round_trip_preserves_copilot_session_id(
+        self, tmp_path: Path
+    ):
+        """AC-06: session_id survives export/import and resolves in state expressions."""
+        from yamlgraph.models.schemas import CopilotResult
+        from yamlgraph.storage.export import export_state_to_path, load_export
+        from yamlgraph.utils.expressions import resolve_state_expression
+
+        state = {
+            "prev_result": CopilotResult(
+                output="ready",
+                backend="cli",
+                session_id="copilot-session-42",
+            )
+        }
+        output_path = tmp_path / "roundtrip.json"
+
+        export_state_to_path(state, output_path)
+        loaded = load_export(output_path)
+
+        assert (
+            resolve_state_expression("{state.prev_result.session_id}", loaded)
+            == "copilot-session-42"
+        )
+
+
+class TestFR269CmdGraphRunStateMerging:
+    """cmd_graph_run contracts for import/export state flags."""
+
+    @pytest.mark.req("REQ-YG-033")
+    @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
+    @patch("yamlgraph.cli.graph_commands._teardown_timeout")
+    @patch("yamlgraph.cli.graph_commands._build_run_config")
+    @patch("yamlgraph.storage.export.load_export", return_value={"imported": "state"})
+    @patch("yamlgraph.graph_loader.get_checkpointer_for_graph")
+    @patch("yamlgraph.graph_loader.compile_graph")
+    @patch("yamlgraph.graph_loader.load_graph_config")
+    def test_import_state_is_base_initial_state(
+        self,
+        mock_load_config,
+        mock_compile,
+        mock_get_cp,
+        mock_load_export,
+        mock_build,
+        _mock_teardown_timeout,
+        _mock_setup_timeout,
+        tmp_path: Path,
+    ):
+        """AC-03: imported JSON state is used as base initial state."""
+        from yamlgraph.cli.graph_commands import cmd_graph_run
+
+        graph_path = tmp_path / "graph.yaml"
+        graph_path.write_text("name: test\nnodes: {}\nedges: []\n")
+        state_path = tmp_path / "state.json"
+        state_path.write_text('{"imported": "state"}')
+
+        mock_app = _setup_graph_loader_mocks(
+            mock_load_config, mock_compile, mock_get_cp
+        )
+        captured_initial_state = {}
+
+        def _fake_build_run_config(_args, _graph_config, initial_state):
+            captured_initial_state.update(initial_state)
+            return dict(initial_state), {}, None, None, None, False, None
+
+        mock_build.side_effect = _fake_build_run_config
+        args = _make_run_args(graph_path, import_state=str(state_path))
+
+        cmd_graph_run(args)
+
+        mock_load_export.assert_called_once()
+        assert captured_initial_state["imported"] == "state"
+        invoked_state = mock_app.invoke.call_args[0][0]
+        assert invoked_state["imported"] == "state"
+
+    @pytest.mark.req("REQ-YG-033")
+    @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
+    @patch("yamlgraph.cli.graph_commands._teardown_timeout")
+    @patch("yamlgraph.cli.graph_commands._build_run_config")
+    @patch(
+        "yamlgraph.storage.export.load_export",
+        return_value={"shared": "imported", "i": 1},
+    )
+    @patch(
+        "yamlgraph.cli.graph_commands.parse_vars",
+        return_value={"shared": "cli", "c": 3},
+    )
+    @patch(
+        "yamlgraph.cli.graph_commands.load_var_file",
+        return_value={"shared": "file", "f": 2},
+    )
+    @patch("yamlgraph.graph_loader.get_checkpointer_for_graph")
+    @patch("yamlgraph.graph_loader.compile_graph")
+    @patch("yamlgraph.graph_loader.load_graph_config")
+    def test_merge_order_is_import_then_var_file_then_var(
+        self,
+        mock_load_config,
+        mock_compile,
+        mock_get_cp,
+        _mock_load_var_file,
+        _mock_parse_vars,
+        mock_load_export,
+        mock_build,
+        _mock_teardown_timeout,
+        _mock_setup_timeout,
+        tmp_path: Path,
+    ):
+        """AC-04: merge precedence is imported < --var-file < --var."""
+        from yamlgraph.cli.graph_commands import cmd_graph_run
+
+        graph_path = tmp_path / "graph.yaml"
+        graph_path.write_text("name: test\nnodes: {}\nedges: []\n")
+        state_path = tmp_path / "state.json"
+        state_path.write_text('{"shared": "imported", "i": 1}')
+
+        _setup_graph_loader_mocks(mock_load_config, mock_compile, mock_get_cp)
+        captured_initial_state = {}
+
+        def _fake_build_run_config(_args, _graph_config, initial_state):
+            captured_initial_state.update(initial_state)
+            return dict(initial_state), {}, None, None, None, False, None
+
+        mock_build.side_effect = _fake_build_run_config
+        args = _make_run_args(
+            graph_path,
+            var=["shared=cli", "c=3"],
+            var_file=str(tmp_path / "vars.yaml"),
+            import_state=str(state_path),
+        )
+
+        cmd_graph_run(args)
+
+        mock_load_export.assert_called_once()
+        assert captured_initial_state == {"shared": "cli", "i": 1, "f": 2, "c": 3}
+
+    @pytest.mark.req("REQ-YG-033")
+    @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
+    @patch("yamlgraph.cli.graph_commands._teardown_timeout")
+    @patch("yamlgraph.cli.graph_commands._build_run_config")
+    @patch(
+        "yamlgraph.storage.export.load_export",
+        return_value={"topic": "from-import", "session_id": "abc"},
+    )
+    @patch(
+        "yamlgraph.cli.graph_commands.parse_vars", return_value={"topic": "from-cli"}
+    )
+    @patch("yamlgraph.cli.graph_commands.load_var_file", return_value={})
+    @patch("yamlgraph.graph_loader.get_checkpointer_for_graph")
+    @patch("yamlgraph.graph_loader.compile_graph")
+    @patch("yamlgraph.graph_loader.load_graph_config")
+    def test_cli_vars_override_imported_keys(
+        self,
+        mock_load_config,
+        mock_compile,
+        mock_get_cp,
+        _mock_load_var_file,
+        _mock_parse_vars,
+        mock_load_export,
+        mock_build,
+        _mock_teardown_timeout,
+        _mock_setup_timeout,
+        tmp_path: Path,
+    ):
+        """AC-05: --var values overwrite matching imported keys."""
+        from yamlgraph.cli.graph_commands import cmd_graph_run
+
+        graph_path = tmp_path / "graph.yaml"
+        graph_path.write_text("name: test\nnodes: {}\nedges: []\n")
+        state_path = tmp_path / "state.json"
+        state_path.write_text('{"topic": "from-import", "session_id": "abc"}')
+
+        _setup_graph_loader_mocks(mock_load_config, mock_compile, mock_get_cp)
+        captured_initial_state = {}
+
+        def _fake_build_run_config(_args, _graph_config, initial_state):
+            captured_initial_state.update(initial_state)
+            return dict(initial_state), {}, None, None, None, False, None
+
+        mock_build.side_effect = _fake_build_run_config
+        args = _make_run_args(
+            graph_path, var=["topic=from-cli"], import_state=str(state_path)
+        )
+
+        cmd_graph_run(args)
+
+        mock_load_export.assert_called_once()
+        assert captured_initial_state["topic"] == "from-cli"
+        assert captured_initial_state["session_id"] == "abc"
+
+    @pytest.mark.req("REQ-YG-033")
+    @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
+    @patch("yamlgraph.cli.graph_commands._teardown_timeout")
+    @patch("yamlgraph.cli.graph_commands._build_run_config")
+    @patch("yamlgraph.graph_loader.get_checkpointer_for_graph")
+    @patch("yamlgraph.graph_loader.compile_graph")
+    @patch("yamlgraph.graph_loader.load_graph_config")
+    def test_import_state_missing_file_exits_with_clear_error(
+        self,
+        mock_load_config,
+        mock_compile,
+        mock_get_cp,
+        mock_build,
+        _mock_teardown_timeout,
+        _mock_setup_timeout,
+        tmp_path: Path,
+        capsys,
+    ):
+        """AC-08: missing --import-state file exits with clear message and code 1."""
+        from yamlgraph.cli.graph_commands import cmd_graph_run
+
+        graph_path = tmp_path / "graph.yaml"
+        graph_path.write_text("name: test\nnodes: {}\nedges: []\n")
+        missing_state = tmp_path / "missing-state.json"
+
+        _setup_graph_loader_mocks(mock_load_config, mock_compile, mock_get_cp)
+        mock_build.return_value = ({}, {}, None, None, None, False, None)
+        args = _make_run_args(graph_path, import_state=str(missing_state))
+
+        with pytest.raises(SystemExit, match="1"):
+            cmd_graph_run(args)
+
+        out = capsys.readouterr().out
+        assert "--import-state" in out
+        assert "not found" in out.lower()
+        assert str(missing_state) in out
+
+    @pytest.mark.req("REQ-YG-038")
+    @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
+    @patch("yamlgraph.cli.graph_commands._teardown_timeout")
+    @patch("yamlgraph.cli.graph_commands._build_run_config")
+    @patch("yamlgraph.graph_loader.get_checkpointer_for_graph")
+    @patch("yamlgraph.graph_loader.compile_graph")
+    @patch("yamlgraph.graph_loader.load_graph_config")
+    def test_export_state_write_failure_exits_with_clear_error(
+        self,
+        mock_load_config,
+        mock_compile,
+        mock_get_cp,
+        mock_build,
+        _mock_teardown_timeout,
+        _mock_setup_timeout,
+        tmp_path: Path,
+        capsys,
+    ):
+        """AC-09: --export-state write failures exit with clear message and code 1."""
+        from yamlgraph.cli.graph_commands import cmd_graph_run
+
+        graph_path = tmp_path / "graph.yaml"
+        graph_path.write_text("name: test\nnodes: {}\nedges: []\n")
+
+        export_target = tmp_path / "as-directory"
+        export_target.mkdir()
+
+        _setup_graph_loader_mocks(mock_load_config, mock_compile, mock_get_cp)
+        mock_build.return_value = ({}, {}, None, None, None, False, None)
+        args = _make_run_args(graph_path, export_state=str(export_target))
+
+        with pytest.raises(SystemExit, match="1"):
+            cmd_graph_run(args)
+
+        out = capsys.readouterr().out
+        assert "error" in out.lower()
+        assert str(export_target) in out
+
+
+@pytest.mark.req("REQ-YG-121")
+def test_architecture_declares_req_yg_267_and_268():
+    """AC-12: ARCHITECTURE.md includes REQ-YG-267 and REQ-YG-268 entries."""
+    text = (REPO_ROOT / "ARCHITECTURE.md").read_text()
+    assert "REQ-YG-267" in text
+    assert "REQ-YG-268" in text

--- a/tests/unit/test_cli_inter_run_state_chaining.py
+++ b/tests/unit/test_cli_inter_run_state_chaining.py
@@ -47,7 +47,7 @@ def _setup_graph_loader_mocks(mock_load_config, mock_compile, mock_get_cp):
 class TestFR269ParserAndHelp:
     """CLI parser contracts for --import-state and --export-state."""
 
-    @pytest.mark.req("REQ-YG-032", "REQ-YG-036")
+    @pytest.mark.req("REQ-YG-032", "REQ-YG-036", "REQ-YG-267", "REQ-YG-268")
     def test_graph_run_accepts_import_and_export_state_independently(self):
         """AC-07: both new flags are usable alone and together."""
         from yamlgraph.cli import create_parser
@@ -80,7 +80,7 @@ class TestFR269ParserAndHelp:
         assert args_both.import_state == "in.json"
         assert args_both.export_state == "out.json"
 
-    @pytest.mark.req("REQ-YG-032", "REQ-YG-036")
+    @pytest.mark.req("REQ-YG-032", "REQ-YG-036", "REQ-YG-267", "REQ-YG-268")
     def test_graph_run_help_lists_import_and_export_state(self, capsys):
         """AC-11: graph run --help documents both flags."""
         from yamlgraph.cli import create_parser
@@ -99,7 +99,7 @@ class TestFR269ParserAndHelp:
 class TestFR269StorageExportContracts:
     """State export/import helpers for inter-run chaining."""
 
-    @pytest.mark.req("REQ-YG-038")
+    @pytest.mark.req("REQ-YG-038", "REQ-YG-268")
     def test_export_state_to_path_writes_full_state_json(self, tmp_path: Path):
         """AC-01: --export-state writes full post-run state to explicit JSON path."""
         from yamlgraph.models.schemas import CopilotResult
@@ -124,7 +124,7 @@ class TestFR269StorageExportContracts:
         assert data["steps"] == ["plan", "enforce"]
         assert data["prev_result"]["session_id"] == "session-123"
 
-    @pytest.mark.req("REQ-YG-038")
+    @pytest.mark.req("REQ-YG-038", "REQ-YG-268")
     def test_export_state_to_path_creates_parent_directories(self, tmp_path: Path):
         """AC-02: --export-state creates missing parent directories."""
         from yamlgraph.storage.export import export_state_to_path
@@ -135,7 +135,7 @@ class TestFR269StorageExportContracts:
         assert output_path.exists()
         assert json.loads(output_path.read_text()) == {"k": "v"}
 
-    @pytest.mark.req("REQ-YG-038")
+    @pytest.mark.req("REQ-YG-038", "REQ-YG-267", "REQ-YG-268")
     def test_export_import_round_trip_preserves_copilot_session_id(
         self, tmp_path: Path
     ):
@@ -165,7 +165,7 @@ class TestFR269StorageExportContracts:
 class TestFR269CmdGraphRunStateMerging:
     """cmd_graph_run contracts for import/export state flags."""
 
-    @pytest.mark.req("REQ-YG-033")
+    @pytest.mark.req("REQ-YG-033", "REQ-YG-267")
     @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
     @patch("yamlgraph.cli.graph_commands._teardown_timeout")
     @patch("yamlgraph.cli.graph_commands._build_run_config")
@@ -211,7 +211,7 @@ class TestFR269CmdGraphRunStateMerging:
         invoked_state = mock_app.invoke.call_args[0][0]
         assert invoked_state["imported"] == "state"
 
-    @pytest.mark.req("REQ-YG-033")
+    @pytest.mark.req("REQ-YG-033", "REQ-YG-267")
     @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
     @patch("yamlgraph.cli.graph_commands._teardown_timeout")
     @patch("yamlgraph.cli.graph_commands._build_run_config")
@@ -271,7 +271,7 @@ class TestFR269CmdGraphRunStateMerging:
         mock_load_export.assert_called_once()
         assert captured_initial_state == {"shared": "cli", "i": 1, "f": 2, "c": 3}
 
-    @pytest.mark.req("REQ-YG-033")
+    @pytest.mark.req("REQ-YG-033", "REQ-YG-267")
     @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
     @patch("yamlgraph.cli.graph_commands._teardown_timeout")
     @patch("yamlgraph.cli.graph_commands._build_run_config")
@@ -325,7 +325,7 @@ class TestFR269CmdGraphRunStateMerging:
         assert captured_initial_state["topic"] == "from-cli"
         assert captured_initial_state["session_id"] == "abc"
 
-    @pytest.mark.req("REQ-YG-033")
+    @pytest.mark.req("REQ-YG-033", "REQ-YG-267")
     @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
     @patch("yamlgraph.cli.graph_commands._teardown_timeout")
     @patch("yamlgraph.cli.graph_commands._build_run_config")
@@ -362,7 +362,7 @@ class TestFR269CmdGraphRunStateMerging:
         assert "not found" in out.lower()
         assert str(missing_state) in out
 
-    @pytest.mark.req("REQ-YG-038")
+    @pytest.mark.req("REQ-YG-038", "REQ-YG-268")
     @patch("yamlgraph.cli.graph_commands._setup_timeout", return_value=None)
     @patch("yamlgraph.cli.graph_commands._teardown_timeout")
     @patch("yamlgraph.cli.graph_commands._build_run_config")

--- a/yamlgraph/cli/__init__.py
+++ b/yamlgraph/cli/__init__.py
@@ -108,6 +108,20 @@ def create_parser() -> argparse.ArgumentParser:
         dest="timing",
         help="Track and display LLM call timing summary after execution",
     )
+    graph_run_parser.add_argument(
+        "--import-state",
+        type=str,
+        default=None,
+        dest="import_state",
+        help="Load initial state from JSON file exported by --export-state",
+    )
+    graph_run_parser.add_argument(
+        "--export-state",
+        type=str,
+        default=None,
+        dest="export_state",
+        help="Write full state JSON to this path after run (for inter-run chaining)",
+    )
 
     # graph info
     graph_info_parser = graph_subparsers.add_parser(

--- a/yamlgraph/cli/graph_commands.py
+++ b/yamlgraph/cli/graph_commands.py
@@ -18,7 +18,9 @@ import yaml
 from yamlgraph.cli.graph_validate import cmd_graph_lint, cmd_graph_validate
 from yamlgraph.cli.helpers import (
     GraphLoadError,
+    handle_state_export,
     load_graph_config,
+    load_imported_state,
     load_var_file,
     parse_vars,
     require_graph_config,
@@ -76,12 +78,7 @@ def _teardown_timeout(ctx: dict | None) -> None:
 
 
 def _display_result(result: dict, truncate: bool = True) -> None:
-    """Display result summary to console.
-
-    Args:
-        result: Graph execution result dict
-        truncate: Whether to truncate long values (default: True)
-    """
+    """Display result summary to console."""
     print("=" * 60)
     print("RESULT")
     print("=" * 60)
@@ -98,14 +95,7 @@ def _display_result(result: dict, truncate: bool = True) -> None:
 
 
 def _get_interrupt_message(result: dict) -> str:
-    """Extract human-readable message from interrupt.
-
-    Args:
-        result: Graph execution result containing __interrupt__
-
-    Returns:
-        Message to display to user
-    """
+    """Extract human-readable message from interrupt."""
     interrupt = result.get("__interrupt__", ())
     if interrupt and len(interrupt) > 0:
         # Interrupt is tuple of Interrupt objects
@@ -261,10 +251,15 @@ def cmd_graph_run(args: Namespace) -> None:
     try:
         file_vars = load_var_file(getattr(args, "var_file", None))
         cli_vars = parse_vars(args.var)
-        initial_state = {**file_vars, **cli_vars}  # CLI wins on conflict
     except (ValueError, FileNotFoundError) as e:
         print(f"❌ {e}")
         sys.exit(1)
+
+    # FR-269: Import state from prior run as base layer
+    imported_state = load_imported_state(getattr(args, "import_state", None))
+
+    # Merge: imported < var-file < CLI vars
+    initial_state = {**imported_state, **file_vars, **cli_vars}
 
     print(f"\n🚀 Running graph: {graph_path.name}")
     if initial_state:
@@ -338,6 +333,10 @@ def cmd_graph_run(args: Namespace) -> None:
 
         if args.export:
             _handle_export(graph_path, result)
+
+        # FR-269: Export full state for inter-run chaining
+        if getattr(args, "export_state", None):
+            handle_state_export(result, args.export_state)
 
         print()
 

--- a/yamlgraph/cli/helpers.py
+++ b/yamlgraph/cli/helpers.py
@@ -129,10 +129,59 @@ def load_var_file(path: str | None) -> dict[str, Any]:
         return yaml.safe_load(f) or {}
 
 
+def load_imported_state(import_state_path: str | None) -> dict:
+    """Load and validate imported state from a prior run's JSON export.
+
+    Args:
+        import_state_path: Path to JSON file, or None to skip.
+
+    Returns:
+        Loaded state dict, or empty dict if no import requested.
+    """
+    import sys
+
+    if import_state_path is None:
+        return {}
+
+    import_path = Path(import_state_path)
+    if not import_path.exists():
+        print(f"\u274c --import-state file not found: {import_path}")
+        sys.exit(1)
+
+    from yamlgraph.storage.export import load_export
+
+    try:
+        return load_export(import_path)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"\u274c --import-state invalid JSON: {import_path}\n  {e}")
+        sys.exit(1)
+
+
+def handle_state_export(result: dict, export_state_path: str) -> None:
+    """Export full pipeline state to an explicit path for inter-run chaining.
+
+    Args:
+        result: Graph execution result dict.
+        export_state_path: Target file path for JSON export.
+    """
+    import sys
+
+    from yamlgraph.storage.export import export_state_to_path
+
+    try:
+        p = export_state_to_path(result, export_state_path)
+        print(f"\n\ud83d\udcbe State exported: {p}")
+    except (OSError, IsADirectoryError) as e:
+        print(f"\n\u274c --export-state error writing {export_state_path}\n  {e}")
+        sys.exit(1)
+
+
 __all__ = [
     "load_graph_config",
     "require_graph_config",
     "GraphLoadError",
     "parse_vars",
     "load_var_file",
+    "load_imported_state",
+    "handle_state_export",
 ]

--- a/yamlgraph/storage/export.py
+++ b/yamlgraph/storage/export.py
@@ -94,6 +94,25 @@ def _serialize_object(obj: Any) -> Any:
         return obj
 
 
+def export_state_to_path(state: dict, path: str | Path) -> Path:
+    """Export full pipeline state to an explicit file path.
+
+    Used by --export-state CLI flag for inter-run state chaining.
+
+    Args:
+        state: State dictionary to export
+        path: Explicit output file path
+
+    Returns:
+        Path to the created file
+    """
+    filepath = Path(path)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with open(filepath, "w") as f:
+        json.dump(_serialize_state(state), f, indent=2, default=str)
+    return filepath
+
+
 def load_export(filepath: str | Path) -> dict:
     """Load an exported JSON file.
 


### PR DESCRIPTION
## FR-269: CLI Inter-Run State Chaining

Adds `--import-state` and `--export-state` flags to `yamlgraph graph run`, enabling external orchestrators to chain graph invocations across shell boundaries while preserving state.

### Changes
- `--export-state <path>` writes full post-run state as JSON
- `--import-state <path>` loads prior state as base (merge: imported < var-file < var)
- `export_state_to_path()` in `storage/export.py` for explicit path export
- `load_imported_state()` and `handle_state_export()` extracted to `cli/helpers.py`
- REQ-YG-267 and REQ-YG-268 added to ARCHITECTURE.md
- CAP-120 capability file created
- Changelog fragment added

### Tests
11 acceptance tests covering: parser wiring, export/import round-trip, merge precedence, error handling, ARCHITECTURE.md requirements.

See `feature-requests/FR-269-cli-inter-run-state-chaining.md`
