### PR TITLE
fix(watcher): write FR directly to feature-requests/ instead of gitignored drafts dir

### DIFF
--- a/.chaplain/graphs/copilot/prompts/judge.yaml
+++ b/.chaplain/graphs/copilot/prompts/judge.yaml
@@ -8,7 +8,7 @@ system: |
   feature requests and render a verdict: APPROVE, AMEND, REJECT, or SPLIT.
 
 user: |
-  **Judge.** Examine the feature request in {drafts_dir}/.
+  **Judge.** Examine the feature request in feature-requests/.
 
   Critically evaluate:
   1. Is the scope clear and minimal?
@@ -31,20 +31,17 @@ user: |
   **APPROVE:** If the feature request is clear, minimal, and internally consistent.
   - Freeze the scope
   - Grant authority to implement
-  - Move the file to feature-requests/
 
   **AMEND:** If the feature request needs work.
   - List specific issues to address
-  - Write issues into the file
-  - Move the file back to .chaplain/inbox/
+  - Write issues back into the FR file
 
   **REJECT:** If the feature request is unfeasible.
   - Add **Status:** Rejected to the file
   - Document the reason for rejection
-  - Move to feature-requests/
 
   **SPLIT:** If the FR addresses multiple orthogonal concerns that can be implemented and tested separately.
   - Identify each independent concern as a numbered sub-topic
   - Write each sub-topic as a separate file in .chaplain/inbox/ (one sentence per file)
-  - Delete the original draft from .chaplain/drafts/
+  - Delete the original FR
   - Each sub-topic re-enters the Plan → Judge pipeline independently

--- a/.chaplain/graphs/copilot/prompts/plan.yaml
+++ b/.chaplain/graphs/copilot/prompts/plan.yaml
@@ -7,7 +7,7 @@ system: |
   into a well-structured feature request document.
 
 user: |
-  **Plan.** Read {topic_file}. Write the feature request in {drafts_dir}/.
+  **Plan.** Read {topic_file}. Write the feature request in feature-requests/.
 
   Follow this process:
   1. Read and understand the topic/idea in the file
@@ -17,7 +17,6 @@ user: |
   5. Propose an implementation approach
 
   Follow the template in feature-requests/TEMPLATE.md.
-  Delete {topic_file} when complete.
 
   Ensure the feature request is:
   - Clear and unambiguous

--- a/.chaplain/graphs/copilot/prompts/research.yaml
+++ b/.chaplain/graphs/copilot/prompts/research.yaml
@@ -8,7 +8,7 @@ system: |
   produce a structured research brief.
 
 user: |
-  **Research.** Read the feature request draft in {drafts_dir}/.
+  **Research.** Read the feature request draft in feature-requests/.
 
   Investigate:
   1. **Competing solutions**: Search the web for how other frameworks and products

--- a/.chaplain/graphs/copilot/prompts/write-acceptance-tests.yaml
+++ b/.chaplain/graphs/copilot/prompts/write-acceptance-tests.yaml
@@ -16,7 +16,7 @@ system: |
   codebase. These tests define the contract that the enforce phase must satisfy.
 
 user: |
-  Read the feature request draft in {drafts_dir}/ and write acceptance tests
+  Read the feature request draft in feature-requests/ and write acceptance tests
   in the worktree at {worktree_dir}.
 
   Follow the acceptance test protocol:

--- a/.chaplain/graphs/watcher-plan/step-acceptance.yaml
+++ b/.chaplain/graphs/watcher-plan/step-acceptance.yaml
@@ -11,7 +11,6 @@ prompts_relative: true
 prompts_dir: ../copilot/prompts
 
 state:
-  drafts_dir: str
   worktree_dir: str
   branch: str
   plan_result: dict
@@ -28,7 +27,6 @@ nodes:
       allow_all_tools: true
       resume: "{state.plan_result.session_id}"
     variables:
-      drafts_dir: "{state.drafts_dir}"
       worktree_dir: "{state.worktree_dir}"
       branch: "{state.branch}"
     state_key: acceptance_tests_result

--- a/.chaplain/graphs/watcher-plan/step-judge.yaml
+++ b/.chaplain/graphs/watcher-plan/step-judge.yaml
@@ -11,7 +11,6 @@ prompts_relative: true
 prompts_dir: ../copilot/prompts
 
 state:
-  drafts_dir: str
   plan_result: dict
   judge_result: dict
 
@@ -25,8 +24,6 @@ nodes:
       allow_all_paths: true
       allow_all_tools: true
       resume: "{state.plan_result.session_id}"
-    variables:
-      drafts_dir: "{state.drafts_dir}"
     state_key: judge_result
     timeout: 1000
 

--- a/.chaplain/graphs/watcher-plan/step-plan.yaml
+++ b/.chaplain/graphs/watcher-plan/step-plan.yaml
@@ -11,7 +11,6 @@ prompts_dir: ../copilot/prompts
 
 state:
   topic_file: str
-  drafts_dir: str
   plan_result: dict
 
 nodes:
@@ -25,7 +24,6 @@ nodes:
       allow_all_tools: true
     variables:
       topic_file: "{state.topic_file}"
-      drafts_dir: "{state.drafts_dir}"
     state_key: plan_result
     timeout: 500
 

--- a/.chaplain/graphs/watcher-plan/step-research.yaml
+++ b/.chaplain/graphs/watcher-plan/step-research.yaml
@@ -11,7 +11,6 @@ prompts_relative: true
 prompts_dir: ../copilot/prompts
 
 state:
-  drafts_dir: str
   plan_result: dict
   research_brief: dict
 
@@ -25,8 +24,6 @@ nodes:
       allow_all_paths: true
       allow_all_tools: true
       resume: "{state.plan_result.session_id}"
-    variables:
-      drafts_dir: "{state.drafts_dir}"
     state_key: research_brief
     timeout: 1000
 

--- a/.chaplain/watcher2.sh
+++ b/.chaplain/watcher2.sh
@@ -102,15 +102,13 @@ while true; do
     # ── Phase 3: Planning + Judging pipeline ────────────────────────────
     # FR-273 Phase 3: copilot session chain with shell steps between nodes
     PIPELINE_STATE="tmp/pipeline-state.json"
-    DRAFTS_DIR=".chaplain/drafts"
     GRAPH_DIR=".chaplain/graphs/watcher-plan"
-    mkdir -p "$DRAFTS_DIR" tmp
+    mkdir -p tmp
 
     # ── Step 1: Plan ────────────────────────────────────────────────────
     log_info "Step 1/4: Plan — reading topic, drafting FR..."
     if ! yamlgraph graph run "$GRAPH_DIR/step-plan.yaml" \
         --var topic_file="$MAIN_DIR/$TOPIC_FILE" \
-        --var drafts_dir="$DRAFTS_DIR" \
         --export-state "$PIPELINE_STATE" \
         --full 2>&1 | tee tmp/watcher2-plan.log; then
         log_error "Plan step failed"
@@ -122,7 +120,7 @@ while true; do
     fi
 
     # Shell: commit FR draft
-    git add "$DRAFTS_DIR/" feature-requests/ 2>/dev/null || true
+    git add feature-requests/ 2>/dev/null || true
     if git diff --cached --quiet; then
         log_error "Plan produced no files"
         cd "$MAIN_DIR"
@@ -136,7 +134,6 @@ while true; do
     # ── Step 2: Research ────────────────────────────────────────────────
     log_info "Step 2/4: Research — gathering evidence..."
     if ! yamlgraph graph run "$GRAPH_DIR/step-research.yaml" \
-        --var drafts_dir="$DRAFTS_DIR" \
         --import-state "$PIPELINE_STATE" \
         --export-state "$PIPELINE_STATE" \
         --full 2>&1 | tee tmp/watcher2-research.log; then
@@ -144,7 +141,7 @@ while true; do
     fi
 
     # Shell: commit research additions to FR
-    git add "$DRAFTS_DIR/" feature-requests/ 2>/dev/null || true
+    git add feature-requests/ 2>/dev/null || true
     if ! git diff --cached --quiet; then
         git commit -m "chore: watcher2 — research brief appended" --no-verify
     fi
@@ -152,7 +149,6 @@ while true; do
     # ── Step 3: Write acceptance tests ──────────────────────────────────
     log_info "Step 3/4: Write acceptance tests (RED)..."
     if ! yamlgraph graph run "$GRAPH_DIR/step-acceptance.yaml" \
-        --var drafts_dir="$DRAFTS_DIR" \
         --var worktree_dir="$(pwd)" \
         --var branch="$WT_BRANCH" \
         --import-state "$PIPELINE_STATE" \
@@ -182,7 +178,6 @@ while true; do
     # ── Step 4: Judge ───────────────────────────────────────────────────
     log_info "Step 4/4: Judge — evaluating FR draft..."
     if ! yamlgraph graph run "$GRAPH_DIR/step-judge.yaml" \
-        --var drafts_dir="$DRAFTS_DIR" \
         --import-state "$PIPELINE_STATE" \
         --export-state "$PIPELINE_STATE" \
         --full 2>&1 | tee tmp/watcher2-judge.log; then
@@ -211,7 +206,7 @@ print('UNKNOWN')
     if [[ "$VERDICT" == "REJECT" ]]; then
         log_warn "FR rejected by judge — aborting cycle"
         # Commit judge result for traceability
-        git add "$DRAFTS_DIR/" feature-requests/ 2>/dev/null || true
+        git add feature-requests/ 2>/dev/null || true
         git diff --cached --quiet || git commit -m "chore: watcher2 — FR rejected by judge" --no-verify
         cd "$MAIN_DIR"
         worktree_teardown
@@ -222,7 +217,7 @@ print('UNKNOWN')
 
     if [[ "$VERDICT" == "AMEND" || "$VERDICT" == "SPLIT" ]]; then
         log_warn "FR needs amendment ($VERDICT) — aborting cycle"
-        git add "$DRAFTS_DIR/" feature-requests/ .chaplain/inbox/ 2>/dev/null || true
+        git add feature-requests/ .chaplain/inbox/ 2>/dev/null || true
         git diff --cached --quiet || git commit -m "chore: watcher2 — FR $VERDICT by judge" --no-verify
         cd "$MAIN_DIR"
         worktree_teardown
@@ -232,7 +227,7 @@ print('UNKNOWN')
     fi
 
     # APPROVE or UNKNOWN — commit and proceed to enforcement
-    git add "$DRAFTS_DIR/" feature-requests/ 2>/dev/null || true
+    git add feature-requests/ 2>/dev/null || true
     git diff --cached --quiet || git commit -m "chore: watcher2 — FR approved by judge" --no-verify
 
     # ── Phase 4: Enforcement pipeline ───────────────────────────────────
@@ -240,8 +235,8 @@ print('UNKNOWN')
     ENFORCE_DIR=".chaplain/graphs/watcher-enforce"
     ENFORCE_STATE="tmp/enforce-state.json"
 
-    # Find the FR path (plan step should have written it to drafts or feature-requests)
-    FR_PATH=$(find feature-requests/ "$DRAFTS_DIR/" -name "FR-*.md" -type f 2>/dev/null | head -1)
+    # Find the FR path
+    FR_PATH=$(find feature-requests/ -name "FR-*.md" -type f 2>/dev/null | head -1)
     if [[ -z "$FR_PATH" ]]; then
         log_error "No FR file found for enforcement"
         cd "$MAIN_DIR"

--- a/changelog/unreleased/fix-watcher2-drafts-gitignore.md
+++ b/changelog/unreleased/fix-watcher2-drafts-gitignore.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: watcher
+---
+- **Fix watcher2 plan step**: Write FR directly to `feature-requests/` instead of gitignored `.chaplain/drafts/`. Removes `drafts_dir` indirection from prompts, step graphs, and orchestrator.

--- a/tests/unit/test_acceptance_tests_before_enforce.py
+++ b/tests/unit/test_acceptance_tests_before_enforce.py
@@ -414,10 +414,10 @@ class TestCreateWorktreeToolUnit:
 class TestPromptTemplateVariables:
     """write-acceptance-tests prompt template must render with valid variables."""
 
-    def test_prompt_template_has_drafts_dir_var(self):
-        """Prompt must use {drafts_dir} variable."""
+    def test_prompt_template_references_feature_requests(self):
+        """Prompt must reference feature-requests/ directory."""
         content = (PROMPTS_DIR / "write-acceptance-tests.yaml").read_text()
-        assert "{drafts_dir}" in content
+        assert "feature-requests/" in content
 
     def test_prompt_template_has_worktree_dir_var(self):
         """Prompt must use {worktree_dir} variable."""

--- a/tests/unit/test_chaplain_research_step.py
+++ b/tests/unit/test_chaplain_research_step.py
@@ -195,10 +195,10 @@ class TestResearchPrompt:
         user = prompt["user"].lower()
         assert "usage" in user
 
-    def test_research_prompt_references_drafts_dir(self):
-        """User prompt must reference {drafts_dir} variable."""
+    def test_research_prompt_references_feature_requests(self):
+        """User prompt must reference feature-requests/ directory."""
         prompt = yaml.safe_load((PROMPTS_DIR / "research.yaml").read_text())
-        assert "{drafts_dir}" in prompt["user"]
+        assert "feature-requests/" in prompt["user"]
 
 
 # ===========================================================================


### PR DESCRIPTION
The .chaplain/drafts/ directory is gitignored, so git add silently did nothing and watcher2 reported 'Plan produced no files'. Fix: write FR directly to feature-requests/ (safe in worktree isolation). Removes drafts_dir from prompts, step graphs, and orchestrator.