### PR TITLE
fix(watcher): FR-273 fix FR discovery picking wrong file

### DIFF
--- a/.chaplain/watcher2.sh
+++ b/.chaplain/watcher2.sh
@@ -129,13 +129,21 @@ while true; do
         continue
     fi
 
-    # Shell: commit FR draft
+    # Shell: commit FR draft and capture created FR path
     git add feature-requests/ 2>/dev/null || true
     if git diff --cached --quiet; then
         handle_failure "plan produced no files"
         continue
     fi
     git commit -m "chore: watcher2 — FR draft from plan step" --no-verify
+    # Capture the FR file created in this commit (not a stale one)
+    CREATED_FR_PATH=$(git diff-tree --no-commit-id --name-only -r HEAD -- feature-requests/ \
+        | grep -E 'FR-[0-9]+.*\.md$' | head -1)
+    if [[ -n "$CREATED_FR_PATH" ]]; then
+        log_info "Plan created: $CREATED_FR_PATH"
+    else
+        log_warn "Could not detect FR path from plan commit"
+    fi
 
     # ── Step 2: Research ────────────────────────────────────────────────
     log_info "Step 2/4: Research — gathering evidence..."
@@ -230,8 +238,14 @@ print('UNKNOWN')
     ENFORCE_DIR=".chaplain/graphs/watcher-enforce"
     ENFORCE_STATE="tmp/enforce-state.json"
 
-    # Find the FR path
-    FR_PATH=$(find feature-requests/ -name "FR-*.md" -type f 2>/dev/null | head -1)
+    # Find the FR path — prefer the one created by the plan step
+    if [[ -n "${CREATED_FR_PATH:-}" && -f "$CREATED_FR_PATH" ]]; then
+        FR_PATH="$CREATED_FR_PATH"
+    else
+        # Fallback: newest FR file by git commit time
+        FR_PATH=$(git log --diff-filter=A --name-only --pretty=format: -- 'feature-requests/FR-*.md' \
+            | grep -E 'FR-[0-9]+.*\.md$' | head -1)
+    fi
     if [[ -z "$FR_PATH" ]]; then
         handle_failure "no FR file for enforcement"
         continue

--- a/changelog/unreleased/fix-watcher2-fr-discovery.md
+++ b/changelog/unreleased/fix-watcher2-fr-discovery.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: watcher
+---
+- **FR-273 Fix watcher2 FR discovery**: Enforce phase now uses the FR file created by the plan step instead of picking an arbitrary file from the feature-requests directory.

--- a/docs/diary/2026-04-23-reflection-fr-273-watcher2-fr-discovery.md
+++ b/docs/diary/2026-04-23-reflection-fr-273-watcher2-fr-discovery.md
@@ -1,0 +1,19 @@
+# Diary: FR-273 Watcher2 FR Discovery Bug
+
+**Date**: 2026-04-23
+**FR**: FR-273 (Phase 5 prerequisite)
+**Trap**: downstream_fix — symptom manifested in enforcement picking wrong FR, but root cause was missing state propagation from plan step
+
+## Insight
+
+The watcher2 pipeline used `find feature-requests/ | head -1` to discover which FR to enforce. In a worktree containing 200+ historical FR files, this returns an arbitrary file — not the one just created by the plan step.
+
+The plan step correctly created FR-268 for gh-180, but the enforce step picked FR-246 (A2A docs) because `find` doesn't guarantee order and `head -1` takes whatever comes first.
+
+## Heuristic
+
+**Pipeline state must flow forward explicitly.** When step N creates an artifact that step N+M consumes, the path must be captured at creation time — not re-discovered by searching a directory containing historical artifacts. `find | head -1` in a directory with accumulated state is always a bug.
+
+## Seed
+
+Could the pipeline state JSON carry a `created_artifacts` list that each step appends to, making the full provenance chain inspectable at any point?


### PR DESCRIPTION
The enforce phase used `find feature-requests/ | head -1` which returns an arbitrary FR from 200+ historical files. For gh-180, it picked FR-246 (A2A docs) instead of the newly created FR-268.

**Fix**: Capture the FR path from the plan step's git commit via `git diff-tree`, then use it directly in enforcement. Fallback uses `git log --diff-filter=A` to find the most recently added FR.

Closes #180 (prerequisite fix — watcher2 must route correctly before it can retire old scripts).