### PR TITLE
fix(watcher): prevent false merge failure from --delete-branch

### DIFF
--- a/.chaplain/lib/watcher/merge_pr.sh
+++ b/.chaplain/lib/watcher/merge_pr.sh
@@ -2,13 +2,26 @@
 # merge_pr.sh — Squash merge a PR via gh CLI
 #
 # Expects: PR_NUMBER set by orchestrator
+#
+# Note: --delete-branch is intentionally omitted because gh tries to
+# switch to the default branch after deleting, which fails when 'main'
+# is already checked out in the main worktree. Branch cleanup is handled
+# by worktree_teardown instead.
 
 merge_pr() {
     log_info "Merging PR #$PR_NUMBER (squash)..."
 
-    gh pr merge "$PR_NUMBER" --squash --delete-branch 2>&1 || {
-        log_error "Failed to merge PR #$PR_NUMBER"
-        return 1
+    gh pr merge "$PR_NUMBER" --squash 2>&1 || {
+        # gh pr merge can fail even after a successful merge (e.g. branch
+        # switch error). Verify actual merge state before returning failure.
+        local pr_state
+        pr_state=$(gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null)
+        if [[ "$pr_state" == "MERGED" ]]; then
+            log_warn "gh pr merge exited non-zero but PR is MERGED — continuing"
+        else
+            log_error "Failed to merge PR #$PR_NUMBER (state: ${pr_state:-unknown})"
+            return 1
+        fi
     }
 
     log_info "PR #$PR_NUMBER merged"

--- a/.chaplain/lib/watcher/worktree_teardown.sh
+++ b/.chaplain/lib/watcher/worktree_teardown.sh
@@ -11,8 +11,9 @@ worktree_teardown() {
     # Remove worktree
     git worktree remove "$WT_DIR" --force 2>/dev/null || log_warn "Failed to remove worktree $WT_DIR"
 
-    # Delete local branch (remote was deleted by squash merge)
+    # Delete local and remote branch
     git branch -D "$WT_BRANCH" 2>/dev/null || true
+    git push origin --delete "$WT_BRANCH" 2>/dev/null || true
 
     # Guard against bare=true corruption (FR-139)
     local bare_val

--- a/changelog/unreleased/fix-watcher2-merge-cleanup.md
+++ b/changelog/unreleased/fix-watcher2-merge-cleanup.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: watcher
+---
+- **Fix watcher2 post-merge cleanup**: Remove `--delete-branch` from `gh pr merge` to prevent false failure when `main` is already checked out in the main worktree. Add merge state verification fallback. Move remote branch deletion to `worktree_teardown`.


### PR DESCRIPTION
## Problem

`gh pr merge --delete-branch` tries to delete the local branch after merging,
but this fails when the branch is checked out in a worktree:

```
failed to delete local branch feat/watcher2-gh-191: failed to run git: error: cannot delete branch 'feat/watcher2-gh-191' used by worktree
```

The non-zero exit code triggers `handle_failure("merge")`, skipping worktree cleanup
even though the PR merged successfully.

## Fix

- **merge_pr.sh**: Remove `--delete-branch`, add merge state verification fallback
- **worktree_teardown.sh**: Add `git push origin --delete` for remote branch cleanup

## Evidence

Watcher2 log from FR-191 cycle shows the exact failure:
```
[watcher2] CI passed for PR #192
[watcher2] Merging PR #192 (squash)...
failed to delete local branch feat/watcher2-gh-191: error: cannot delete branch used by worktree
[watcher2] Failed to merge PR #192
[watcher2] Cycle failed: merge
```

PR #192 was actually MERGED at 19:40 UTC but cleanup never ran.