### PR TITLE
feat(demo): FR-263 add azure variant to hellograph speed comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 
 # Environment
 .env
+.env.azure
+.env.google
+.env.vertex
 .venv/
 venv/
 ENV/
@@ -87,6 +90,7 @@ docs/ebook/v*/
 # Planning files
 .chaplain/inbox/
 .chaplain/drafts/
+watcher.pid
 
 # Generated files (FR-179: append-only changelog fragments)
 CHANGELOG.md

--- a/changelog/unreleased/20260423-hellograph-speed-azure-demo.md
+++ b/changelog/unreleased/20260423-hellograph-speed-azure-demo.md
@@ -1,3 +1,5 @@
-- Added Azure variant for hellograph-speed demo
-- Added provider-specific env ignore entries
-- Added examples/README demos index entry for hellograph-speed
+---
+type: feat
+scope: demo
+---
+- **Hellograph Speed Azure Demo**: Added Azure variant for hellograph-speed multi-provider comparison demo.

--- a/changelog/unreleased/20260423-hellograph-speed-azure-demo.md
+++ b/changelog/unreleased/20260423-hellograph-speed-azure-demo.md
@@ -1,0 +1,3 @@
+- Added Azure variant for hellograph-speed demo
+- Added provider-specific env ignore entries
+- Added examples/README demos index entry for hellograph-speed

--- a/docs/diary/2026-04-24-reflection-fr-263-hellograph-speed-azure.md
+++ b/docs/diary/2026-04-24-reflection-fr-263-hellograph-speed-azure.md
@@ -1,0 +1,35 @@
+# Reflection: FR-263 Hellograph Speed Azure Variant Demo
+
+**Date:** 2026-04-24
+**FR:** FR-263 (Azure OpenAI Provider)
+**Scope:** Adding Azure variant to the hellograph-speed multi-provider comparison demo
+
+## Cognitive Process
+
+The hellograph-speed demo already existed for Google/Vertex providers. Adding an Azure variant
+was straightforward YAML work — the provider abstraction in `llm_factory.py` means a new demo
+graph is just a `provider: azure` declaration.
+
+## Trap: Branch Divergence from Stale Remote
+
+The branch had diverged from its remote tracking branch because main had been rebased into it
+locally but the remote still pointed at the old fork point. The fix was a force push after
+confirming local was correct and ahead.
+
+## Trap: Pre-existing Test Failures Block Unrelated Commits
+
+Pre-commit hooks run the full test suite. The `test_fr275` tests used hardcoded `"python"` binary
+which doesn't exist on macOS (only `python3`). This blocked committing the changelog fix even though
+the change was unrelated. Fix: commit the test fix (`sys.executable`) first.
+
+## Heuristic
+
+**Boundary normalization applies to subprocess calls too.** Just as LLM provider responses must be
+normalized at the boundary, subprocess invocations must use `sys.executable` — the Python binary
+name is an OS-level boundary where the assumption `python == python3` breaks.
+
+## Seed
+
+Could the pre-commit test gate run only tests affected by the changed files (pytest --co + dependency
+analysis) instead of the full suite? This would prevent unrelated failures from blocking commits
+while maintaining the safety net.

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,6 +65,7 @@ Standalone demos that teach a single YAMLGraph concept. Ordered by the learning 
 | Demo | Node Types | Description |
 |------|------------|-------------|
 | [hello](demos/hello/) | `llm` | Minimal example — start here |
+| [hellograph-speed](demos/hellograph-speed/) | `llm` | Provider latency comparison across Google, Vertex, and Azure |
 | [router](demos/router/) | `router` | Tone-based conditional routing |
 | [router-race-candidates](demos/router-race-candidates/) | `router`, `tool` | Router `candidates` race with default-route fallback (FR-272) |
 | [map](demos/map/) | `map`, `llm` | Parallel fan-out processing |

--- a/examples/demos/hellograph-speed/.env.azure.example
+++ b/examples/demos/hellograph-speed/.env.azure.example
@@ -1,0 +1,6 @@
+# Minimal env for hello speed demo (Azure AI Foundry)
+# Endpoint example: https://my-resource.services.ai.azure.com/openai/v1
+AZURE_AI_ENDPOINT=replace-with-your-azure-ai-endpoint
+AZURE_AI_API_KEY=replace-with-your-azure-ai-api-key
+# Optional: deployment/model name used for bench model override
+AZURE_MODEL=gpt-4o

--- a/examples/demos/hellograph-speed/.env.google.example
+++ b/examples/demos/hellograph-speed/.env.google.example
@@ -1,0 +1,2 @@
+# Minimal env for hello speed demo (Google consumer API)
+GOOGLE_API_KEY=replace-with-your-google-api-key

--- a/examples/demos/hellograph-speed/.env.vertex.example
+++ b/examples/demos/hellograph-speed/.env.vertex.example
@@ -1,0 +1,6 @@
+# Minimal env for hello speed demo (Vertex Express mode)
+VERTEX_API_KEY=replace-with-your-vertex-api-key
+
+# Alternative, gcloud auth
+# GOOGLE_CLOUD_PROJECT=scp-tenant-dps-dev
+# GOOGLE_CLOUD_LOCATION=europe-north1

--- a/examples/demos/hellograph-speed/README.md
+++ b/examples/demos/hellograph-speed/README.md
@@ -1,0 +1,71 @@
+# HelloGraph Speed Demo
+
+Copy of the hello demo with provider-specific graph configs to compare latency:
+- Google consumer API
+- Vertex API
+- Azure AI Foundry
+
+## Files
+
+- `graph.google.yaml` - Hello graph using `provider: google`
+- `graph.vertex.yaml` - Hello graph using `provider: vertex`
+- `graph.azure.yaml` - Hello graph using `provider: azure`
+- `prompts/greet.yaml` - Shared prompt
+- `vars.yaml` - Fixed inputs for repeatable benchmarking
+- `.env.google.example` - Minimal Google consumer API env
+- `.env.vertex.example` - Minimal Vertex env (Express mode)
+- `.env.azure.example` - Minimal Azure AI Foundry env
+- `compare_speed.sh` - Runs available providers back-to-back with same workload
+
+## Setup
+
+From repo root:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+# Azure provider support
+pip install -e ".[dev,azure]"
+```
+
+Then prepare env files in this demo directory:
+
+```bash
+cd examples/demos/hellograph-speed
+cp .env.google.example .env.google
+cp .env.vertex.example .env.vertex
+cp .env.azure.example .env.azure
+```
+
+## Run Once Per Provider
+
+```bash
+yamlgraph graph run graph.google.yaml --var-file vars.yaml --full
+yamlgraph graph run graph.vertex.yaml --var-file vars.yaml --full
+yamlgraph graph run graph.azure.yaml --var-file vars.yaml --full
+```
+
+## Compare Speed
+
+```bash
+chmod +x compare_speed.sh
+./compare_speed.sh 5
+```
+
+Argument `5` is run count per provider. Use a larger value (for example 10-20) for a more stable average.
+
+## Minimal Required Env
+
+Google consumer API (`.env.google`):
+- `GOOGLE_API_KEY`
+
+Vertex Express (`.env.vertex`):
+- `VERTEX_API_KEY`
+
+Azure AI Foundry (`.env.azure`):
+- `AZURE_AI_ENDPOINT`
+- `AZURE_AI_API_KEY`
+- `AZURE_MODEL` (optional, default in graph is `gpt-4o`)
+
+No extra variables are required for this hello demo because provider/model are set in each graph config.

--- a/examples/demos/hellograph-speed/compare_speed.sh
+++ b/examples/demos/hellograph-speed/compare_speed.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ ! -f .env.google ]] || [[ ! -f .env.vertex ]]; then
+  echo "Missing .env.google or .env.vertex"
+  echo "Copy templates first:"
+  echo "  cp .env.google.example .env.google"
+  echo "  cp .env.vertex.example .env.vertex"
+  echo "  cp .env.azure.example .env.azure  # optional"
+  exit 1
+fi
+
+runs="${1:-5}"
+
+echo "== Google consumer API =="
+set -a
+source ./.env.google
+set +a
+yamlgraph graph bench ./graph.google.yaml \
+  --models google/gemini-2.0-flash \
+  --var-file ./vars.yaml \
+  --runs "$runs"
+
+unset GOOGLE_API_KEY PROVIDER GOOGLE_MODEL
+
+echo
+echo "== Vertex API =="
+set -a
+source ./.env.vertex
+set +a
+yamlgraph graph bench ./graph.vertex.yaml \
+  --models vertex/gemini-2.0-flash \
+  --var-file ./vars.yaml \
+  --runs "$runs"
+
+if [[ -f .env.azure ]]; then
+  unset VERTEX_API_KEY GOOGLE_CLOUD_PROJECT GOOGLE_CLOUD_LOCATION VERTEX_MODEL
+
+  echo
+  echo "== Azure AI Foundry =="
+  set -a
+  source ./.env.azure
+  set +a
+
+  azure_model="${AZURE_MODEL:-gpt-4o}"
+  yamlgraph graph bench ./graph.azure.yaml \
+    --models "azure/${azure_model}" \
+    --var-file ./vars.yaml \
+    --runs "$runs"
+else
+  echo
+  echo "== Azure AI Foundry =="
+  echo "Skipped (.env.azure not found)."
+fi

--- a/examples/demos/hellograph-speed/demo-output.log
+++ b/examples/demos/hellograph-speed/demo-output.log
@@ -1,0 +1,16 @@
+2026-04-23 14:50:20,862 [INFO] yamlgraph.node_compiler: Added node: greet (type=llm)
+2026-04-23 14:50:20,982 [INFO] yamlgraph.utils.llm_factory: Creating LLM: azure/aaa-gpt-5.4-mini (temp=0.2)
+2026-04-23 14:50:22,890 [INFO] httpx: HTTP Request: POST https://ai-samijpheikkinenaihub338640401537.cognitiveservices.azure.com/openai/v1/chat/completions "HTTP/1.1 200 OK"
+2026-04-23 14:50:22,896 [INFO] yamlgraph.node_factory.llm_nodes: Node greet completed successfully
+
+🚀 Running graph: graph.azure.yaml
+   Variables: {'name': 'World', 'style': 'concise'}
+
+🔗 Trace: https://eu.smith.langchain.com/o/1c1b3d09-e172-4c82-bddb-5d1fe06a132a/projects/p/f0827681-a26f-48d8-88ca-3b3b51df6ed2/r/019dba2d-3fc4-7e42-a538-2d288951e08a?poll=true
+============================================================
+RESULT
+============================================================
+  current_step: greet
+  style: concise
+  name: World
+  greeting: Hello, World! Warm wishes to you.

--- a/examples/demos/hellograph-speed/graph.azure.yaml
+++ b/examples/demos/hellograph-speed/graph.azure.yaml
@@ -1,0 +1,33 @@
+# HelloGraph Speed Demo - Azure AI Foundry
+# Same hello graph as demo/hello, configured for provider=azure
+
+version: "1.0"
+name: hellograph-speed-azure
+description: Hello graph configured for Azure AI Foundry speed checks
+
+prompts_relative: true
+prompts_dir: prompts
+
+defaults:
+  provider: azure
+  model: aaa-gpt-5.4-mini
+  temperature: 0.2
+
+state:
+  name: str
+  style: str
+
+nodes:
+  greet:
+    type: llm
+    prompt: greet
+    variables:
+      name: "{state.name}"
+      style: "{state.style}"
+    state_key: greeting
+
+edges:
+  - from: START
+    to: greet
+  - from: greet
+    to: END

--- a/tests/unit/test_fr275_test_speed_optimization.py
+++ b/tests/unit/test_fr275_test_speed_optimization.py
@@ -7,6 +7,7 @@ All tests should FAIL on the unmodified codebase (RED phase).
 """
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -34,7 +35,7 @@ class TestSlowMarkerInfrastructure:
         """Pytest should recognize the slow marker without warnings."""
         # This will fail until the marker is properly configured
         result = subprocess.run(
-            ["python", "-m", "pytest", "--markers"],
+            [sys.executable, "-m", "pytest", "--markers"],
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent.parent,
@@ -108,7 +109,7 @@ class TestSlowTestFiltering:
         # This test will fail until slow markers are implemented
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "pytest",
                 "tests/unit/",
@@ -131,7 +132,15 @@ class TestSlowTestFiltering:
     def test_slow_test_run_includes_only_slow_tests(self):
         """Running pytest -m 'slow' should include only slow-marked tests."""
         result = subprocess.run(
-            ["python", "-m", "pytest", "tests/unit/", "-m", "slow", "--collect-only"],
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/unit/",
+                "-m",
+                "slow",
+                "--collect-only",
+            ],
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent.parent,
@@ -231,7 +240,7 @@ class TestMarkerFunctionality:
         """Verify that pytest marker selection syntax works correctly."""
         # Test that -m "slow" and -m "not slow" syntax is valid
         result = subprocess.run(
-            ["python", "-m", "pytest", "--help"],
+            [sys.executable, "-m", "pytest", "--help"],
             capture_output=True,
             text=True,
             cwd=Path(__file__).parent.parent.parent,
@@ -251,7 +260,7 @@ class TestNoTestBehaviorChanges:
         # This verifies that adding slow markers doesn't exclude tests by default
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "pytest",
                 "tests/unit/test_map_node_timeout.py",


### PR DESCRIPTION
## Summary  Adds Azure OpenAI variant to the hellograph-speed multi-provider comparison demo, proving FR-263 Azure provider works end-to-end.  ## Changes - Azure graph variant (`graph.azure.yaml`) with `provider: azure` configuration - Provider-specific `.env.*.example` files (Azure, Google, Vertex) - Shell script for running cross-provider speed comparisons - Demo output log proving execution - Updated examples index  ## FR Reference - FR-263: Azure OpenAI Provider (demo proof)