### PR TITLE
feat(demo): restore missing hellograph-speed provider demo files

### DIFF
--- a/examples/demos/hellograph-speed/graph.google.yaml
+++ b/examples/demos/hellograph-speed/graph.google.yaml
@@ -1,0 +1,34 @@
+# HelloGraph Speed Demo - Google Consumer API
+# Same hello graph as demo/hello, configured for provider=google
+
+version: "1.0"
+name: hellograph-speed-google
+description: Hello graph configured for Google consumer API speed checks
+
+prompts_relative: true
+prompts_dir: prompts
+
+defaults:
+  provider: google
+  model: gemini-2.5-flash
+  temperature: 0.2
+  thinking_budget: 0
+
+state:
+  name: str
+  style: str
+
+nodes:
+  greet:
+    type: llm
+    prompt: greet
+    variables:
+      name: "{state.name}"
+      style: "{state.style}"
+    state_key: greeting
+
+edges:
+  - from: START
+    to: greet
+  - from: greet
+    to: END

--- a/examples/demos/hellograph-speed/graph.vertex.yaml
+++ b/examples/demos/hellograph-speed/graph.vertex.yaml
@@ -1,0 +1,34 @@
+# HelloGraph Speed Demo - Vertex API
+# Same hello graph as demo/hello, configured for provider=vertex
+
+version: "1.0"
+name: hellograph-speed-vertex
+description: Hello graph configured for Vertex speed checks
+
+prompts_relative: true
+prompts_dir: prompts
+
+defaults:
+  provider: vertex
+  model: gemini-2.5-flash
+  temperature: 0.2
+  thinking_budget: 0
+
+state:
+  name: str
+  style: str
+
+nodes:
+  greet:
+    type: llm
+    prompt: greet
+    variables:
+      name: "{state.name}"
+      style: "{state.style}"
+    state_key: greeting
+
+edges:
+  - from: START
+    to: greet
+  - from: greet
+    to: END

--- a/examples/demos/hellograph-speed/prompts/greet.yaml
+++ b/examples/demos/hellograph-speed/prompts/greet.yaml
@@ -1,0 +1,12 @@
+system: |
+  You are a friendly assistant that generates personalized greetings.
+  Adjust your greeting style based on the requested tone.
+
+user: |
+  Generate a greeting for "{name}" in a {style} style.
+
+  The greeting should:
+
+  - Match the requested tone ({style})
+  - Be culturally appropriate
+  - Be memorable and warm

--- a/examples/demos/hellograph-speed/vars.yaml
+++ b/examples/demos/hellograph-speed/vars.yaml
@@ -1,0 +1,2 @@
+name: World
+style: holy see of code


### PR DESCRIPTION
- Restore missing files from commit b018fa7 for examples/demos/hellograph-speed
- Added provider graphs (google, vertex), vars.yaml, and prompt greet.yaml
- Enables running graph.google.yaml and graph.vertex.yaml with vars.yaml