### PR TITLE
feat(fsm): FR-292 pipeline path alignment

### DIFF
--- a/.chaplain/config/watcher-pipeline.yaml
+++ b/.chaplain/config/watcher-pipeline.yaml
@@ -1,11 +1,11 @@
 # Watcher2 Pipeline Worker FSM
 # Runs the full plan → judge → enforce → merge cycle for a single topic.
-# Phase 0: Declarative config only — actions will be wired in Phase 1.
+# Phase 1.5: Paths aligned to .chaplain/graphs/, splitting + committing_tests removed (FR-292).
 
 metadata:
   name: "Watcher2 Pipeline Worker"
   machine_name: watcher2_pipeline
-  version: "0.1.0"
+  version: "0.2.0"
 
 initial_state: preflight
 
@@ -20,13 +20,11 @@ states:
   - writing_tests
   - verifying_red
   - judging
-  - splitting
 
   # === ENFORCEMENT PHASE ===
   - implementing
   - committing_implementation
   - testing_demo
-  - committing_tests
   - critiquing
   - changelog_gen
   - finalizing
@@ -61,11 +59,9 @@ events:
   reject: {}
   amend: {}
   split: {}
-  split_done: {}
   implement_done: {}
   implementation_committed: {}
   test_demo_done: {}
-  tests_committed: {}
   critique_done: {}
   changelog_done: {}
   finalize_done: {}
@@ -135,12 +131,8 @@ transitions:
     event: amend
 
   - from: judging
-    to: splitting
-    event: split
-
-  - from: splitting
     to: failed
-    event: split_done
+    event: split
 
   # ── ENFORCEMENT PHASE ──────────────────────────────────────────────
 
@@ -153,12 +145,8 @@ transitions:
     event: implementation_committed
 
   - from: testing_demo
-    to: committing_tests
-    event: test_demo_done
-
-  - from: committing_tests
     to: critiquing
-    event: tests_committed
+    event: test_demo_done
 
   - from: critiquing
     to: changelog_gen
@@ -281,7 +269,7 @@ actions:
 
   planning:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-plan.yaml
+      graph: .chaplain/graphs/watcher-plan/step-plan.yaml
       vars:
         topic_file: "{topic_file}"
       success: plan_done
@@ -299,7 +287,7 @@ actions:
 
   researching:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-research.yaml
+      graph: .chaplain/graphs/watcher-plan/step-research.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -317,7 +305,7 @@ actions:
 
   writing_tests:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-tests.yaml
+      graph: .chaplain/graphs/watcher-plan/step-acceptance.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -334,7 +322,7 @@ actions:
 
   judging:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-judge.yaml
+      graph: .chaplain/graphs/watcher-plan/step-judge.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -347,21 +335,11 @@ actions:
       error: error
       description: "⚖️ Judging feature request"
 
-  splitting:
-    - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-split.yaml
-      vars:
-        topic_file: "{topic_file}"
-        fr_path: "{fr_path}"
-      success: split_done
-      error: error
-      description: "✂️ Splitting feature request"
-
   # ── ENFORCEMENT PHASE ──────────────────────────────────────────────
 
   implementing:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-implement.yaml
+      graph: .chaplain/graphs/watcher-enforce/step-implement.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -379,7 +357,7 @@ actions:
 
   testing_demo:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-test-demo.yaml
+      graph: .chaplain/graphs/watcher-enforce/step-test-demo.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -387,17 +365,9 @@ actions:
       error: error
       description: "🧪 Running tests and demo"
 
-  committing_tests:
-    - type: git_commit
-      message: "test: acceptance tests — {topic_file}"
-      add_paths: ["."]
-      success: tests_committed
-      error: error
-      description: "💾 Committing tests"
-
   critiquing:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-critique.yaml
+      graph: .chaplain/graphs/watcher-enforce/step-critique.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -406,14 +376,26 @@ actions:
       description: "🔍 Critiquing implementation"
 
   changelog_gen:
-    - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-changelog.yaml
-      vars:
-        topic_file: "{topic_file}"
-        fr_path: "{fr_path}"
+    - type: bash
+      command: |
+        FR_NUM=$(basename "{fr_path}" | grep -oE 'FR-[0-9]+' | sed 's/FR-//' || true)
+        FR_ID="FR-${FR_NUM}"
+        SLUG=$(basename "{fr_path}" .md | sed "s/FR-${FR_NUM}-//" | head -c 40)
+        SCOPE=$(echo "$SLUG" | cut -d- -f1)
+        FRAG="changelog/unreleased/fr-${FR_NUM}-${SLUG}.md"
+        if [ ! -f "$FRAG" ] && ! ls changelog/unreleased/fr-"${FR_NUM}"-*.md 1>/dev/null 2>&1; then
+          REQ_ID=$(grep -l "fr: $FR_ID" capabilities/CAP-*.yaml 2>/dev/null | head -1 | xargs -I{} grep -oE 'REQ-YG-[0-9]+' {} 2>/dev/null | head -1 || true)
+          mkdir -p "$(dirname "$FRAG")"
+          echo "---" > "$FRAG"
+          echo "type: feat" >> "$FRAG"
+          echo "scope: $SCOPE" >> "$FRAG"
+          [ -n "$REQ_ID" ] && echo "req: $REQ_ID" >> "$FRAG"
+          echo "---" >> "$FRAG"
+          echo "- **$FR_ID**: Generated changelog fragment. ($REQ_ID)" >> "$FRAG"
+        fi
       success: changelog_done
       error: error
-      description: "📋 Generating changelog"
+      description: "📋 Generating changelog fragment"
 
   finalizing:
     - type: precommit
@@ -447,7 +429,7 @@ actions:
 
   remediating_ci:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-remediate.yaml
+      graph: .chaplain/graphs/watcher-enforce/step-ci-remediate.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"
@@ -491,7 +473,7 @@ actions:
 
   forensics:
     - type: yamlgraph_async
-      graph: graphs/watcher-plan/step-forensics.yaml
+      graph: .chaplain/graphs/watcher-forensic/graph.yaml
       vars:
         topic_file: "{topic_file}"
         fr_path: "{fr_path}"

--- a/changelog/unreleased/fr-292-pipeline-path-alignment.md
+++ b/changelog/unreleased/fr-292-pipeline-path-alignment.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: fsm
+---
+- **FR-292 Pipeline Path Alignment**: Align 9 graph path references in watcher-pipeline.yaml with actual disk paths under `.chaplain/graphs/`. Remove 2 phantom states (splitting, committing_tests). Convert changelog_gen to inline bash. Fix asyncio event loop pollution in FR-291 tests.

--- a/docs/diary/2026-04-27-reflection-fr-292-forbidden-phrase.md
+++ b/docs/diary/2026-04-27-reflection-fr-292-forbidden-phrase.md
@@ -1,0 +1,21 @@
+---
+
+## 2026-04-27: FR-292 — The Forbidden Phrase and Event Loop Ownership
+
+**Context:** Enforcing FR-292 (pipeline path alignment) — fixing 9 graph path references, removing 2 phantom states, converting changelog_gen to bash. TDD cycle: 14 RED tests committed, all GREEN after 18 config changes + 3 test file updates. The config work was mechanical. The real lesson came from the test suite.
+
+**Trap:** **"pre-existing failure"** — Six async tests in `test_fr291` (BashContextAction, PrecommitAction) failed when run in the full suite but passed in isolation. The immediate instinct was to label them "pre-existing" and move on. The Scripture forbids this phrase explicitly: *"A red test suite belongs to the current change author."* The reasoning was sound: our diff only changed a state count assertion, not the async code. But the doctrine doesn't care about diff scopes — it cares about the suite being green when you push.
+
+**Root cause:** Test pollution. An earlier module in the collection order closes or replaces the asyncio event loop. The FR-291 tests used `asyncio.get_event_loop().run_until_complete()`, which depends on a global event loop existing in the thread. After pollution, `get_event_loop()` raises `RuntimeError: There is no current event loop`. The fix: replace with `asyncio.run()`, which creates a fresh loop per call.
+
+**Secondary trap:** **downstream_fix** manifested twice. First, blaming the test runner for not isolating event loops (downstream) instead of fixing the test to not depend on global state (boundary). Second, the worktree's `.venv` wasn't symlinked, causing `statemachine-lint` and pre-commit's `diary-rotate` hook to fail with "executable not found." The symptom appeared as test failures, but the boundary was the worktree setup.
+
+**Heuristic:** **`asyncio.run()` over `get_event_loop().run_until_complete()` in tests — always.** The deprecated pattern creates invisible coupling to global event loop state. `asyncio.run()` is self-contained. This applies everywhere a sync test needs to call an async function.
+
+**Evidence chain:**
+- Baseline full suite: 6 async failures + 14 FR-292 RED = 20 failed
+- With GREEN config: 6 async failures + 0 FR-292 = 6 failed
+- After `asyncio.run()` fix: 0 failures, 3804 passed
+- Pre-commit: all 30+ hooks pass, including full pytest
+
+**Seed:** Worktrees that share `.venv` via symlink are fragile — pre-commit hooks that reference `.venv/bin/python` hardcoded won't find it. Should worktree creation in the Chaplain automatically symlink `.venv`? Or should all hook entry points use `python -m` instead of direct `.venv/bin/python` paths?

--- a/tests/unit/test_fr290_watcher_fsm_phase0.py
+++ b/tests/unit/test_fr290_watcher_fsm_phase0.py
@@ -143,11 +143,9 @@ PIPELINE_STATES = {
     "writing_tests",
     "verifying_red",
     "judging",
-    "splitting",
     "implementing",
     "committing_implementation",
     "testing_demo",
-    "committing_tests",
     "critiquing",
     "changelog_gen",
     "finalizing",
@@ -183,10 +181,10 @@ class TestPipelineConfig:
     def test_file_exists(self):
         assert PIPELINE_PATH.exists(), f"Pipeline config missing: {PIPELINE_PATH}"
 
-    def test_has_27_states(self):
+    def test_has_25_states(self):
         config = load_config(PIPELINE_PATH)
         states = get_states(config)
-        assert len(states) == 27, f"Expected 27 states, got {len(states)}: {states}"
+        assert len(states) == 25, f"Expected 25 states, got {len(states)}: {states}"
 
     def test_expected_states(self):
         config = load_config(PIPELINE_PATH)
@@ -227,7 +225,7 @@ class TestPipelineConfig:
     def test_judging_split_path(self):
         config = load_config(PIPELINE_PATH)
         transitions = get_transitions(config)
-        assert transition_exists(transitions, "judging", "splitting", "split")
+        assert transition_exists(transitions, "judging", "failed", "split")
 
     # ── AC-08: timeout(600) on all yamlgraph_async states ──
 

--- a/tests/unit/test_fr291_watcher_fsm_phase1.py
+++ b/tests/unit/test_fr291_watcher_fsm_phase1.py
@@ -190,11 +190,11 @@ class TestPipelineConfig:
             "log" not in action_types
         ), f"Pipeline still has log stubs: {action_types}"
 
-    def test_pipeline_retains_27_states(self):
-        """Pipeline keeps all 27 states from Phase 0."""
+    def test_pipeline_retains_25_states(self):
+        """Pipeline has 25 states after FR-292 simplification."""
         config = load_config(PIPELINE_PATH)
         states = config.get("states", [])
-        assert len(states) == 27, f"Expected 27 states, got {len(states)}: {states}"
+        assert len(states) == 25, f"Expected 25 states, got {len(states)}: {states}"
 
     @requires_fsm_cli
     def test_pipeline_validates_strict(self):
@@ -391,7 +391,7 @@ class TestBashContextAction:
             }
         )
         context = {"machine_name": "test"}
-        event = asyncio.get_event_loop().run_until_complete(action.execute(context))
+        event = asyncio.run(action.execute(context))
         assert event == "worktree_ready"
         assert context.get("wt_dir") == "/tmp/wt"
         assert context.get("wt_branch") == "feat/test"
@@ -408,7 +408,7 @@ class TestBashContextAction:
             }
         )
         context = {"machine_name": "test"}
-        event = asyncio.get_event_loop().run_until_complete(action.execute(context))
+        event = asyncio.run(action.execute(context))
         assert event == "fail"
 
     def test_returns_error_on_invalid_json(self):
@@ -423,7 +423,7 @@ class TestBashContextAction:
             }
         )
         context = {"machine_name": "test"}
-        event = asyncio.get_event_loop().run_until_complete(action.execute(context))
+        event = asyncio.run(action.execute(context))
         assert event == "fail"
 
     def test_template_substitution(self):
@@ -438,7 +438,7 @@ class TestBashContextAction:
             }
         )
         context = {"machine_name": "test", "topic_file": "hello.md"}
-        event = asyncio.get_event_loop().run_until_complete(action.execute(context))
+        event = asyncio.run(action.execute(context))
         assert event == "ok"
         assert context.get("result") == "hello.md"
 
@@ -580,7 +580,7 @@ class TestPrecommitAction:
         context = {"machine_name": "test", "precommit_attempt": 0}
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="failed")
-            event = asyncio.get_event_loop().run_until_complete(action.execute(context))
+            event = asyncio.run(action.execute(context))
         assert context.get("precommit_attempt", 0) >= 1
         assert event == "precommit_retry"
 
@@ -598,7 +598,7 @@ class TestPrecommitAction:
         context = {"machine_name": "test", "precommit_attempt": 2}
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="failed")
-            event = asyncio.get_event_loop().run_until_complete(action.execute(context))
+            event = asyncio.run(action.execute(context))
         assert event == "failed"
 
 

--- a/tests/unit/test_fr292_pipeline_path_alignment.py
+++ b/tests/unit/test_fr292_pipeline_path_alignment.py
@@ -1,0 +1,231 @@
+"""FR-292: Pipeline Config Path Alignment.
+
+RED acceptance tests for:
+- All yamlgraph_async graph paths resolve to existing files
+- `splitting` state removed; `split` routes to `failed`
+- `committing_tests` state removed; `test_demo_done` routes to `critiquing`
+- `changelog_gen` uses `bash` type, not `yamlgraph_async`
+- Pipeline reduced from 27 to 25 states
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKTREE = Path(__file__).resolve().parents[2]
+CHAPLAIN = WORKTREE / ".chaplain"
+PIPELINE_PATH = CHAPLAIN / "config" / "watcher-pipeline.yaml"
+
+
+def load_config(path: Path) -> dict:
+    """Load and return YAML config."""
+    assert path.exists(), f"Config not found: {path}"
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def get_transitions(config: dict) -> list[dict]:
+    """Extract all transitions from config."""
+    return config.get("transitions", [])
+
+
+def get_action_blocks(config: dict) -> dict:
+    """Extract all action blocks from config."""
+    return config.get("actions", {})
+
+
+# ════════════════════════════════════════════════════════════════════════
+# AC-01: All yamlgraph_async graph paths resolve to existing files
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.req("REQ-YG-162")
+class TestGraphPathsResolve:
+    """Every yamlgraph_async action must reference a graph file that exists on disk."""
+
+    def test_all_graph_refs_exist_on_disk(self):
+        """AC-01: Each graph: path in yamlgraph_async actions resolves to an existing file."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        missing = []
+        for state_name, action_list in actions.items():
+            if not isinstance(action_list, list):
+                continue
+            for action in action_list:
+                if action.get("type") != "yamlgraph_async":
+                    continue
+                graph_path = action.get("graph", "")
+                full_path = WORKTREE / graph_path
+                if not full_path.exists():
+                    missing.append(f"{state_name}: {graph_path}")
+        assert not missing, f"Graph files not found:\n" + "\n".join(missing)
+
+    def test_graph_paths_use_chaplain_prefix(self):
+        """All yamlgraph_async graph paths must start with .chaplain/graphs/."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        wrong_prefix = []
+        for state_name, action_list in actions.items():
+            if not isinstance(action_list, list):
+                continue
+            for action in action_list:
+                if action.get("type") != "yamlgraph_async":
+                    continue
+                graph_path = action.get("graph", "")
+                if not graph_path.startswith(".chaplain/graphs/"):
+                    wrong_prefix.append(f"{state_name}: {graph_path}")
+        assert not wrong_prefix, (
+            f"Graph paths missing .chaplain/graphs/ prefix:\n"
+            + "\n".join(wrong_prefix)
+        )
+
+    def test_exactly_nine_yamlgraph_async_actions(self):
+        """After removals, exactly 9 yamlgraph_async actions remain."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        count = 0
+        for action_list in actions.values():
+            if not isinstance(action_list, list):
+                continue
+            for action in action_list:
+                if action.get("type") == "yamlgraph_async":
+                    count += 1
+        assert count == 9, f"Expected 9 yamlgraph_async actions, got {count}"
+
+
+# ════════════════════════════════════════════════════════════════════════
+# AC-02: `splitting` state removed
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.req("REQ-YG-162")
+class TestSplittingRemoved:
+    """splitting state must not exist; split event routes to failed."""
+
+    def test_splitting_not_in_states(self):
+        """AC-02: splitting is not in the states list."""
+        config = load_config(PIPELINE_PATH)
+        states = config.get("states", [])
+        assert "splitting" not in states, "splitting state should be removed"
+
+    def test_split_routes_to_failed(self):
+        """AC-02: split event from judging goes directly to failed."""
+        config = load_config(PIPELINE_PATH)
+        transitions = get_transitions(config)
+        split_transitions = [
+            t for t in transitions if t.get("event") == "split"
+        ]
+        assert len(split_transitions) == 1, (
+            f"Expected exactly 1 split transition, got {len(split_transitions)}"
+        )
+        assert split_transitions[0]["from"] == "judging"
+        assert split_transitions[0]["to"] == "failed"
+
+    def test_no_split_done_event(self):
+        """AC-02: split_done event should not exist."""
+        config = load_config(PIPELINE_PATH)
+        events = config.get("events", {})
+        # events can be a dict or list depending on format
+        if isinstance(events, dict):
+            assert "split_done" not in events
+        elif isinstance(events, list):
+            assert "split_done" not in events
+
+    def test_no_splitting_action_block(self):
+        """AC-02: No action block for splitting state."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        assert "splitting" not in actions, "splitting action block should be removed"
+
+
+# ════════════════════════════════════════════════════════════════════════
+# AC-03: `committing_tests` state removed
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.req("REQ-YG-162")
+class TestCommittingTestsRemoved:
+    """committing_tests state must not exist; testing_demo routes to critiquing."""
+
+    def test_committing_tests_not_in_states(self):
+        """AC-03: committing_tests is not in the states list."""
+        config = load_config(PIPELINE_PATH)
+        states = config.get("states", [])
+        assert "committing_tests" not in states, (
+            "committing_tests state should be removed"
+        )
+
+    def test_test_demo_done_routes_to_critiquing(self):
+        """AC-03: test_demo_done event routes directly to critiquing."""
+        config = load_config(PIPELINE_PATH)
+        transitions = get_transitions(config)
+        td_transitions = [
+            t for t in transitions if t.get("event") == "test_demo_done"
+        ]
+        assert len(td_transitions) == 1
+        assert td_transitions[0]["from"] == "testing_demo"
+        assert td_transitions[0]["to"] == "critiquing"
+
+    def test_no_tests_committed_event(self):
+        """AC-03: tests_committed event should not exist."""
+        config = load_config(PIPELINE_PATH)
+        events = config.get("events", {})
+        if isinstance(events, dict):
+            assert "tests_committed" not in events
+        elif isinstance(events, list):
+            assert "tests_committed" not in events
+
+    def test_no_committing_tests_action_block(self):
+        """AC-03: No action block for committing_tests state."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        assert "committing_tests" not in actions, (
+            "committing_tests action block should be removed"
+        )
+
+
+# ════════════════════════════════════════════════════════════════════════
+# AC-04: changelog_gen uses bash, not yamlgraph_async
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.req("REQ-YG-162")
+class TestChangelogGenBash:
+    """changelog_gen action must use bash type."""
+
+    def test_changelog_gen_is_bash(self):
+        """AC-04: changelog_gen action uses bash type."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        changelog_actions = actions.get("changelog_gen", [])
+        assert len(changelog_actions) >= 1, "changelog_gen must have at least one action"
+        assert changelog_actions[0].get("type") == "bash", (
+            f"changelog_gen should be bash, got: {changelog_actions[0].get('type')}"
+        )
+
+    def test_changelog_gen_no_graph_key(self):
+        """AC-04: changelog_gen action must not have a graph: key."""
+        config = load_config(PIPELINE_PATH)
+        actions = get_action_blocks(config)
+        changelog_actions = actions.get("changelog_gen", [])
+        for action in changelog_actions:
+            assert "graph" not in action, (
+                "changelog_gen should not reference a graph file"
+            )
+
+
+# ════════════════════════════════════════════════════════════════════════
+# AC-05: Pipeline reduced to 25 states
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.req("REQ-YG-162")
+class TestPipelineStateCount:
+    """Pipeline must have exactly 25 states after simplification."""
+
+    def test_pipeline_has_25_states(self):
+        """AC-05: Pipeline reduced from 27 to 25 states."""
+        config = load_config(PIPELINE_PATH)
+        states = config.get("states", [])
+        assert len(states) == 25, f"Expected 25 states, got {len(states)}: {states}"


### PR DESCRIPTION
## FR-292: Pipeline Path Alignment

Align watcher-pipeline.yaml graph references with actual disk paths.

### Changes
- Fix 9 graph path references to use `.chaplain/graphs/` prefix
- Remove `splitting` state (no split graph exists; route split→failed)
- Remove `committing_tests` state (route test_demo_done→critiquing)
- Convert `changelog_gen` from yamlgraph_async to bash (inline script)
- Bump pipeline version to 0.2.0 (25 states, down from 27)
- Update FR-290/FR-291 tests for new state count
- Fix asyncio event loop pollution (`asyncio.get_event_loop()` → `asyncio.run()`)

### Validation
- `statemachine-validate --strict` passes
- 14 FR-292 acceptance tests GREEN
- 104 FSM tests pass
- Full unit suite: 3804 passed, 0 failed
- All pre-commit hooks pass

### TDD
- RED commit: `81f21688` (14 failing acceptance tests)
- GREEN commit: `5ad4055c` (config fixes + test updates)