### PR TITLE
feat(tests): FR-293 add pytest-xdist parallel test execution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,7 +225,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest (unit only, ~20s)
-        entry: bash -c '.venv/bin/python -m pytest tests/unit/ -q --tb=short --no-cov && echo "" && echo "✓ Unit tests passed. Run integration tests separately:" && echo "  pytest tests/integration/ -v"'
+        entry: bash -c '.venv/bin/python -m pytest tests/unit/ -q --tb=short --no-cov -m "not slow" -n auto && echo "" && echo "✓ Unit tests passed. Run integration tests separately:" && echo "  pytest tests/integration/ -v"'
         language: system
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,10 @@ pre-commit install --hook-type commit-msg
 
 ### Testing
 ```bash
-# Ultra-fast tests (skip slow tests)
+# Ultra-fast parallel tests (skip slow, ~20s on 12 cores)
+pytest tests/unit/ -q --no-cov -m "not slow" -n auto
+
+# Ultra-fast tests sequential (skip slow, ~42s)
 pytest tests/unit/ -q --no-cov -m "not slow"
 
 # Fast unit tests (no coverage report)

--- a/changelog/unreleased/fr-293-pytest-xdist.md
+++ b/changelog/unreleased/fr-293-pytest-xdist.md
@@ -1,0 +1,7 @@
+## FR-293: pytest-xdist parallel test execution
+
+- Added `pytest-xdist>=3.5.0` to dev dependencies
+- Pre-commit pytest hook now uses `-n auto -m "not slow"` for parallel execution
+- Fixed surrogate Unicode in `image_node.py` that crashed xdist workers
+- Unit test fast run: 42s → 21s (parallel on 12 cores)
+- CI workflow unchanged (coverage + xdist needs separate validation)

--- a/docs/confessions.md
+++ b/docs/confessions.md
@@ -641,6 +641,12 @@ These are E402 suppressions and are acceptable as "glue code" patterns.
 - **Sin**: `list_diary_files(state)` ignores the `state` parameter — the function needs no input state.
 - **Penance**: YAMLGraph python-node signature requires a `state: dict` parameter. The function scans the filesystem directly, so `state` is unused but mandatory for the node contract.
 
+### CONF-142
+- **File**: [tests/unit/test_fr293_pytest_xdist.py](../tests/unit/test_fr293_pytest_xdist.py#L15)
+- **Code**: F401
+- **Sin**: `import xdist` appears unused — the module is imported but not referenced.
+- **Penance**: The import IS the test — we're asserting that xdist is importable (installed). F401 cannot understand this pattern.
+
 ### CONF-210
 - **File**: [yamlgraph/node_factory/copilot_node.py](../yamlgraph/node_factory/copilot_node.py#L292)
 - **Code**: S603

--- a/docs/dependency-rationale.yaml
+++ b/docs/dependency-rationale.yaml
@@ -80,6 +80,11 @@ dependencies:
     modules: ["pyproject.toml [tool.pytest.ini_options]"]
     added: "0.1.0"
 
+  pytest-xdist:
+    rationale: "Parallel test execution across 12 cores — FR-293 (42s → 21s)"
+    modules: ["tests/"]
+    added: "0.4.69"
+
   ruff:
     rationale: "Linter and formatter — Commandment 6 (expose every fault)"
     modules: ["pyproject.toml [tool.ruff]"]

--- a/docs/diary/2026-04-27-reflection-fr-293-pytest-xdist.md
+++ b/docs/diary/2026-04-27-reflection-fr-293-pytest-xdist.md
@@ -1,0 +1,28 @@
+# Reflection: FR-293 pytest-xdist parallel tests
+
+**Date:** 2026-04-27
+**FR:** FR-293
+**Trap encountered:** downstream_fix — surrogate Unicode in source file only manifested under xdist serialization
+
+## What happened
+
+Adding pytest-xdist for parallel test execution revealed a lurking bug: `image_node.py` contained surrogate-pair escape sequences (`\ud83d\uddbc\ufe0f`) in logger calls instead of proper Unicode emoji. These are valid Python string literals but invalid UTF-8 — they can't be serialized by execnet across worker boundaries.
+
+The fix was at the boundary (the source file), not downstream (suppressing the xdist error).
+
+## Insight
+
+**The One Law applied:** The surrogate data entered at the source code boundary. Normalizing there (replacing escape sequences with real emoji) fixed all downstream consumers — xdist, log output, CI, everything.
+
+**Benchmark-first worked:** Implementation Step 0 (benchmark before committing) caught the crash immediately and validated the 21s target before any other changes.
+
+## Metrics
+
+- Sequential (no slow): 42s
+- Parallel `-n auto` (12 cores): 21.8s
+- Speedup: 1.93x (I/O-bound tests don't parallelize as well as CPU-bound)
+- Worker startup overhead: ~3s (acceptable for 3700+ tests)
+
+## Seed
+
+**When should xdist be extended to CI?** Coverage + xdist requires `pytest-cov` distributed mode. The 2-4 core CI runners may not benefit. Is there a threshold (core count × test count) below which xdist overhead exceeds sequential execution?

--- a/examples/storyboard/nodes/image_node.py
+++ b/examples/storyboard/nodes/image_node.py
@@ -66,7 +66,7 @@ def generate_images_node(state: GraphState) -> dict:
 
     # Get model selection from state (default: z-image)
     model_name = state.get("model", "z-image")
-    logger.info(f"\ud83d\uddbc\ufe0f  Using model: {model_name}")
+    logger.info(f"🖼️  Using model: {model_name}")
 
     # Generate each panel image
     results: list[ImageResult] = []
@@ -78,7 +78,7 @@ def generate_images_node(state: GraphState) -> dict:
             continue
 
         output_path = output_dir / f"panel_{i}.png"
-        logger.info(f"\ud83d\udcf8 Panel {i}: {prompt[:60]}...")
+        logger.info(f"📸 Panel {i}: {prompt[:60]}...")
 
         result = generate_image(prompt, output_path, model_name=model_name)
         results.append(result)

--- a/feature-requests/FR-293-pytest-xdist-parallel-tests.md
+++ b/feature-requests/FR-293-pytest-xdist-parallel-tests.md
@@ -1,6 +1,12 @@
 # Feature Request: FR-293 pytest-xdist parallel test execution
 
-## Status: Judged — Approved with amendments
+## Status: Enforced
+
+### Implementation Decisions
+- AC-07 resolved: CI excluded from xdist scope (coverage + xdist needs separate validation; CI has 2-4 cores where overhead may negate gains)
+- AC-08 deferred: Coverage correctness with xdist not yet validated for CI
+- Surrogate Unicode fix in `image_node.py` was required for xdist worker serialization
+- Pre-existing FR-291 failures (missing `statemachine-lint`) unrelated to xdist
 
 ## Problem
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.0.0",
+    "pytest-xdist>=3.5.0",
     "ruff>=0.1.0",
     "radon>=6.0.0",
     "vulture>=2.0",

--- a/tests/unit/test_fr293_pytest_xdist.py
+++ b/tests/unit/test_fr293_pytest_xdist.py
@@ -1,0 +1,99 @@
+"""FR-293: pytest-xdist parallel test execution.
+
+Structural tests verifying xdist is properly configured.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_xdist_is_installed():
+    """pytest-xdist must be importable."""
+    import xdist  # noqa: F401
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_xdist_in_pyproject_dev_deps():
+    """pytest-xdist must be listed in pyproject.toml dev dependencies."""
+    from pathlib import Path
+
+    pyproject = Path(__file__).parents[2] / "pyproject.toml"
+    content = pyproject.read_text()
+    assert "pytest-xdist" in content, "pytest-xdist missing from pyproject.toml"
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_precommit_uses_parallel_flag():
+    """Pre-commit pytest hook must include -n auto for parallel execution."""
+    from pathlib import Path
+
+    config = Path(__file__).parents[2] / ".pre-commit-config.yaml"
+    content = config.read_text()
+    assert "-n auto" in content, "Pre-commit pytest hook missing -n auto flag"
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_precommit_excludes_slow_tests():
+    """Pre-commit pytest hook must include -m 'not slow' filter."""
+    from pathlib import Path
+
+    config = Path(__file__).parents[2] / ".pre-commit-config.yaml"
+    content = config.read_text()
+    assert "not slow" in content, "Pre-commit pytest hook missing slow filter"
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_dependency_rationale_entry():
+    """pytest-xdist must have an entry in dependency-rationale.yaml."""
+    from pathlib import Path
+
+    rationale = Path(__file__).parents[2] / "docs" / "dependency-rationale.yaml"
+    content = rationale.read_text()
+    assert (
+        "pytest-xdist" in content
+    ), "pytest-xdist missing from dependency-rationale.yaml"
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_no_surrogate_unicode_in_image_node():
+    """image_node.py must not contain surrogate Unicode escape sequences.
+
+    Surrogates crash xdist workers (execnet can't serialize them).
+    """
+    from pathlib import Path
+
+    image_node = (
+        Path(__file__).parents[2]
+        / "examples"
+        / "storyboard"
+        / "nodes"
+        / "image_node.py"
+    )
+    content = image_node.read_text(encoding="utf-8")
+    # Verify no surrogate escapes in source
+    assert "\\ud83d" not in content, "Surrogate escape sequences found in image_node.py"
+
+
+@pytest.mark.req("REQ-YG-012")
+@pytest.mark.slow
+def test_xdist_n_flag_accepted():
+    """pytest must accept -n auto flag (xdist plugin loaded)."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--co",
+            "-q",
+            "-n",
+            "auto",
+            "tests/unit/test_fr293_pytest_xdist.py",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"pytest -n auto rejected: {result.stderr}"


### PR DESCRIPTION
Add pytest-xdist for parallel unit test execution (42s → 21s).

- pytest-xdist>=3.5.0 added to dev dependencies
- Pre-commit hook: -n auto and -m 'not slow' flags
- Fixed surrogate Unicode in image_node.py (crashed xdist workers)
- CLAUDE.md updated with parallel commands
- 7 witness tests, diary reflection, changelog fragment