### PR TITLE
fix(ci): FR-294 pre-commit pytest hook venv PATH isolation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,7 +225,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest (unit only, ~20s)
-        entry: bash -c '.venv/bin/python -m pytest tests/unit/ -q --tb=short --no-cov -m "not slow" -n auto && echo "" && echo "✓ Unit tests passed. Run integration tests separately:" && echo "  pytest tests/integration/ -v"'
+        entry: bash -c 'export PATH=".venv/bin:$PATH" && .venv/bin/python -m pytest tests/unit/ -q --tb=short --no-cov -m "not slow" -n auto && echo "" && echo "✓ Unit tests passed. Run integration tests separately:" && echo "  pytest tests/integration/ -v"'
         language: system
         pass_filenames: false
         always_run: true

--- a/changelog/unreleased/fr-294-precommit-venv-path.md
+++ b/changelog/unreleased/fr-294-precommit-venv-path.md
@@ -1,0 +1,6 @@
+---
+type: fix
+scope: ci
+req: REQ-YG-012
+---
+- **FR-294 Pre-commit venv PATH isolation**: Prepend `.venv/bin` to PATH in pytest hook so subprocess calls to venv-installed tools succeed. (REQ-YG-012)

--- a/docs/diary/2026-04-27-reflection-fr-294-precommit-venv-path.md
+++ b/docs/diary/2026-04-27-reflection-fr-294-precommit-venv-path.md
@@ -1,0 +1,17 @@
+# Reflection: FR-294 Pre-commit venv PATH isolation
+
+**Date:** 2026-04-27
+**FR:** FR-294
+**Trap encountered:** downstream_fix — test failures from missing CLI tools were diagnosed at the test level, but the root cause was the pre-commit hook's missing PATH
+
+## What happened
+
+During FR-293 enforcement, `test_dispatcher_lints_clean` failed with `FileNotFoundError: statemachine-lint`. The tool existed in `.venv/bin/` but pre-commit doesn't activate the venv — it only calls `.venv/bin/python`. Subprocess calls from within tests couldn't find venv-installed CLI tools.
+
+## Insight
+
+**The One Law:** The boundary is the pre-commit hook entry point. PATH must be normalized there, not worked around in individual tests with `shutil.which()` guards. One `export PATH=".venv/bin:$PATH"` at the entry fixes all downstream subprocess calls.
+
+## Seed
+
+Should all pre-commit hooks that invoke `.venv/bin/python` also prepend the PATH? Are there other hooks (ruff, vulture, radon) that might benefit from consistent venv PATH exposure?

--- a/feature-requests/FR-294-precommit-venv-path-isolation.md
+++ b/feature-requests/FR-294-precommit-venv-path-isolation.md
@@ -1,0 +1,48 @@
+# Feature Request: FR-294 Pre-commit pytest hook venv PATH isolation
+
+## Status: Enforced
+
+## Problem
+
+The pre-commit pytest hook invokes `.venv/bin/python -m pytest` but does not activate the venv. This means tools installed in the venv (e.g. `statemachine-lint`, `statemachine-validate`, `yamlgraph`) are not on `PATH` when tests spawn subprocesses via `subprocess.run()` or `shutil.which()`.
+
+**Symptom:** Tests that call venv-installed CLI tools fail with `FileNotFoundError` during pre-commit, but pass when the venv is manually activated.
+
+**Example:** `test_dispatcher_lints_clean` calls `subprocess.run(["statemachine-lint", ...])`. The binary exists at `.venv/bin/statemachine-lint`, but pre-commit's PATH doesn't include `.venv/bin/`.
+
+The `requires_fsm_cli` skipif guard uses `shutil.which("statemachine-validate")`, which also fails without venv activation — but the skip correctly fires only when the tool is genuinely absent. When the base conda environment leaks a different Python or when PATH ordering varies, the guard becomes unreliable.
+
+## Current hook
+
+```yaml
+entry: bash -c '.venv/bin/python -m pytest tests/unit/ -q --tb=short --no-cov'
+```
+
+## Objective
+
+Ensure pre-commit pytest hook runs with `.venv/bin` on PATH so that subprocess calls to venv-installed tools succeed.
+
+## Constraints
+
+- Must not require manual venv activation before running `git commit`
+- Must work with both `pre-commit run` and `git commit` invocations
+- Must not break CI (GitHub Actions installs deps globally, no venv)
+
+## Proposed Fix
+
+```yaml
+entry: bash -c 'export PATH=".venv/bin:$PATH" && .venv/bin/python -m pytest tests/unit/ -q --tb=short --no-cov -m "not slow" -n auto'
+```
+
+This prepends `.venv/bin` to PATH before invoking pytest, making all venv-installed tools available to subprocess calls.
+
+## Acceptance Criteria
+
+- AC-01: Pre-commit pytest hook prepends `.venv/bin` to PATH
+- AC-02: Tests calling `shutil.which("statemachine-lint")` find the binary during pre-commit
+- AC-03: Tests calling `subprocess.run(["statemachine-lint", ...])` succeed during pre-commit
+- AC-04: CI workflow unaffected (no venv in CI)
+
+## Risk
+
+- Low. PATH prepend is idempotent and scoped to the bash subshell.

--- a/tests/unit/test_fr294_precommit_venv_path.py
+++ b/tests/unit/test_fr294_precommit_venv_path.py
@@ -1,0 +1,19 @@
+"""FR-294: Pre-commit venv PATH isolation.
+
+Verify that the pre-commit pytest hook prepends .venv/bin to PATH
+so subprocess calls to venv-installed tools succeed.
+"""
+
+import pytest
+
+
+@pytest.mark.req("REQ-YG-012")
+def test_precommit_hook_exports_venv_path():
+    """Pre-commit pytest hook must export PATH with .venv/bin prepended."""
+    from pathlib import Path
+
+    config = Path(__file__).parents[2] / ".pre-commit-config.yaml"
+    content = config.read_text()
+    assert (
+        'export PATH=".venv/bin:$PATH"' in content
+    ), "Pre-commit pytest hook missing PATH export for .venv/bin"


### PR DESCRIPTION
Prepend .venv/bin to PATH in pre-commit pytest hook so subprocess calls to venv-installed tools succeed without manual venv activation.