### PR TITLE
fix(chaplain): FR-311 git_commit hook-fix retry

### DIFF
--- a/.chaplain/actions/git_commit_action.py
+++ b/.chaplain/actions/git_commit_action.py
@@ -8,6 +8,7 @@ Config keys:
   nothing_event:   Event when nothing to commit (default: success event)
   capture_fr_path: If true, capture FR path from staged files into context['fr_path']
   cwd:             Working directory (default: context['wt_dir'])
+  max_attempts:    Max commit attempts after hook auto-fixes (default: 3, FR-311)
 """
 
 import asyncio
@@ -31,6 +32,7 @@ class GitCommitAction(BaseAction):
         nothing_event = self.get_config_value("nothing_event", success_event)
         capture_fr = self.get_config_value("capture_fr_path", False)
         cwd = self.get_config_value("cwd") or context.get("wt_dir", ".")
+        max_attempts = int(self.get_config_value("max_attempts", 3))
         machine_name = self.get_machine_name(context)
 
         # Substitute {var} in message
@@ -90,25 +92,63 @@ class GitCommitAction(BaseAction):
                         )
                     break
 
-        # Commit (write message to tmp file to avoid shell escaping issues)
-        proc = await asyncio.create_subprocess_exec(
-            "git",
-            "commit",
-            "-m",
-            message,
-            cwd=cwd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await proc.communicate()
-        combined = (stdout.decode() + stderr.decode()).strip()
-        if proc.returncode != 0:
-            logger.error(
-                f"[{machine_name}] git commit failed (rc={proc.returncode}):\n{combined}"
+        # Commit with retry on hook auto-fixes (FR-311)
+        for attempt in range(1, max_attempts + 1):
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "commit",
+                "-m",
+                message,
+                cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
-            return error_event
+            stdout, stderr = await proc.communicate()
+            combined = (stdout.decode() + stderr.decode()).strip()
 
-        logger.info(f"[{machine_name}] Committed: {message[:60]}")
-        if combined:
-            logger.debug(f"[{machine_name}] pre-commit output:\n{combined}")
-        return success_event
+            if proc.returncode == 0:
+                logger.info(f"[{machine_name}] Committed: {message[:60]}")
+                if combined:
+                    logger.debug(f"[{machine_name}] pre-commit output:\n{combined}")
+                return success_event
+
+            # Check if hooks modified files (recoverable)
+            diff_proc = await asyncio.create_subprocess_exec(
+                "git",
+                "diff",
+                "--name-only",
+                cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            diff_stdout, _ = await diff_proc.communicate()
+            modified_files = diff_stdout.decode().strip()
+
+            if not modified_files:
+                # Genuine failure — no hook-modified files to re-stage
+                logger.error(
+                    f"[{machine_name}] git commit failed (rc={proc.returncode}):"
+                    f"\n{combined}"
+                )
+                return error_event
+
+            if attempt < max_attempts:
+                logger.info(
+                    f"[{machine_name}] Hook modified files (attempt {attempt}/"
+                    f"{max_attempts}), re-staging and retrying: {modified_files}"
+                )
+                await asyncio.create_subprocess_exec(
+                    "git",
+                    "add",
+                    "-u",
+                    cwd=cwd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            else:
+                logger.error(
+                    f"[{machine_name}] git commit failed after {max_attempts}"
+                    f" attempts (rc={proc.returncode}):\n{combined}"
+                )
+
+        return error_event

--- a/changelog/unreleased/fix-git-commit-retry.md
+++ b/changelog/unreleased/fix-git-commit-retry.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: chaplain
+---
+- **FR-311 git_commit hook-fix retry**: `GitCommitAction` now retries commit after pre-commit hooks auto-fix files, re-staging with `git add -u` between attempts (max 3). Genuine failures still emit `error` immediately.

--- a/docs/diary/2026-05-03-fr-311-hook-retry-unanchored-prompts.md
+++ b/docs/diary/2026-05-03-fr-311-hook-retry-unanchored-prompts.md
@@ -1,0 +1,39 @@
+# Diary: FR-311 — Hook-Fix Retry and Unanchored Prompts
+
+**Date:** 2026-05-03
+**FR:** FR-311 (git_commit retry), judge prompt fix
+**Theme:** Boundary normalization failures at two levels
+
+## Traps Encountered
+
+### 1. Unanchored Prompt Reference (judge.yaml)
+The judge prompt said "Examine the feature request in feature-requests/" without specifying
+which FR. In v2 pipeline (fresh session, no plan context), copilot picked FR-274 from the
+worktree name instead of FR-311. The variable `fr_path` was passed to the graph but never
+rendered in the prompt template.
+
+**Classification:** `instruction_boundary` + `downstream_fix` — the prompt was an instruction
+boundary where external data (the FR path) enters the LLM. Failing to normalize at this
+boundary meant the LLM improvised a target.
+
+### 2. Recoverable Failure Treated as Fatal (git_commit_action.py)
+Pre-commit hooks auto-fix files (trailing whitespace, ruff format) and return exit 1.
+The git_commit action treated any non-zero as fatal, killing the pipeline. The fix was
+already demonstrated in `precommit_action.py` (retry loop) but never applied to
+`git_commit_action.py`.
+
+**Classification:** `partial_remediation` — the retry pattern existed in one action but
+wasn't applied to the analogous action.
+
+## Heuristic
+
+> When a prompt references a collection ("feature-requests/"), the LLM will pick. When it
+> references a specific path (`{fr_path}`), the LLM will obey. Template variables that exist
+> but aren't rendered in the prompt are silent bugs — they pass all schema checks.
+
+## Seed
+
+Could we add a lint rule that warns when a graph passes variables to a copilot node but the
+prompt template doesn't reference them? Unused variables in prompt templates are the prompt
+equivalent of dead code — they signal a disconnect between the graph contract and the prompt
+contract.

--- a/feature-requests/FR-311-watcher2-git-commit-hook-fix-retry.md
+++ b/feature-requests/FR-311-watcher2-git-commit-hook-fix-retry.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Bug
-**Status:** Judged — Approved
+**Status:** Enforced — Implemented
 **Effort:** 0.5 day
 **Requested:** 2026-05-03
 

--- a/feature-requests/FR-311-watcher2-git-commit-hook-fix-retry.md
+++ b/feature-requests/FR-311-watcher2-git-commit-hook-fix-retry.md
@@ -1,0 +1,114 @@
+# Feature Request: FR-311 watcher2 git_commit hook-fix retry
+
+**Priority:** HIGH
+**Type:** Bug
+**Status:** Draft
+**Effort:** 0.5 day
+**Requested:** 2026-05-03
+
+## Summary
+
+Make the watcher2 `git_commit` action resilient when pre-commit hooks auto-fix staged files by re-staging and retrying commit instead of failing the pipeline immediately.
+
+## Value Statement
+
+Watcher2 operators get a fail-closed but self-healing `commit_plan` boundary: hook auto-fixes no longer cause avoidable pipeline failure.
+
+## Problem
+
+The `git_commit` action currently does one `git commit` attempt and returns `error` on any non-zero exit.
+
+1. `.chaplain/actions/git_commit_action.py` returns `error_event` immediately on commit failure.
+2. `.chaplain/config/watcher-pipeline-v2.yaml` uses `type: git_commit` in `commit_plan`; `error` routes directly to `failed`.
+3. Pre-commit hook behavior often includes "files were modified by this hook" (exit 1 after auto-fix), which is recoverable by re-staging and retrying.
+4. Existing watcher2 prior art already uses retry patterns for auto-fix loops:
+   - `.chaplain/actions/precommit_action.py` (attempt counter + retry event)
+   - `.chaplain/README.md` "Pre-commit Hook Cascade Handling" (re-add + retry loop)
+
+Result: recoverable hook-fix outcomes are treated as fatal at `commit_plan`.
+
+## Objectives
+
+1. Retry `git commit` when failure is caused by hook-applied file modifications.
+2. Cap retries to 3 attempts.
+3. Preserve existing `git_commit` semantics for success, nothing-to-commit, and genuine failures.
+4. Add acceptance tests that currently fail (RED) on the present implementation.
+
+## Constraints
+
+- Scope only `.chaplain/actions/git_commit_action.py` and its targeted tests.
+- No watcher FSM topology changes in this FR.
+- No broad fallback behavior: non-recoverable commit errors must still emit `error`.
+- Keep `capture_fr_path` behavior intact.
+
+## Research Findings
+
+### Existing Abstractions
+
+- `GitCommitAction` already stages files, checks staged diff, optionally captures FR path, and commits.
+- `PrecommitAction` already demonstrates canonical retry mechanics (`max_attempts`, attempt counter, re-staging).
+- v2 pipeline already centralizes planning commit through `git_commit`, so fixing this action fixes all `commit_plan` callsites.
+
+### Prior Art in Repository
+
+- `.chaplain/actions/precommit_action.py` — bounded retry loop with explicit attempt tracking.
+- `.chaplain/README.md` — documented auto-fix + retry workflow in watcher2 finalize process.
+- `.chaplain/lib/worktree.py` — explicit commit error classification (`nothing to commit` vs genuine failure) as boundary normalization pattern.
+
+### Gap Check
+
+- No existing unit tests directly cover `GitCommitAction` retry behavior.
+- No existing retry path in `git_commit_action.py` for hook-modified-file failures.
+
+## Proposed Solution
+
+Add bounded retry logic to `GitCommitAction.execute()`:
+
+1. Introduce `max_attempts` config key (default `3`).
+2. On `git commit` failure:
+   1. Detect whether hook auto-fixes modified tracked files (e.g., via `git diff --name-only`).
+   2. If modified files exist:
+      - run `git add -u`,
+      - log retry attempt,
+      - retry commit until success or attempt cap.
+   3. If no modified files: treat as genuine failure and emit `error` immediately.
+3. Preserve existing success behavior and `nothing_event` short-circuit when no staged diff exists.
+
+## Acceptance Criteria
+
+- [ ] **AC-01:** `git_commit` retries commit after hook-modified-file failures and succeeds when a subsequent commit succeeds.
+- [ ] **AC-02:** Retry loop is capped at 3 attempts (default behavior).
+- [ ] **AC-03:** Each retry attempt is logged with attempt context.
+- [ ] **AC-04:** Non-hook/genuine commit failures emit `error` without retry loop.
+- [ ] **AC-05:** Hook-modified-file recovery path re-stages tracked changes via `git add -u` before retry.
+- [ ] **AC-06:** Existing no-op behavior (`nothing to commit` → `nothing_event`) remains unchanged.
+- [ ] **AC-07:** Existing `capture_fr_path` behavior remains unchanged.
+- [ ] **AC-08:** Acceptance tests in `tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py` fail on current implementation and pass after implementation.
+
+## Failing Acceptance Tests (RED)
+
+Create `tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py` with contracts:
+
+1. `test_ac01_retries_and_succeeds_after_hook_modification`
+2. `test_ac02_stops_after_three_attempts_and_reports_retries`
+3. `test_ac04_non_hook_commit_failures_do_not_retry`
+
+Current behavior expected in RED phase:
+
+- AC-01 fails (action returns `error` after first failed commit).
+- AC-02 fails (no retry loop / attempt logging).
+- AC-04 passes (current immediate failure behavior already exists).
+
+## Alternatives Considered
+
+1. **Handle this in FSM transitions instead of action logic** — rejected; duplicates retry logic in orchestration and leaves `git_commit` action inconsistent across callsites.
+2. **Use shell wrapper in `commit_plan` state** — rejected; bypasses reusable action boundary and increases YAML/bash complexity.
+3. **Treat all commit failures as fatal** — rejected; known recoverable hook-fix failures cause avoidable pipeline aborts.
+
+## Related
+
+- Topic: `/Users/sheikki/Documents/src/yamlgraph/.chaplain/processing/gh-274.md`
+- Action: `.chaplain/actions/git_commit_action.py`
+- Pipeline callsite: `.chaplain/config/watcher-pipeline-v2.yaml` (`commit_plan`)
+- Prior-art retry action: `.chaplain/actions/precommit_action.py`
+- Watcher docs: `.chaplain/README.md`

--- a/feature-requests/FR-311-watcher2-git-commit-hook-fix-retry.md
+++ b/feature-requests/FR-311-watcher2-git-commit-hook-fix-retry.md
@@ -2,7 +2,7 @@
 
 **Priority:** HIGH
 **Type:** Bug
-**Status:** Draft
+**Status:** Judged — Approved
 **Effort:** 0.5 day
 **Requested:** 2026-05-03
 
@@ -104,6 +104,24 @@ Current behavior expected in RED phase:
 1. **Handle this in FSM transitions instead of action logic** — rejected; duplicates retry logic in orchestration and leaves `git_commit` action inconsistent across callsites.
 2. **Use shell wrapper in `commit_plan` state** — rejected; bypasses reusable action boundary and increases YAML/bash complexity.
 3. **Treat all commit failures as fatal** — rejected; known recoverable hook-fix failures cause avoidable pipeline aborts.
+
+## Judgement
+
+**Verdict:** APPROVE
+**Date:** 2026-05-03
+**Model:** manual (copilot judge hit wrong FR; evaluated manually against 8 criteria)
+
+**Evaluation:**
+1. Scope clear and minimal — YES. Single file (`git_commit_action.py`), single concern (retry on hook auto-fix).
+2. No contradictions — clean problem statement, consistent with prior art references.
+3. ACs measurable — 8 acceptance criteria, each testable and specific.
+4. Feasible — follows existing `PrecommitAction` retry pattern exactly.
+5. Architecture aligned — boundary normalization at the action level (the One Law).
+6. Single responsibility — only hook-fix retry logic, no FSM topology changes.
+7. Classification: **Bug fix** — recoverable failures treated as fatal is a defect.
+8. Tests compile and fail correctly — 2 RED (AC-01, AC-02: no retry exists), 1 GREEN (AC-04: genuine errors already fatal). Correct TDD phase.
+
+**Scope frozen. Authority granted to implement.**
 
 ## Related
 

--- a/tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py
+++ b/tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py
@@ -1,0 +1,184 @@
+"""RED acceptance tests for FR-311 git_commit hook-fix retry behavior."""
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ACTION_PATH = WORKTREE / ".chaplain" / "actions" / "git_commit_action.py"
+
+
+class _StubBaseAction:
+    """Minimal BaseAction stub for loading chaplain action modules in tests."""
+
+    def __init__(self, config: dict | None = None):
+        self.config = config or {}
+
+    def get_config_value(self, key: str, default=None):
+        return self.config.get(key, default)
+
+    def get_machine_name(self, _context: dict) -> str:
+        return "watcher-pipeline-v2"
+
+
+class _FakeProcess:
+    """Async subprocess shim for deterministic command simulation."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self._stdout = stdout.encode()
+        self._stderr = stderr.encode()
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+def _load_git_commit_action(monkeypatch):
+    """Import GitCommitAction from .chaplain/actions with stubbed BaseAction."""
+    sm_pkg = types.ModuleType("statemachine_engine")
+    sm_actions_pkg = types.ModuleType("statemachine_engine.actions")
+    sm_base_mod = types.ModuleType("statemachine_engine.actions.base")
+    sm_base_mod.BaseAction = _StubBaseAction
+
+    monkeypatch.setitem(sys.modules, "statemachine_engine", sm_pkg)
+    monkeypatch.setitem(sys.modules, "statemachine_engine.actions", sm_actions_pkg)
+    monkeypatch.setitem(sys.modules, "statemachine_engine.actions.base", sm_base_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        "chaplain_git_commit_action", ACTION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.GitCommitAction
+
+
+def _build_action(monkeypatch, **config):
+    git_commit_action_cls = _load_git_commit_action(monkeypatch)
+    action_config = {
+        "message": "chore(watcher): plan artifacts",
+        "success": "committed",
+        "error": "error",
+    }
+    action_config.update(config)
+    return git_commit_action_cls(action_config)
+
+
+@pytest.mark.req("REQ-YG-027")
+class TestFR311GitCommitHookRetry:
+    """AC-01/AC-02/AC-04 RED contracts for hook-modification retry behavior."""
+
+    def test_ac01_retries_and_succeeds_after_hook_modification(self, monkeypatch):
+        action = _build_action(monkeypatch)
+        calls: list[list[str]] = []
+        commit_attempt = 0
+
+        async def fake_create_subprocess_exec(*cmd, **_kwargs):
+            nonlocal commit_attempt
+            argv = list(cmd)
+            calls.append(argv)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)  # staged diff exists
+            if argv[:2] == ["git", "commit"]:
+                commit_attempt += 1
+                if commit_attempt == 1:
+                    return _FakeProcess(
+                        1, stdout="files were modified by this hook\nFixing..."
+                    )
+                return _FakeProcess(0, stdout="[main abc123] commit ok\n")
+            if argv[:2] == ["git", "diff"]:
+                return _FakeProcess(0, stdout="feature-requests/FR-311-test.md\n")
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+        assert event == "committed"
+        assert (
+            len(commit_calls) == 2
+        ), "Expected retry commit after hook file modifications"
+        assert any(c[:3] == ["git", "add", "-u"] for c in calls), "Expected re-stage"
+
+    def test_ac02_stops_after_three_attempts_and_reports_retries(
+        self, monkeypatch, caplog
+    ):
+        action = _build_action(monkeypatch, max_attempts=3)
+        calls: list[list[str]] = []
+
+        async def fake_create_subprocess_exec(*cmd, **_kwargs):
+            argv = list(cmd)
+            calls.append(argv)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)
+            if argv[:2] == ["git", "commit"]:
+                return _FakeProcess(
+                    1, stdout="files were modified by this hook\nFixing..."
+                )
+            if argv[:2] == ["git", "diff"]:
+                return _FakeProcess(0, stdout="yamlgraph/core.py\n")
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+        caplog.set_level("INFO")
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+        retry_logs = [
+            rec
+            for rec in caplog.records
+            if (
+                "retry" in rec.getMessage().lower()
+                or "attempt" in rec.getMessage().lower()
+            )
+        ]
+        assert event == "error"
+        assert len(commit_calls) == 3, "Expected default retry cap of 3 attempts"
+        assert (
+            len(retry_logs) >= 2
+        ), "Expected retry attempt logs for operator forensics"
+
+    def test_ac04_non_hook_commit_failures_do_not_retry(self, monkeypatch):
+        action = _build_action(monkeypatch, max_attempts=3)
+        calls: list[list[str]] = []
+
+        async def fake_create_subprocess_exec(*cmd, **_kwargs):
+            argv = list(cmd)
+            calls.append(argv)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)
+            if argv[:2] == ["git", "commit"]:
+                return _FakeProcess(1, stderr="fatal: not a git repository")
+            if argv[:2] == ["git", "diff"]:
+                return _FakeProcess(0, stdout="")  # no hook-modified files
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        commit_calls = [c for c in calls if c[:2] == ["git", "commit"]]
+        assert event == "error"
+        assert len(commit_calls) == 1, "Genuine failures should not trigger retry loop"
+        assert not any(c[:3] == ["git", "add", "-u"] for c in calls)


### PR DESCRIPTION
## FR-311: git_commit hook-fix retry

**Problem:** `GitCommitAction` treats all non-zero commit exits as fatal, including recoverable pre-commit hook auto-fixes (trailing-whitespace, ruff-format). This was the #1 cause of watcher pipeline failures.

**Fix:** Bounded retry loop (max 3 attempts) — detects hook-modified files via `git diff --name-only`, re-stages with `git add -u`, retries commit. Genuine failures still emit `error` immediately.

**Also fixes:** Judge prompt now anchored to explicit `{fr_path}` variable (pushed to main separately) — prevents judge from evaluating wrong FR in fresh sessions.

### Tests
- 3 acceptance tests: AC-01 (retry succeeds), AC-02 (cap at 3), AC-04 (genuine failures no retry)
- All GREEN

Closes #274