### PR TITLE
fix(watcher): set cwd to worktree in yamlgraph_async action

### DIFF
--- a/.chaplain/actions/yamlgraph_async_action.py
+++ b/.chaplain/actions/yamlgraph_async_action.py
@@ -50,9 +50,16 @@ class YamlgraphAsyncAction(BaseAction):
         command = " ".join(cmd_parts)
         logger.info(f"[{machine_name}] yamlgraph: {command[:120]}")
 
+        # FR-314: Run in worktree dir so relative paths (fr_path etc.) resolve
+        # correctly against the feature branch, not main.
+        wt_dir = context.get("wt_dir")
+        cwd = f"{main_dir}/{wt_dir}" if wt_dir else main_dir
+        logger.debug(f"[{machine_name}] cwd={cwd}")
+
         try:
             process = await asyncio.create_subprocess_shell(
                 command,
+                cwd=cwd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/changelog/unreleased/fix-yamlgraph-async-cwd.md
+++ b/changelog/unreleased/fix-yamlgraph-async-cwd.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: chaplain
+---
+- **FR-314 yamlgraph_async cwd**: `YamlgraphAsyncAction` now sets `cwd` to the worktree directory so relative paths (e.g. `fr_path`) resolve against the feature branch, not main. Fixes judge rejecting valid FRs that only exist on the feature branch.


### PR DESCRIPTION
## Problem

`YamlgraphAsyncAction` runs `yamlgraph graph run` with no `cwd`, so copilot CLI starts in the main repo root. Relative paths like `fr_path` (e.g. `feature-requests/FR-313-...`) resolve against main where the file doesn't exist — it only exists on the feature branch in the worktree.

This caused gh-279 judge to REJECT a valid FR because it couldn't find the file.

## Fix

Set `cwd` to `{main_dir}/{wt_dir}` when `wt_dir` is in context. Falls back to `main_dir` when no worktree is active.

Closes #279