### PR TITLE
fix(watcher): remove commit_plan step from pipeline

### DIFF
--- a/.chaplain/config/watcher-pipeline-v2.yaml
+++ b/.chaplain/config/watcher-pipeline-v2.yaml
@@ -2,15 +2,15 @@
 # FR-305: Collapsed 20+ states into operational states + terminals.
 # FR-310: Added validate + precommit_check post-enforce gate.
 #
-# Flow: setup → plan → commit_plan → judge →(approve)→ enforce_session
-#                                      ↑ revise       │ enforce_done
-#                                      └────────┘     ▼
-#                               validate ← fix_needed ← precommit_check
-#                                  │ validate_done         │ pass
-#                                  └──→ precommit_check ──→ done
-#                                          │ error (max 5)
-#                                          ▼
-#                                        failed
+# Flow: setup → plan → judge →(approve)→ enforce_session
+#                       ↑ revise       │ enforce_done
+#                       └────────┘     ▼
+#                        validate ← fix_needed ← precommit_check
+#                           │ validate_done         │ pass
+#                           └──→ precommit_check ──→ done
+#                                   │ error (max 5)
+#                                   ▼
+#                                 failed
 
 metadata:
   name: "Watcher2 Pipeline Worker v2"
@@ -23,7 +23,6 @@ states:
   # === OPERATIONAL STATES ===
   - setup
   - plan
-  - commit_plan
   - judge
   - enforce_session
   - validate
@@ -42,7 +41,6 @@ events:
       wt_branch: payload.wt_branch
       main_dir: payload.main_dir
   plan_done: {}
-  committed: {}
   approve: {}
   revise: {}
   reject: {}
@@ -64,12 +62,8 @@ transitions:
     event: setup_done
 
   - from: plan
-    to: commit_plan
-    event: plan_done
-
-  - from: commit_plan
     to: judge
-    event: committed
+    event: plan_done
 
   - from: judge
     to: enforce_session
@@ -114,10 +108,6 @@ transitions:
     event: error
 
   - from: plan
-    to: failed
-    event: error
-
-  - from: commit_plan
     to: failed
     event: error
 
@@ -181,22 +171,17 @@ actions:
         topic_file: "{topic_file}"
         worktree_dir: "{wt_dir}"
         branch: "{wt_branch}"
-      success: plan_done
+      success: ""
       error: error
       timeout: 600
       description: "📝 Planning (unified: FR + research + tests + verify-red)"
-
-  # ── COMMIT PLAN ────────────────────────────────────────────────────
-  # Commits all planning artifacts in one atomic commit.
-
-  commit_plan:
-    - type: git_commit
-      message: "chore(watcher): plan artifacts — {topic_file}"
-      add_paths: ["."]
-      capture_fr_path: true
-      success: committed
+    - type: bash_context
+      command: "cd {wt_dir} && FR=$(ls feature-requests/FR-*.md 2>/dev/null | sort -t- -k2 -n | tail -1) && echo \"{\\\"fr_path\\\": \\\"$FR\\\"}\""
+      capture_keys: [fr_path]
+      success: plan_done
       error: error
-      description: "💾 Committing plan artifacts"
+      timeout: 5
+      description: "🔍 Capture FR path from plan artifacts"
 
   # ── JUDGE ──────────────────────────────────────────────────────────
   # Fresh session, DIFFERENT MODEL from plan — no shared context, no anchoring.

--- a/changelog/unreleased/fix-remove-commit-plan.md
+++ b/changelog/unreleased/fix-remove-commit-plan.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: chaplain
+---
+- **Remove commit_plan step**: Plan artifacts are no longer committed in a separate step with pre-commit hooks. The `commit_plan` state, transitions, and action are removed. FR path is captured via lightweight `bash_context` at end of plan step. Fixes pipeline failures caused by RED acceptance tests failing pytest during plan commit.

--- a/tests/unit/test_fr305_watcher_pipeline_v2.py
+++ b/tests/unit/test_fr305_watcher_pipeline_v2.py
@@ -83,7 +83,7 @@ class TestV2PipelineStructure:
     def test_has_eleven_states_total(self):
         config = load_config(V2_PIPELINE_PATH)
         states = get_states(config)
-        assert len(states) == 11, f"Expected 11 states, got {len(states)}: {states}"
+        assert len(states) == 10, f"Expected 10 states, got {len(states)}: {states}"
 
     def test_operational_states(self):
         config = load_config(V2_PIPELINE_PATH)
@@ -91,7 +91,6 @@ class TestV2PipelineStructure:
         expected_operational = {
             "setup",
             "plan",
-            "commit_plan",
             "judge",
             "enforce_session",
             "done",
@@ -132,15 +131,10 @@ class TestV2HappyPath:
         transitions = get_transitions(config)
         assert transition_exists(transitions, "setup", "plan", "setup_done")
 
-    def test_plan_to_commit_plan(self):
+    def test_plan_to_judge(self):
         config = load_config(V2_PIPELINE_PATH)
         transitions = get_transitions(config)
-        assert transition_exists(transitions, "plan", "commit_plan", "plan_done")
-
-    def test_commit_plan_to_judge(self):
-        config = load_config(V2_PIPELINE_PATH)
-        transitions = get_transitions(config)
-        assert transition_exists(transitions, "commit_plan", "judge", "committed")
+        assert transition_exists(transitions, "plan", "judge", "plan_done")
 
     def test_judge_to_enforce_session(self):
         config = load_config(V2_PIPELINE_PATH)
@@ -209,12 +203,6 @@ class TestV2FailurePaths:
         config = load_config(V2_PIPELINE_PATH)
         transitions = get_transitions(config)
         assert transition_exists(transitions, "enforce_session", "failed", "error")
-
-    def test_commit_plan_error_to_failed(self):
-        """FR-305a: commit_plan must have error→failed to prevent infinite retry."""
-        config = load_config(V2_PIPELINE_PATH)
-        transitions = get_transitions(config)
-        assert transition_exists(transitions, "commit_plan", "failed", "error")
 
     def test_done_error_to_failed(self):
         config = load_config(V2_PIPELINE_PATH)
@@ -432,18 +420,13 @@ class TestV2ActionTypes:
         actions = get_action_config(config, "plan")
         assert actions[0]["type"] == "yamlgraph_async"
 
-    def test_commit_plan_is_git_commit(self):
+    def test_plan_captures_fr_path(self):
+        """Plan step must include bash_context action to capture fr_path."""
         config = load_config(V2_PIPELINE_PATH)
-        actions = get_action_config(config, "commit_plan")
-        assert actions[0]["type"] == "git_commit"
-
-    def test_commit_plan_uses_chore_prefix(self):
-        """FR-305a: plan commit must use chore: not feat: to avoid hook rejection."""
-        config = load_config(V2_PIPELINE_PATH)
-        actions = get_action_config(config, "commit_plan")
-        message = actions[0]["message"]
-        assert message.startswith("chore"), f"Expected chore: prefix, got: {message}"
-        assert not message.startswith("feat"), f"feat: triggers FR-XXX hook: {message}"
+        actions = get_action_config(config, "plan")
+        assert len(actions) >= 2, "Plan should have yamlgraph_async + bash_context"
+        assert actions[1]["type"] == "bash_context"
+        assert "fr_path" in actions[1].get("capture_keys", [])
 
     def test_judge_is_yamlgraph_async(self):
         config = load_config(V2_PIPELINE_PATH)


### PR DESCRIPTION
## Problem

The `commit_plan` step runs `git commit` with pre-commit hooks, which includes pytest. Plan artifacts include RED acceptance tests that intentionally fail — causing the commit to be blocked.

## Fix

- Remove `commit_plan` state, transitions, and action
- Connect `plan` directly to `judge` via `plan_done`
- Add lightweight `bash_context` action at end of plan to capture `fr_path` from FR files in worktree
- yamlgraph_async in plan uses `success: ""` (empty = no event) so the sequential bash_context runs next
- Update tests to match new 10-state pipeline