### PR TITLE
fix(watcher): replace commit_plan with capture_fr state

### DIFF
--- a/.chaplain/config/watcher-pipeline-v2.yaml
+++ b/.chaplain/config/watcher-pipeline-v2.yaml
@@ -2,9 +2,9 @@
 # FR-305: Collapsed 20+ states into operational states + terminals.
 # FR-310: Added validate + precommit_check post-enforce gate.
 #
-# Flow: setup → plan → judge →(approve)→ enforce_session
-#                       ↑ revise       │ enforce_done
-#                       └────────┘     ▼
+# Flow: setup → plan → capture_fr → judge →(approve)→ enforce_session
+#                              ↑ revise       │ enforce_done
+#                              └────────┘     ▼
 #                        validate ← fix_needed ← precommit_check
 #                           │ validate_done         │ pass
 #                           └──→ precommit_check ──→ done
@@ -23,6 +23,7 @@ states:
   # === OPERATIONAL STATES ===
   - setup
   - plan
+  - capture_fr
   - judge
   - enforce_session
   - validate
@@ -41,6 +42,7 @@ events:
       wt_branch: payload.wt_branch
       main_dir: payload.main_dir
   plan_done: {}
+  fr_captured: {}
   approve: {}
   revise: {}
   reject: {}
@@ -62,8 +64,12 @@ transitions:
     event: setup_done
 
   - from: plan
-    to: judge
+    to: capture_fr
     event: plan_done
+
+  - from: capture_fr
+    to: judge
+    event: fr_captured
 
   - from: judge
     to: enforce_session
@@ -108,6 +114,10 @@ transitions:
     event: error
 
   - from: plan
+    to: failed
+    event: error
+
+  - from: capture_fr
     to: failed
     event: error
 
@@ -171,16 +181,21 @@ actions:
         topic_file: "{topic_file}"
         worktree_dir: "{wt_dir}"
         branch: "{wt_branch}"
-      success: ""
+      success: plan_done
       error: error
       timeout: 600
       description: "📝 Planning (unified: FR + research + tests + verify-red)"
+
+  # ── CAPTURE FR PATH ─────────────────────────────────────────────────
+  # Lightweight state: find the newest FR file in the worktree.
+
+  capture_fr:
     - type: bash_context
       command: "cd {wt_dir} && FR=$(ls feature-requests/FR-*.md 2>/dev/null | sort -t- -k2 -n | tail -1) && echo \"{\\\"fr_path\\\": \\\"$FR\\\"}\""
       capture_keys: [fr_path]
-      success: plan_done
+      success: fr_captured
       error: error
-      timeout: 5
+      timeout: 10
       description: "🔍 Capture FR path from plan artifacts"
 
   # ── JUDGE ──────────────────────────────────────────────────────────

--- a/changelog/unreleased/fix-remove-commit-plan.md
+++ b/changelog/unreleased/fix-remove-commit-plan.md
@@ -2,4 +2,4 @@
 type: fix
 scope: chaplain
 ---
-- **Remove commit_plan step**: Plan artifacts are no longer committed in a separate step with pre-commit hooks. The `commit_plan` state, transitions, and action are removed. FR path is captured via lightweight `bash_context` at end of plan step. Fixes pipeline failures caused by RED acceptance tests failing pytest during plan commit.
+- **Remove commit_plan step**: Plan artifacts are no longer committed in a separate step with pre-commit hooks. The `commit_plan` state is replaced by a lightweight `capture_fr` state using `bash_context` to find the FR path. Fixes pipeline failures caused by RED acceptance tests failing pytest during plan commit.

--- a/tests/unit/test_fr305_watcher_pipeline_v2.py
+++ b/tests/unit/test_fr305_watcher_pipeline_v2.py
@@ -83,7 +83,7 @@ class TestV2PipelineStructure:
     def test_has_eleven_states_total(self):
         config = load_config(V2_PIPELINE_PATH)
         states = get_states(config)
-        assert len(states) == 10, f"Expected 10 states, got {len(states)}: {states}"
+        assert len(states) == 11, f"Expected 11 states, got {len(states)}: {states}"
 
     def test_operational_states(self):
         config = load_config(V2_PIPELINE_PATH)
@@ -91,6 +91,7 @@ class TestV2PipelineStructure:
         expected_operational = {
             "setup",
             "plan",
+            "capture_fr",
             "judge",
             "enforce_session",
             "done",
@@ -131,10 +132,15 @@ class TestV2HappyPath:
         transitions = get_transitions(config)
         assert transition_exists(transitions, "setup", "plan", "setup_done")
 
-    def test_plan_to_judge(self):
+    def test_plan_to_capture_fr(self):
         config = load_config(V2_PIPELINE_PATH)
         transitions = get_transitions(config)
-        assert transition_exists(transitions, "plan", "judge", "plan_done")
+        assert transition_exists(transitions, "plan", "capture_fr", "plan_done")
+
+    def test_capture_fr_to_judge(self):
+        config = load_config(V2_PIPELINE_PATH)
+        transitions = get_transitions(config)
+        assert transition_exists(transitions, "capture_fr", "judge", "fr_captured")
 
     def test_judge_to_enforce_session(self):
         config = load_config(V2_PIPELINE_PATH)
@@ -421,12 +427,11 @@ class TestV2ActionTypes:
         assert actions[0]["type"] == "yamlgraph_async"
 
     def test_plan_captures_fr_path(self):
-        """Plan step must include bash_context action to capture fr_path."""
+        """capture_fr state uses bash_context to find FR file."""
         config = load_config(V2_PIPELINE_PATH)
-        actions = get_action_config(config, "plan")
-        assert len(actions) >= 2, "Plan should have yamlgraph_async + bash_context"
-        assert actions[1]["type"] == "bash_context"
-        assert "fr_path" in actions[1].get("capture_keys", [])
+        actions = get_action_config(config, "capture_fr")
+        assert actions[0]["type"] == "bash_context"
+        assert "fr_path" in actions[0].get("capture_keys", [])
 
     def test_judge_is_yamlgraph_async(self):
         config = load_config(V2_PIPELINE_PATH)


### PR DESCRIPTION
Replaces #282 approach with proper separation of concerns.

## Problem
commit_plan ran git commit with pre-commit hooks including pytest. RED acceptance tests from plan step caused commit failure.

## Fix
- Replace commit_plan with dedicated `capture_fr` state
- `plan →(plan_done)→ capture_fr →(fr_captured)→ judge`
- capture_fr uses bash_context to find newest FR file in worktree
- No mixing of concerns: yamlgraph_async untouched, single-purpose state