### PR TITLE
feat(watcher): FR-321 diagnostics handoff for validate_fix

### DIFF
--- a/.chaplain/config/watcher-pipeline-v2.yaml
+++ b/.chaplain/config/watcher-pipeline-v2.yaml
@@ -271,6 +271,7 @@ actions:
         worktree_dir: "{wt_dir}"
         branch: "{wt_branch}"
         precommit_output: "{precommit_output}"
+        validate_gate_output: "{validate_gate_output}"
       success: validate_done
       error: error
       timeout: 600

--- a/.chaplain/graphs/watcher-enforce/prompts/validate-session.yaml
+++ b/.chaplain/graphs/watcher-enforce/prompts/validate-session.yaml
@@ -19,13 +19,24 @@ user: |
 
   ## Validate-gate context
 
-  {% if precommit_output and precommit_output != "" %}
+  {% set normalized_precommit_output = precommit_output | default("", true) | trim %}
+  {% if normalized_precommit_output and normalized_precommit_output != "{precommit_output}" %}
   The previous validate_gate/pre-commit attempt reported:
   ```
-  {{ precommit_output }}
+  {{ normalized_precommit_output }}
   ```
   {% else %}
   This is the first validate_fix pass — no prior gate diagnostics.
+  {% endif %}
+
+  {% set normalized_validate_gate_output = validate_gate_output | default("", true) | trim %}
+  {% if normalized_validate_gate_output and normalized_validate_gate_output != "{validate_gate_output}" %}
+  ## Validate-gate diagnostics (checks/failures)
+
+  Deterministic validate_gate checks/failures payload:
+  ```
+  {{ normalized_validate_gate_output }}
+  ```
   {% endif %}
 
   ## Process

--- a/.chaplain/graphs/watcher-enforce/validate-session.yaml
+++ b/.chaplain/graphs/watcher-enforce/validate-session.yaml
@@ -14,6 +14,7 @@ state:
   worktree_dir: str
   branch: str
   precommit_output: str
+  validate_gate_output: str
   validate_result: dict
 
 nodes:
@@ -30,6 +31,7 @@ nodes:
       worktree_dir: "{state.worktree_dir}"
       branch: "{state.branch}"
       precommit_output: "{state.precommit_output}"
+      validate_gate_output: "{state.validate_gate_output}"
     state_key: validate_result
     timeout: 600
 

--- a/changelog/unreleased/fr-321-watcher-validate-fix-gate-diagnostics-handoff.md
+++ b/changelog/unreleased/fr-321-watcher-validate-fix-gate-diagnostics-handoff.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: watcher
+---
+- **FR-321**: Pass validate_gate diagnostics into validate_fix remediation context and ignore literal first-pass precommit placeholders in prompt rendering.

--- a/docs/diary/2026-05-04-reflection-fr-321-validate-fix-gate-diagnostics.md
+++ b/docs/diary/2026-05-04-reflection-fr-321-validate-fix-gate-diagnostics.md
@@ -1,0 +1,23 @@
+# Reflection: FR-321 Validate-Fix Gate Diagnostics Handoff
+
+**Date:** 2026-05-04
+**FR:** FR-321
+**Issue:** gh-318
+
+## Cognitive Process
+
+The validate_fix ↔ validate_gate loop ran 5+ times across multiple issues (gh-304, gh-306, gh-308, gh-318) always failing on diary_parity. The copilot CLI completed in 5-6 seconds — too fast to have done anything. The pattern was consistent: validate_gate caught the problem, but validate_fix never received the diagnostics.
+
+## Trap Encountered
+
+**downstream_fix** — The symptom appeared as "diary-gate failure" but the root cause was upstream: the pipeline config never passed `validate_gate_output` to validate_fix. The LLM saw either a literal `{precommit_output}` placeholder (first pass) or all-green pre-commit output (subsequent passes), so it returned PASS immediately without acting.
+
+**plausible_wrong_answer** — The LLM output passed shape check (exit code 0, no errors) but was semantically wrong: it declared success without fixing anything. The 5-6 second execution time was the signal.
+
+## Insight
+
+Normalize at the boundary where external data enters. The validate_gate action stored diagnostics in context but the pipeline config was the boundary that needed to shuttle them to the next action. A missing variable declaration at the config boundary caused a complete feedback loop failure.
+
+## Seed
+
+Should the FSM engine warn when a context variable is stored but never referenced in any downstream action's vars? A "dead variable" lint could catch this class of plumbing bugs.

--- a/feature-requests/FR-321-watcher-validate-fix-gate-diagnostics-handoff.md
+++ b/feature-requests/FR-321-watcher-validate-fix-gate-diagnostics-handoff.md
@@ -1,0 +1,137 @@
+# Feature Request: FR-321 watcher validate_fix gate diagnostics handoff
+
+**Priority:** HIGH
+**Type:** Bug
+**Status:** Implemented
+**Effort:** 0.5 day
+**Requested:** 2026-05-04
+
+## Summary
+
+Pass deterministic `validate_gate_output` diagnostics into `validate_fix` so remediation sees the actual gate failures (especially diary-parity), and treat first-pass `precommit_output` as empty context instead of rendering unresolved placeholder text.
+
+## Value Statement
+
+Watcher2 maintainers get actionable remediation loops (instead of blind retries), reducing repeated validate cycles where the LLM cannot see the failing gate reason.
+
+## Problem
+
+GitHub issue #318 identifies a broken feedback loop between `validate_gate` and `validate_fix`:
+
+1. `validate_gate` stores structured diagnostics in `context["validate_gate_output"]`, but `validate_fix` does not receive that value.
+2. `validate_fix` currently depends on `precommit_output`, which does not fully represent gate failures like `diary_parity`.
+3. On first `validate_fix` pass, `precommit_output` can render as literal `{precommit_output}`, producing misleading prompt context.
+
+Impact:
+
+- `validate_fix` retries can loop without seeing the real deterministic gate failure.
+- Diary-parity failures are invisible to the remediation prompt even when `validate_gate` has already diagnosed them.
+
+## Research: Existing Patterns and Prior Art
+
+1. **Diagnostics already exist at the boundary.**
+   `.chaplain/actions/validate_gate_action.py` writes both `context["precommit_output"]` and `context["validate_gate_output"]` with structured `checks` and `failures`.
+
+2. **Pipeline handoff is incomplete.**
+   `.chaplain/config/watcher-pipeline-v2.yaml` `validate_fix` action passes `precommit_output` but not `validate_gate_output`.
+
+3. **Validate graph/prompt are precommit-only today.**
+   `.chaplain/graphs/watcher-enforce/validate-session.yaml` state/variables include `precommit_output` only; `.chaplain/graphs/watcher-enforce/prompts/validate-session.yaml` renders only that channel.
+
+4. **Architecture intent already covers deterministic gate + remediation split.**
+   `REQ-YG-318` / `CAP-140` define `validate_fix` + `validate_gate` cooperation, but current implementation misses diagnostics plumbing needed for effective retries.
+
+5. **Related prior fix is adjacent, not sufficient.**
+   FR-319 hardens shell-safe var transport, but does not add `validate_gate_output` to the remediation prompt contract.
+
+## Objectives
+
+1. Ensure `validate_fix` receives `validate_gate_output` from pipeline context on retry passes.
+2. Expose gate diagnostics in validate prompt content so remediation can target actual failing checks.
+3. Preserve existing FSM topology and retry semantics while removing misleading first-pass placeholder output.
+
+## Constraints
+
+1. Scope is limited to validate diagnostics handoff (pipeline vars, validate graph state/vars, validate prompt contract, and directly coupled tests).
+2. No changes to watcher FSM state topology or event routing.
+3. No relaxation of deterministic gate checks; fix feedback visibility, not enforcement strictness.
+4. Apply fix at watcher validate callsite/prompt boundary; avoid unrelated broad behavior changes.
+
+## Proposed Solution
+
+### In scope
+
+1. Update `.chaplain/config/watcher-pipeline-v2.yaml` `validate_fix` vars to include:
+   - `validate_gate_output: "{validate_gate_output}"`
+2. Update `.chaplain/graphs/watcher-enforce/validate-session.yaml`:
+   - Add `validate_gate_output` in `state`
+   - Pass it to node variables for prompt rendering
+3. Update `.chaplain/graphs/watcher-enforce/prompts/validate-session.yaml`:
+   - Add a dedicated diagnostics section rendering `validate_gate_output` when present
+   - Treat unresolved/literal `{precommit_output}` as first-pass/no-diagnostics context
+4. Add focused unit tests that lock this handoff contract.
+
+### Out of scope
+
+1. Redesigning `validate_gate` rules or retry counts.
+2. Modifying unrelated `yamlgraph_async_action` global substitution semantics.
+3. Any changes to enforce, sanity-check, done, or dispatcher behavior beyond diagnostics handoff.
+
+## Acceptance Criteria
+
+- [x] **AC-01:** `watcher-pipeline-v2.yaml` `validate_fix` action passes `validate_gate_output` variable from FSM context.
+- [x] **AC-02:** `watcher-enforce/validate-session.yaml` declares and forwards `validate_gate_output` state for prompt consumption.
+- [x] **AC-03:** `watcher-enforce/prompts/validate-session.yaml` explicitly renders validate-gate diagnostics (checks/failures context) when provided.
+- [x] **AC-04:** First `validate_fix` pass treats unresolved/literal `{precommit_output}` as no prior diagnostics (no misleading literal output block).
+- [x] **AC-05:** Existing validate retry topology remains unchanged (`validate_gate` retry event still routes to `validate_fix`; pass/error routing unchanged).
+- [x] **AC-06:** Unit tests are added for AC-01..AC-05.
+
+## Failing Acceptance Tests (RED)
+
+Create:
+
+- `tests/unit/test_fr321_watcher_validate_fix_gate_diagnostics_handoff.py`
+
+Test cases:
+
+1. `test_ac01_validate_fix_action_passes_validate_gate_output_var`
+2. `test_ac02_validate_session_graph_declares_validate_gate_output_state_and_variable`
+3. `test_ac03_validate_prompt_renders_validate_gate_diagnostics_section`
+4. `test_ac04_validate_prompt_handles_literal_precommit_placeholder_as_first_pass`
+5. `test_ac05_validate_gate_retry_topology_unchanged`
+
+RED command:
+
+```bash
+pytest tests/unit/test_fr321_watcher_validate_fix_gate_diagnostics_handoff.py -q --no-cov
+```
+
+Additional RED evidence commands (expected to fail before implementation):
+
+```bash
+rg -n 'validate_gate_output:\s*"\{validate_gate_output\}"' .chaplain/config/watcher-pipeline-v2.yaml
+rg -n 'validate_gate_output' .chaplain/graphs/watcher-enforce/validate-session.yaml .chaplain/graphs/watcher-enforce/prompts/validate-session.yaml
+```
+
+## Alternatives Considered
+
+1. **Use only `precommit_output` and keep current prompt shape**
+   Rejected: cannot surface deterministic gate failures (e.g., `diary_parity`) that are not encoded in pre-commit output.
+
+2. **Move remediation logic into deterministic gate action**
+   Rejected: violates separation of concerns (`validate_gate` should diagnose/enforce; `validate_fix` should remediate).
+
+3. **Change global placeholder substitution behavior in shared async action**
+   Rejected for this FR: broader blast radius than needed; this issue is solvable at watcher validate handoff boundary.
+
+## Related
+
+- GitHub issue #318: <https://github.com/sheikkinen/yamlgraph/issues/318>
+- `.chaplain/config/watcher-pipeline-v2.yaml`
+- `.chaplain/actions/validate_gate_action.py`
+- `.chaplain/graphs/watcher-enforce/validate-session.yaml`
+- `.chaplain/graphs/watcher-enforce/prompts/validate-session.yaml`
+- `tests/unit/test_fr316_watcher2_validate_split_fix_gate.py`
+- `feature-requests/FR-319-watcher-yamlgraph-async-shell-safe-vars.md`
+- Topic source requested: `.chaplain/processing/gh-318.md` (not present in this worktree)
+- Canonical topic source used for drafting: GitHub issue #318

--- a/tests/unit/test_diary_importer.py
+++ b/tests/unit/test_diary_importer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from yamlgraph.diary import importer
 from yamlgraph.diary.importer import (
     ImportResult,
     import_git_reports,
@@ -88,9 +89,12 @@ class TestImportScheduledEntries:
         results = import_scheduled_entries(diary_dir, Path("/nonexistent"))
         assert results == []
 
-    def test_default_source_dir(self, diary_dir: Path) -> None:
+    def test_default_source_dir(
+        self, diary_dir: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         """When source_dir is None, uses ~/scheduled-yamlgraphs/outputs/."""
-        # Just verifying it doesn't crash — default dir won't exist in test
+        # Force deterministic default source regardless of host HOME contents.
+        monkeypatch.setattr(importer, "DEFAULT_SOURCE", tmp_path / "missing-default")
         results = import_scheduled_entries(diary_dir)
         assert results == []
 

--- a/tests/unit/test_fr321_watcher_validate_fix_gate_diagnostics_handoff.py
+++ b/tests/unit/test_fr321_watcher_validate_fix_gate_diagnostics_handoff.py
@@ -1,0 +1,94 @@
+"""Acceptance tests for FR-321 watcher validate-fix gate diagnostics handoff."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from jinja2 import Template
+
+WORKTREE = Path(__file__).resolve().parents[2]
+CHAPLAIN = WORKTREE / ".chaplain"
+PIPELINE_V2 = CHAPLAIN / "config" / "watcher-pipeline-v2.yaml"
+VALIDATE_SESSION_GRAPH = (
+    CHAPLAIN / "graphs" / "watcher-enforce" / "validate-session.yaml"
+)
+VALIDATE_PROMPT = (
+    CHAPLAIN / "graphs" / "watcher-enforce" / "prompts" / "validate-session.yaml"
+)
+
+
+def _load_yaml(path: Path) -> dict:
+    assert path.exists(), f"Missing YAML file: {path}"
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def _transition_exists(
+    transitions: list[dict], from_state: str, to_state: str, event: str
+) -> bool:
+    return any(
+        t.get("from") == from_state
+        and t.get("to") == to_state
+        and t.get("event") == event
+        for t in transitions
+    )
+
+
+@pytest.mark.req("REQ-YG-318")
+class TestFR321ValidateFixGateDiagnosticsHandoff:
+    """AC-01..AC-05 contracts for validate diagnostics handoff."""
+
+    def test_ac01_validate_fix_action_passes_validate_gate_output_var(self):
+        pipeline = _load_yaml(PIPELINE_V2)
+        action = pipeline["actions"]["validate_fix"][0]
+        assert "validate_gate_output" in action["vars"]
+        assert action["vars"]["validate_gate_output"] == "{validate_gate_output}"
+
+    def test_ac02_validate_session_graph_declares_validate_gate_output_state_and_variable(
+        self,
+    ):
+        graph = _load_yaml(VALIDATE_SESSION_GRAPH)
+        assert graph["state"]["validate_gate_output"] == "str"
+        variables = graph["nodes"]["validate_fix"]["variables"]
+        assert variables["validate_gate_output"] == "{state.validate_gate_output}"
+
+    def test_ac03_validate_prompt_renders_validate_gate_diagnostics_section(self):
+        prompt_yaml = _load_yaml(VALIDATE_PROMPT)
+        template = Template(prompt_yaml["user"])
+        rendered = template.render(
+            fr_path="feature-requests/FR-321.md",
+            worktree_dir="/tmp/worktree",
+            branch="feat/x",
+            precommit_output="ruff failed",
+            validate_gate_output='{"checks":[{"name":"diary_parity","status":"failed"}],"failures":["diary_parity"]}',
+        )
+        assert "Validate-gate diagnostics (checks/failures)" in rendered
+        assert "diary_parity" in rendered
+
+    def test_ac04_validate_prompt_handles_literal_precommit_placeholder_as_first_pass(
+        self,
+    ):
+        prompt_yaml = _load_yaml(VALIDATE_PROMPT)
+        template = Template(prompt_yaml["user"])
+        rendered = template.render(
+            fr_path="feature-requests/FR-321.md",
+            worktree_dir="/tmp/worktree",
+            branch="feat/x",
+            precommit_output="{precommit_output}",
+            validate_gate_output="",
+        )
+        assert "first validate_fix pass — no prior gate diagnostics" in rendered
+        assert "The previous validate_gate/pre-commit attempt reported:" not in rendered
+        assert "{precommit_output}" not in rendered
+
+    def test_ac05_validate_gate_retry_topology_unchanged(self):
+        pipeline = _load_yaml(PIPELINE_V2)
+        transitions = pipeline.get("transitions", [])
+        assert _transition_exists(
+            transitions, "validate_gate", "validate_fix", "fix_needed"
+        )
+        assert _transition_exists(transitions, "validate_gate", "done", "pass")
+        assert _transition_exists(transitions, "validate_gate", "failed", "error")
+        assert _transition_exists(
+            transitions, "validate_fix", "sanity_check", "validate_done"
+        )


### PR DESCRIPTION
Closes #318

## Changes

Pass `validate_gate_output` diagnostics to `validate_fix` so the LLM can see what the gate actually caught (e.g., diary-parity failures) instead of only seeing pre-commit output.

### Pipeline config
- Add `validate_gate_output: "{validate_gate_output}"` to validate_fix vars

### Graph config
- Add `validate_gate_output: str` to graph state
- Pass through to copilot node vars

### Prompt
- Render gate diagnostics in a dedicated section
- Handle literal `{precommit_output}` / `{validate_gate_output}` placeholders (first-pass default)
- Normalize with Jinja `default()` + trim + literal-check