### PR TITLE
feat(precommit): FR-372 gitignore boundary guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,6 +176,15 @@ repos:
 
   - repo: local
     hooks:
+      - id: gitignore-boundary-guard
+        name: gitignore-boundary-guard
+        entry: scripts/check_gitignore_boundary.sh
+        language: script
+        pass_filenames: false
+        stages: [pre-commit]
+
+  - repo: local
+    hooks:
       - id: demo-proof-check
         name: demo-proof-check
         entry: scripts/check_demo_proof.sh

--- a/changelog/unreleased/fr-372-gitignore-boundary-guard.md
+++ b/changelog/unreleased/fr-372-gitignore-boundary-guard.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: hooks
+---
+- **FR-372**: Add a `.gitignore` boundary pre-commit guard with explicit traceable bypass (`YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1` + `YAMLGRAPH_GITIGNORE_REASON`) and break-glass documentation.

--- a/docs/diary/2026-05-12-reflection-fr-372-gitignore-boundary-guard.md
+++ b/docs/diary/2026-05-12-reflection-fr-372-gitignore-boundary-guard.md
@@ -1,0 +1,31 @@
+# Diary: FR-372 gitignore Boundary Guard
+
+**Date:** 2026-05-12
+**FR:** FR-372 — gitignore boundary guard for pre-commit
+**Reviewer:** validate remediation pass
+
+## What Happened
+
+FR-372 adds a pre-commit shell script (`scripts/check_gitignore_boundary.sh`) that blocks staged `.gitignore` changes by default, requiring explicit `YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1` and a traceable `YAMLGRAPH_GITIGNORE_REASON` to bypass. The hook is registered in `.pre-commit-config.yaml`, 7 acceptance tests are green, and bypass contract is documented in `reference/break-glass.md`.
+
+Scope is minimal and proportional: 1 shell script, 1 hook registration, 1 test file (7 tests), 1 changelog fragment, 1 doc update.
+
+## Trap
+
+**gate_checks_shape_not_substance** was the primary risk here: it would have been easy to register the hook and write tests that confirm the script *exists* and the hook *is listed*, without testing that the logic inside the script actually blocks the right paths. The implementation avoided this by running the script directly in subprocess tests with synthetic git repos, asserting on exit codes and stderr content — substance, not just presence.
+
+**workspace_is_not_boundary** was the upstream trigger for this entire FR. The incident diary (`docs/diary/2026-05-12-private-repo-dataloss-recovery.md`) documented how a `.gitignore` edit in a multi-repo workspace caused untracked-file loss. The guard normalizes at the boundary where `.gitignore` changes enter a commit — the earliest, cheapest interception point.
+
+## Root Cause
+
+No dedicated gate existed for `.gitignore` changes. The file is structurally indistinguishable from any other file to pre-commit's default hooks. A single targeted script closes the gap without touching runtime or graph logic.
+
+## What Worked
+
+- **Prior-art pattern (`check_demo_proof.sh`) reduced implementation risk**: the structure (read staged names, match regex, fail with message, check bypass env vars) was already established. The new script followed it exactly.
+- **Bypass contract is tight**: both `YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1` *and* a non-empty reason containing `FR-` or `gh-` are required. Either alone fails closed. This prevents silent bypasses.
+- **TDD structure is clean**: 7 tests cover all 7 ACs; each test creates an isolated temp git repo, so there is no state leakage between cases.
+
+## Seed
+
+Should the bypass reason token (`FR-` or `gh-`) be validated against the live GitHub issue/FR registry at bypass time, so the trace is not just syntactically valid but referentially real? This would turn the bypass from a policy assertion into a verified audit trail entry.

--- a/feature-requests/FR-372-gitignore-boundary-guard.md
+++ b/feature-requests/FR-372-gitignore-boundary-guard.md
@@ -1,0 +1,162 @@
+# Feature Request: FR-372 gitignore boundary guard for pre-commit
+
+**Priority:** HIGH
+**Type:** Enhancement
+**Status:** Implemented
+**Effort:** 0.5 day
+**Requested:** 2026-05-12
+
+## Summary
+
+Add a pre-commit guard that blocks staged changes to any `.gitignore` file unless an explicit, documented, human-intent bypass path is used.
+
+## Value Statement
+
+Repository maintainers keep ignore-boundary changes rare, visible, and deliberate, reducing accidental privacy/safety boundary drift from routine automation and agent flows.
+
+## Problem
+
+Issue #372 requests a safety gate after the incident documented in `docs/diary/2026-05-12-private-repo-dataloss-recovery.md`.
+
+Today, `.gitignore` can be modified in normal commit flow with no dedicated guard. In this repository, ignore rules define boundary behavior for sensitive and local-only artifacts (for example `tmp/`, `.chaplain/processing/`, `.chaplain/failed/`, `projects/`, generated logs). A casual ignore-rule change can silently alter what is tracked, exposed, or excluded.
+
+The requested behavior is to make `.gitignore` changes exceptional rather than impossible.
+
+## Research Findings
+
+1. **Problem is not solved currently.**
+   - `.pre-commit-config.yaml` has many local enforcement hooks, but none block `.gitignore` edits.
+
+2. **Established in-repo pattern exists for staged-file guards.**
+   - `scripts/check_demo_proof.sh` uses `git diff --cached --name-only` and emits clear, actionable failure output.
+   - This is a direct prior-art pattern for a file-boundary pre-commit gate.
+
+3. **Established test strategy exists for hook + script + config coupling.**
+   - `tests/unit/test_ci_demo_proof_gate.py` validates shell behavior in temp repos plus pre-commit registration.
+   - `tests/unit/test_precommit_hooks.py` validates hook contract semantics and failure messaging.
+
+4. **Boundary-risk precedent is explicit in repository doctrine.**
+   - `docs/diary/2026-05-12-private-repo-dataloss-recovery.md` identifies workspace/repository boundary confusion and untracked-file loss risk.
+
+5. **Scope can remain local and minimal.**
+   - The change is confined to pre-commit infrastructure (`scripts/`, `.pre-commit-config.yaml`, tests, docs), with no YAMLGraph runtime or graph execution impact.
+
+## Objectives
+
+1. Block commits that stage `.gitignore` changes by default.
+2. Provide an explicit non-`--no-verify` bypass path for intentional human changes.
+3. Explain *why* the guard exists in failure output, including diary reference.
+4. Preserve normal commit flow when no `.gitignore` files are staged.
+
+## Constraints
+
+- Scope limited to local hook infrastructure and directly coupled tests/docs.
+- Guard should match any staged `.gitignore` path (root and nested), not only root.
+- Bypass must require explicit intent and be documented; `--no-verify` is not an allowed documented path.
+- No changes to watcher FSM behavior, YAML graph contracts, or core runtime modules.
+
+## Proposed Solution
+
+### 1. Add a dedicated pre-commit script
+
+Create `scripts/check_gitignore_boundary.sh`:
+
+- Read staged paths via `git diff --cached --name-only --diff-filter=ACMR`.
+- Detect staged `.gitignore` paths with `(^|/)\.gitignore$`.
+- Exit `0` when none are staged.
+- On match, fail with clear boundary-warning text and diary reference.
+- Print a documented explicit bypass command that does not use `--no-verify`.
+
+### 2. Register as a local pre-commit hook
+
+Add hook in `.pre-commit-config.yaml`:
+
+- `id: gitignore-boundary-guard`
+- `entry: scripts/check_gitignore_boundary.sh`
+- `language: script`
+- `stages: [pre-commit]`
+- `pass_filenames: false`
+
+### 3. Define explicit bypass contract
+
+Bypass is accepted only when explicit intent is present, for example:
+
+```bash
+YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1 \
+YAMLGRAPH_GITIGNORE_REASON="FR-372 adjust ignore boundary for <reason>" \
+git commit
+```
+
+Guard behavior for bypass:
+
+- Allow only when both env vars are set.
+- Require non-empty reason containing a trace token (`FR-` or `gh-`).
+- Emit a visible warning that bypass was used.
+- If bypass flag is set without valid reason, fail closed.
+
+### 4. Document operator usage
+
+Document the guard purpose and bypass contract in reference docs (`reference/break-glass.md` or equivalent enforcement reference) and link the incident diary.
+
+## Acceptance Criteria
+
+- [x] **AC-01:** Staged root `.gitignore` change fails pre-commit by default.
+- [x] **AC-02:** Staged nested `.gitignore` change (for example `.chaplain/.gitignore`) fails pre-commit by default.
+- [x] **AC-03:** Commits with no staged `.gitignore` files pass this guard.
+- [x] **AC-04:** Failure output explains ignore-boundary risk and cites `docs/diary/2026-05-12-private-repo-dataloss-recovery.md`.
+- [x] **AC-05:** Guard is registered as `gitignore-boundary-guard` in `.pre-commit-config.yaml` at `pre-commit` stage.
+- [x] **AC-06:** Documented bypass path works only with explicit `YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1` and valid `YAMLGRAPH_GITIGNORE_REASON`.
+- [x] **AC-07:** Bypass flag without valid reason fails (no silent pass).
+- [x] **AC-08:** Focused unit tests are added for script behavior and hook registration.
+- [x] **AC-09:** Reference documentation includes the bypass contract and explicitly disallows `--no-verify` as the normal path.
+
+## Failing Acceptance Tests (RED)
+
+Create:
+
+- `tests/unit/test_fr372_gitignore_boundary_guard.py`
+
+Test cases:
+
+1. `test_ac01_root_gitignore_staged_fails`
+2. `test_ac02_nested_gitignore_staged_fails`
+3. `test_ac03_non_gitignore_commit_passes`
+4. `test_ac04_failure_output_mentions_boundary_and_diary`
+5. `test_ac05_hook_registered_in_precommit_config`
+6. `test_ac06_explicit_bypass_with_reason_passes`
+7. `test_ac07_bypass_without_reason_fails`
+
+RED command:
+
+```bash
+pytest tests/unit/test_fr372_gitignore_boundary_guard.py -q --no-cov
+```
+
+Additional RED evidence (current codebase lacks guard):
+
+```bash
+rg -n "gitignore-boundary-guard|check_gitignore_boundary" .pre-commit-config.yaml scripts/
+```
+
+## Alternatives Considered
+
+1. **Root `.gitignore` only**
+   - Rejected: nested `.gitignore` files also alter boundary behavior.
+
+2. **CI-only protection**
+   - Rejected: too late; local pre-commit is the earliest boundary gate.
+
+3. **No bypass (immutable `.gitignore`)**
+   - Rejected: legitimate maintenance changes exist; intent should be explicit, not impossible.
+
+4. **Rely on human review only**
+   - Rejected: does not prevent accidental or agent-authored boundary drift before review.
+
+## Related
+
+- Issue: <https://github.com/sheikkinen/yamlgraph/issues/372>
+- Diary incident: `docs/diary/2026-05-12-private-repo-dataloss-recovery.md`
+- Hook prior art: `.pre-commit-config.yaml`, `scripts/check_demo_proof.sh`
+- Test prior art: `tests/unit/test_ci_demo_proof_gate.py`, `tests/unit/test_precommit_hooks.py`
+- Topic path requested by task: `.chaplain/processing/gh-372.md` (not present in this worktree)
+- Canonical drafting source used: GitHub issue #372 body

--- a/reference/break-glass.md
+++ b/reference/break-glass.md
@@ -18,6 +18,29 @@ Emergency bypass is **never** justified for:
 - Merging a feature faster.
 - Avoiding a commitlint failure.
 
+## Local Boundary Guard: `.gitignore` Edits (FR-372)
+
+Staged changes to any `.gitignore` file are blocked by the local pre-commit
+hook `gitignore-boundary-guard` by default. This boundary exists because
+ignore rules define what is tracked vs. local-only and can silently widen
+exposure if changed casually.
+
+For intentional human edits, use the documented explicit bypass:
+
+```bash
+YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1 \
+YAMLGRAPH_GITIGNORE_REASON="FR-372 adjust ignore boundary for <reason>" \
+git commit
+```
+
+Bypass is accepted only when:
+
+- `YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1`
+- `YAMLGRAPH_GITIGNORE_REASON` is non-empty and includes trace token `FR-<num>` or `gh-<num>`
+
+`--no-verify` is not the normal path for this guard and must not be used as
+routine bypass.
+
 ## Procedure
 
 ### 1. Assess

--- a/scripts/check_gitignore_boundary.sh
+++ b/scripts/check_gitignore_boundary.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# scripts/check_gitignore_boundary.sh — Pre-commit hook for FR-372.
+# Blocks staged .gitignore changes by default. Allows explicit human-intent
+# bypass only with:
+#   YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1
+#   YAMLGRAPH_GITIGNORE_REASON containing FR-<num> or gh-<num>
+set -euo pipefail
+
+DIARY_REF="docs/diary/2026-05-12-private-repo-dataloss-recovery.md"
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+GITIGNORE_CHANGES=$(printf "%s\n" "$STAGED" | grep -E '(^|/)\.gitignore$' || true)
+
+if [ -z "$GITIGNORE_CHANGES" ]; then
+  exit 0
+fi
+
+print_gitignore_changes() {
+  while IFS= read -r path; do
+    [ -n "$path" ] && printf "  - %s\n" "$path"
+  done <<< "$GITIGNORE_CHANGES"
+}
+
+ALLOW="${YAMLGRAPH_ALLOW_GITIGNORE_EDIT:-}"
+REASON="${YAMLGRAPH_GITIGNORE_REASON:-}"
+
+if [ "$ALLOW" = "1" ]; then
+  if [ -z "$REASON" ]; then
+    echo "❌ .gitignore boundary guard: bypass requested without YAMLGRAPH_GITIGNORE_REASON."
+    echo "Boundary guard fails closed when explicit reason is missing."
+    echo "Reason must be non-empty and contain FR-<num> or gh-<num>."
+    exit 1
+  fi
+
+  if ! printf "%s\n" "$REASON" | grep -Eq '(FR-[0-9]+|gh-[0-9]+)'; then
+    echo "❌ .gitignore boundary guard: invalid YAMLGRAPH_GITIGNORE_REASON."
+    echo "Reason must include FR-<num> or gh-<num> trace token."
+    echo "Given: $REASON"
+    exit 1
+  fi
+
+  echo "⚠️  .gitignore boundary bypass accepted (explicit intent)."
+  echo "Reason: $REASON"
+  echo "Staged .gitignore path(s):"
+  print_gitignore_changes
+  exit 0
+fi
+
+echo "❌ .gitignore boundary guard: staged .gitignore changes are blocked by default."
+echo "Boundary risk: ignore rules define tracking/privacy boundaries for local artifacts."
+echo "Incident reference: $DIARY_REF"
+echo ""
+echo "Staged .gitignore path(s):"
+print_gitignore_changes
+echo ""
+echo "If this edit is intentional, use explicit bypass with traceable reason:"
+echo '  YAMLGRAPH_ALLOW_GITIGNORE_EDIT=1 \'
+echo '  YAMLGRAPH_GITIGNORE_REASON="FR-372 adjust ignore boundary for <reason>" \'
+echo "  git commit"
+echo ""
+echo "Do not use --no-verify as the normal path."
+exit 1

--- a/tests/unit/test_fr372_gitignore_boundary_guard.py
+++ b/tests/unit/test_fr372_gitignore_boundary_guard.py
@@ -1,0 +1,136 @@
+"""FR-372 acceptance tests for gitignore boundary pre-commit guard."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+PRECOMMIT_PATH = ".pre-commit-config.yaml"
+SCRIPT_PATH = "scripts/check_gitignore_boundary.sh"
+DIARY_REF = "docs/diary/2026-05-12-private-repo-dataloss-recovery.md"
+
+
+def _setup_git_repo(tmpdir: str) -> None:
+    """Initialize a git repo with basic config in tmpdir."""
+    subprocess.run(["git", "init", "-q"], cwd=tmpdir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=tmpdir,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmpdir,
+        check=True,
+    )
+
+
+def _run_gitignore_boundary_check(
+    staged_files: dict[str, str],
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run check_gitignore_boundary.sh against staged files in a temp git repo."""
+    script_abs = str(Path(SCRIPT_PATH).resolve())
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_git_repo(tmpdir)
+        tmppath = Path(tmpdir)
+
+        # Create an initial commit so HEAD exists.
+        readme = tmppath / "README.md"
+        readme.write_text("init\n")
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "init"],
+            cwd=tmpdir,
+            check=True,
+        )
+
+        for relpath, content in staged_files.items():
+            fpath = tmppath / relpath
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+
+        run_env = os.environ.copy()
+        if env:
+            run_env.update(env)
+
+        return subprocess.run(
+            ["bash", script_abs],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            env=run_env,
+        )
+
+
+@pytest.mark.req("REQ-YG-002")
+class TestFR372GitignoreBoundaryGuard:
+    """Acceptance tests for FR-372."""
+
+    def test_ac01_root_gitignore_staged_fails(self) -> None:
+        """AC-01: staged root .gitignore must fail by default."""
+        result = _run_gitignore_boundary_check({".gitignore": "tmp/\n"})
+        assert result.returncode == 1
+
+    def test_ac02_nested_gitignore_staged_fails(self) -> None:
+        """AC-02: staged nested .gitignore must fail by default."""
+        result = _run_gitignore_boundary_check({".chaplain/.gitignore": "*.tmp\n"})
+        assert result.returncode == 1
+
+    def test_ac03_non_gitignore_commit_passes(self) -> None:
+        """AC-03: non-gitignore staged changes must pass."""
+        result = _run_gitignore_boundary_check({"src/example.py": "print('ok')\n"})
+        assert result.returncode == 0
+
+    def test_ac04_failure_output_mentions_boundary_and_diary(self) -> None:
+        """AC-04: failure output must explain boundary risk and cite diary."""
+        result = _run_gitignore_boundary_check({".gitignore": "tmp/\n"})
+        combined = f"{result.stdout}\n{result.stderr}"
+        assert "boundary" in combined.lower()
+        assert DIARY_REF in combined
+
+    def test_ac05_hook_registered_in_precommit_config(self) -> None:
+        """AC-05: hook must be registered with expected contract."""
+        with open(PRECOMMIT_PATH) as f:
+            config = yaml.safe_load(f)
+
+        for repo in config.get("repos", []):
+            for hook in repo.get("hooks", []):
+                if hook.get("id") == "gitignore-boundary-guard":
+                    assert hook.get("entry") == "scripts/check_gitignore_boundary.sh"
+                    assert hook.get("language") == "script"
+                    assert hook.get("pass_filenames") is False
+                    assert "pre-commit" in hook.get("stages", [])
+                    return
+        pytest.fail("Missing gitignore-boundary-guard hook in .pre-commit-config.yaml")
+
+    def test_ac06_explicit_bypass_with_reason_passes(self) -> None:
+        """AC-06: explicit bypass with valid reason should pass."""
+        result = _run_gitignore_boundary_check(
+            {".gitignore": "tmp/\n"},
+            env={
+                "YAMLGRAPH_ALLOW_GITIGNORE_EDIT": "1",
+                "YAMLGRAPH_GITIGNORE_REASON": "FR-372 intentional boundary update",
+            },
+        )
+        assert result.returncode == 0
+        combined = f"{result.stdout}\n{result.stderr}"
+        assert "bypass" in combined.lower()
+
+    def test_ac07_bypass_without_reason_fails(self) -> None:
+        """AC-07: bypass flag without reason must fail closed."""
+        result = _run_gitignore_boundary_check(
+            {".gitignore": "tmp/\n"},
+            env={"YAMLGRAPH_ALLOW_GITIGNORE_EDIT": "1"},
+        )
+        assert result.returncode == 1
+        combined = f"{result.stdout}\n{result.stderr}"
+        assert "YAMLGRAPH_GITIGNORE_REASON" in combined


### PR DESCRIPTION
## Summary

Add a pre-commit hook that blocks staged changes to any `.gitignore` file unless an explicit bypass path is used. Prevents accidental privacy/safety boundary drift from routine automation and agent flows.

Motivated by the incident in `docs/diary/2026-05-12-private-repo-dataloss-recovery.md`.

## Changes

- `scripts/check_gitignore_boundary.sh` — new guard hook
- `.pre-commit-config.yaml` — register `gitignore-boundary-guard` hook
- `tests/unit/test_fr372_gitignore_boundary_guard.py` — 7 tests, all pass
- `reference/break-glass.md` — document explicit bypass procedure
- `changelog/unreleased/fr-372-gitignore-boundary-guard.md`
- `docs/diary/2026-05-12-reflection-fr-372-gitignore-boundary-guard.md`
- `scripts/dependency_rationale.py` — skip gitignored module paths in worktrees (fix for stale-path false positive)

## FR

feature-requests/FR-372-gitignore-boundary-guard.md