### PR TITLE
feat(ci): FR-373 enforce gate artifact substance validation

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -77,17 +77,36 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify changelog fragment exists
+      - name: Verify changelog fragments
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '^changelog/unreleased/'; then
-            echo "✅ Changelog fragment found"
-          else
+          source scripts/gate_artifact_semantics.sh
+
+          CHANGED_FRAGMENTS=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -E '^changelog/unreleased/.*\.md$' || true)
+
+          if [ -z "$CHANGED_FRAGMENTS" ]; then
             echo "::error::feat/fix PRs must include a changelog fragment in changelog/unreleased/"
             exit 1
           fi
+
+          INVALID=0
+          while IFS= read -r FRAGMENT; do
+            if [ -z "$FRAGMENT" ]; then
+              continue
+            fi
+            if ! validate_changelog_fragment_file "$FRAGMENT" "$FRAGMENT"; then
+              INVALID=$((INVALID + 1))
+            fi
+          done <<< "$CHANGED_FRAGMENTS"
+
+          if [ "$INVALID" -gt 0 ]; then
+            echo "::error::One or more changelog fragments failed substance validation"
+            exit 1
+          fi
+
+          echo "✅ Changelog fragment(s) validated"
 
   release-hygiene:
     name: Release hygiene (tag validation)
@@ -195,12 +214,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify diary reflection exists
+      - name: Verify diary reflection
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          source scripts/gate_artifact_semantics.sh
+
           # Extract FR number from PR title
           FR_NUM=$(echo "$PR_TITLE" | grep -oE 'FR-[0-9]+' | head -1 | sed 's/FR-//')
 
@@ -211,9 +232,9 @@ jobs:
 
           echo "🔍 Checking for diary reflection for FR-$FR_NUM..."
 
-          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "docs/diary/.*reflection.*fr-${FR_NUM}[^0-9]"; then
-            echo "✅ Diary reflection found for FR-$FR_NUM"
-          else
+          MATCHING_DIARIES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -E "docs/diary/.*reflection.*fr-${FR_NUM}([^0-9]|$)" || true)
+
+          if [ -z "$MATCHING_DIARIES" ]; then
             echo "::error::feat/fix PRs referencing FR-$FR_NUM must include a diary reflection in docs/diary/"
             echo ""
             echo "Expected: docs/diary/YYYY-MM-DD-reflection-fr-${FR_NUM}.md"
@@ -226,3 +247,20 @@ jobs:
             echo "See docs/diary/ for examples."
             exit 1
           fi
+
+          INVALID=0
+          while IFS= read -r DIARY_FILE; do
+            if [ -z "$DIARY_FILE" ]; then
+              continue
+            fi
+            if ! validate_diary_reflection_file "$DIARY_FILE" "$DIARY_FILE"; then
+              INVALID=$((INVALID + 1))
+            fi
+          done <<< "$MATCHING_DIARIES"
+
+          if [ "$INVALID" -gt 0 ]; then
+            echo "::error::Diary reflection content requirements not met for FR-$FR_NUM"
+            exit 1
+          fi
+
+          echo "✅ Diary reflection validated for FR-$FR_NUM"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -879,13 +879,13 @@ Every on-disk example and demo is accurately indexed in examples/README.md with 
 
 ### 50. CI CHANGELOG Gate
 
-GitHub Actions job in commitlint.yml that blocks merge of feat and fix PRs unless CHANGELOG.md is modified in the PR diff.
+GitHub Actions job in commitlint.yml that blocks merge of feat and fix PRs unless changed fragments in `changelog/unreleased/` satisfy semantic substance checks.
 
 **Feature Request:** FR-149
 
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
-| REQ-YG-148 | `changelog-gate` job in `commitlint.yml` runs `git diff --name-only` against base/head SHAs and fails when `CHANGELOG.md` is absent from diff; job-level `if` condition restricts to `feat`/`fix` PR titles (skipped for other types); uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `tests/unit/test_ci_changelog_gate` |
+| REQ-YG-148 | `changelog-gate` job in `commitlint.yml` runs `git diff --name-only` against base/head SHAs and fails when no `changelog/unreleased/*.md` fragment is present in diff; each changed fragment must be non-empty, include YAML front matter with `type:`, and contain at least one markdown list item in the body; semantic checks are shared via `scripts/gate_artifact_semantics.sh`; job-level `if` condition restricts to `feat`/`fix` PR titles (skipped for other types); uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `scripts/gate_artifact_semantics.sh`, `tests/unit/test_ci_changelog_gate` |
 
 ### 51. Branch Protection Documentation
 
@@ -909,13 +909,13 @@ CI job that fails when unresolved merge conflict markers are found in tracked fi
 
 ### 54. CI Diary Existence Gate
 
-CI gate ensuring feat/fix PRs with FR references include a diary reflection file in the diff.
+CI gate ensuring feat/fix PRs with FR references include a diary reflection file in the diff and that reflection content is substantive.
 
 **Feature Request:** FR-158
 
 | Requirement | Description | Key Modules |
 |------------|-------------|-------------|
-| REQ-YG-152 | `diary-gate` job in `commitlint.yml` extracts `FR-XXX` from PR title, runs `git diff --name-only` against base/head SHAs, and fails when no `docs/diary/*reflection*fr-{number}*` file is in diff; skips (passes) when PR title has no FR reference; job-level `if` condition restricts to `feat`/`fix` PR titles; uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `tests/unit/test_ci_diary_gate` |
+| REQ-YG-152 | `diary-gate` job in `commitlint.yml` extracts `FR-XXX` from PR title, runs `git diff --name-only` against base/head SHAs, and fails when no `docs/diary/*reflection*fr-{number}*` file is in diff; matching diary files must be non-empty, larger than 100 bytes, include at least one markdown `##` header, and contain a `Seed:` marker; semantic checks are shared via `scripts/gate_artifact_semantics.sh`; skips (passes) when PR title has no FR reference; job-level `if` condition restricts to `feat`/`fix` PR titles; uses `actions/checkout@v4` with `fetch-depth: 0` for full history | `.github/workflows/commitlint.yml`, `scripts/gate_artifact_semantics.sh`, `tests/unit/test_ci_diary_gate` |
 
 ### 55. Chaplain Inbox Documentation
 

--- a/capabilities/CAP-50-ci-changelog-gate.yaml
+++ b/capabilities/CAP-50-ci-changelog-gate.yaml
@@ -2,19 +2,25 @@ id: CAP-50
 name: CI CHANGELOG Gate
 description: >
   GitHub Actions job in commitlint.yml that blocks merge of feat and fix PRs
-  unless CHANGELOG.md is modified in the PR diff.
+  unless changed changelog fragments under changelog/unreleased/ pass substance
+  validation.
 modules:
   - .github/workflows/commitlint.yml
+  - scripts/gate_artifact_semantics.sh
   - tests/unit/test_ci_changelog_gate
 requirements:
   - id: REQ-YG-148
     description: >
       `changelog-gate` job in `commitlint.yml` runs `git diff --name-only`
-      against base/head SHAs and fails when `CHANGELOG.md` is absent from diff;
-      job-level `if` condition restricts to `feat`/`fix` PR titles (skipped for
-      other types); uses `actions/checkout@v4` with `fetch-depth: 0` for full
-      history
+      against base/head SHAs and fails when no `changelog/unreleased/*.md`
+      fragment is present in diff; each changed fragment must be non-empty,
+      contain YAML front matter with `type:`, and include at least one markdown
+      list item in the body; shared validation is sourced from
+      `scripts/gate_artifact_semantics.sh`; job-level `if` condition restricts
+      to `feat`/`fix` PR titles (skipped for other types); uses
+      `actions/checkout@v4` with `fetch-depth: 0` for full history
     modules:
       - .github/workflows/commitlint.yml
+      - scripts/gate_artifact_semantics.sh
       - tests/unit/test_ci_changelog_gate
 fr: FR-149

--- a/capabilities/CAP-54-ci-diary-existence-gate.yaml
+++ b/capabilities/CAP-54-ci-diary-existence-gate.yaml
@@ -2,20 +2,24 @@ id: CAP-54
 name: CI Diary Existence Gate
 description: >
   CI gate ensuring feat/fix PRs with FR references include a diary reflection
-  file in the diff.
+  file in the diff and that the reflection passes substance validation.
 modules:
   - .github/workflows/commitlint.yml
+  - scripts/gate_artifact_semantics.sh
   - tests/unit/test_ci_diary_gate
 requirements:
   - id: REQ-YG-152
     description: >
       `diary-gate` job in `commitlint.yml` extracts `FR-XXX` from PR title, runs
       `git diff --name-only` against base/head SHAs, and fails when no
-      `docs/diary/*reflection*fr-{number}*` file is in diff; skips (passes) when
-      PR title has no FR reference; job-level `if` condition restricts to
-      `feat`/`fix` PR titles; uses `actions/checkout@v4` with `fetch-depth: 0`
-      for full history
+      `docs/diary/*reflection*fr-{number}*` file is in diff; matching files must
+      be non-empty, exceed 100 bytes, contain at least one markdown `##` header,
+      and include `Seed:` marker; shared validation is sourced from
+      `scripts/gate_artifact_semantics.sh`; skips (passes) when PR title has no
+      FR reference; job-level `if` condition restricts to `feat`/`fix` PR titles;
+      uses `actions/checkout@v4` with `fetch-depth: 0` for full history
     modules:
       - .github/workflows/commitlint.yml
+      - scripts/gate_artifact_semantics.sh
       - tests/unit/test_ci_diary_gate
 fr: FR-158

--- a/changelog/unreleased/fr-373-gate-substance-validation.md
+++ b/changelog/unreleased/fr-373-gate-substance-validation.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: ci
+---
+- **FR-373**: Hardened `changelog-gate` and `diary-gate` with shared semantic substance validation in CI.

--- a/docs/diary/2026-05-13-reflection-fr-373-gate-substance-validation.md
+++ b/docs/diary/2026-05-13-reflection-fr-373-gate-substance-validation.md
@@ -1,0 +1,57 @@
+# Diary: FR-373 Gate Artifact Substance Validation
+
+**Date:** 2026-05-13
+**FR:** FR-373 — Substance validation for diary-gate and changelog-gate
+**Reviewer:** validate_fix remediation pass
+
+## What Happened
+
+FR-373 hardens two CI merge gates (`changelog-gate` and `diary-gate`) from
+presence-only checks to substance-validated checks. The gates now call shared
+shell validation functions from `scripts/gate_artifact_semantics.sh` and reject
+artifacts that are empty, lack required structural markers (front-matter `type:`
+field, `##` headers, `Seed:` marker), or fall below a minimum byte threshold.
+
+The implementation reuses the FR-325 `demo_log_semantics.sh` pattern:
+extract validation logic into a sourced shell module, wire it into the CI
+workflow, and cover both shapes (valid/invalid) with unit tests.
+
+## Trap: gate_checks_shape_not_substance
+
+The exact trap named in the Knowledge Graph was the driver for this FR:
+
+> Gate validates presence (file exists, field non-empty, format matches) but
+> not substance — compliance theatre; a 1-byte file satisfies the gate while
+> conveying nothing.
+
+Both gates fell into this pattern independently. The cure was to treat each
+artifact as an external input entering the enforcement boundary — normalizing
+there rather than trusting form alone.
+
+## What Worked
+
+- **Shared validator module** (`gate_artifact_semantics.sh`) eliminates
+  duplicated inline logic and makes future gate extensions a one-line `source`.
+- **TDD structure is explicit:** `test_fr373_gate_substance_validation_red.py`
+  names every acceptance criterion; existing `test_ci_changelog_gate.py` and
+  `test_ci_diary_gate.py` are extended to cover semantic cases.
+- **Incremental scope:** only `changelog-gate` and `diary-gate` are touched;
+  `demo-gate` and other gates are out of scope, keeping the blast radius small.
+
+## Concerns
+
+1. Minimum byte threshold (100 bytes for diary, checked via `wc -c`) is a
+   proxy for substance. A sophisticated actor can satisfy the threshold with
+   padding. The `##` header + `Seed:` structural requirement is the real
+   semantic guard; size is a secondary sanity check.
+2. The shared shell module is tested by inspecting its source file in Python
+   unit tests. This is a structural test, not an execution test — a behavioral
+   integration test (actually sourcing the script in bash) would be stronger.
+
+## Seed
+
+If structural marker checks (`##`, `Seed:`, `type:`) are the real substance
+gates, should a future FR define a YAML schema for diary reflections and
+changelog fragments and validate them with a proper parser (e.g., `pyyaml` +
+Pydantic) rather than shell `grep`? Would that finally close the gap between
+shape validation and semantic validation for compliance artifacts?

--- a/feature-requests/FR-373-substance-validation-diary-changelog-gates.md
+++ b/feature-requests/FR-373-substance-validation-diary-changelog-gates.md
@@ -1,0 +1,150 @@
+# Feature Request: FR-373 Substance validation for diary-gate and changelog-gate
+
+**Priority:** HIGH
+**Type:** Bug
+**Status:** Implemented
+**Effort:** 1 day
+**Requested:** 2026-05-13
+
+## Summary
+
+Harden `diary-gate` and `changelog-gate` so they validate artifact substance (not just filename presence) before allowing feat/fix PRs to merge.
+
+## Value Statement
+
+Maintainers get merge gates that reject empty/meaningless compliance artifacts, reducing false-green CI outcomes and preserving traceability quality.
+
+## Problem
+
+Both gates currently validate shape only:
+
+1. `changelog-gate` passes when any path under `changelog/unreleased/` appears in the PR diff, even if the fragment is empty or malformed.
+2. `diary-gate` passes when any matching `docs/diary/*reflection*fr-NNN*` filename appears, even if the file has no substantive reflection content.
+
+This allows compliance theatre: CI passes while the required artifact conveys no meaningful information.
+
+## Research: Existing Patterns, Prior Art, and Gaps
+
+1. **Current CI scripts are presence-only.**
+   - `.github/workflows/commitlint.yml` contains inline shell checks based on `git diff --name-only` + regex path match for both `changelog-gate` and `diary-gate`.
+   - `tests/unit/test_ci_changelog_gate.py` and `tests/unit/test_ci_diary_gate.py` lock in this presence behavior today.
+2. **There is proven prior art for semantic gate validation.**
+   - FR-325 introduced `scripts/demo_log_semantics.sh` with `validate_demo_output_log_file()` and CI wiring via `source scripts/demo_log_semantics.sh`.
+   - `tests/unit/test_fr325_demo_gate_log_content_validation.py` proves semantic checks through script-structure and behavior tests.
+3. **Current local enforcement does not close the CI gap.**
+   - `.pre-commit-config.yaml` `diary-reflection-check` only rejects known placeholder strings; it does not enforce minimum substance structure (size/header/Seed marker), and local hooks are bypassed by server-side squash merge.
+4. **Recurring evidence of this exact failure mode exists.**
+   - `docs/diary/2026-04-08-inquisitor-audit-162.md` and `...-163.md` explicitly identify existence-only gates as compliance theatre and propose minimum-content checks.
+5. **Topic source discrepancy in this worktree.**
+   - Requested source `.chaplain/processing/gh-373.md` is not present; canonical planning source used: GitHub issue #373.
+
+## Objectives
+
+1. Ensure `diary-gate` rejects empty or structurally invalid diary reflections.
+2. Ensure `changelog-gate` rejects empty or structurally invalid changelog fragments.
+3. Reuse the FR-325 semantic-validation pattern (shared shell validation function(s)) for maintainability and testability.
+
+## Constraints
+
+1. **Single responsibility:** only strengthen substance validation for existing `diary-gate` and `changelog-gate`.
+2. Preserve existing gate trigger semantics (`feat`/`fix` PR titles, FR extraction behavior in `diary-gate`).
+3. Preserve existing path contracts:
+   - diary files still keyed by FR number in `docs/diary/`
+   - changelog entries still in `changelog/unreleased/`
+4. No expansion to unrelated gates (for example `demo-gate`).
+5. Keep implementation shell-first and CI-local (no new external actions/services).
+
+## Proposed Solution
+
+### In scope
+
+1. Add a shared shell semantic validator module for CI gate artifact checks (patterned after `scripts/demo_log_semantics.sh`), with:
+   - `validate_diary_reflection_file <path> <label>`
+   - `validate_changelog_fragment_file <path> <label>`
+2. Update `changelog-gate` in `.github/workflows/commitlint.yml` to:
+   - gather changed files under `changelog/unreleased/*.md`,
+   - fail if none exist (existing behavior),
+   - validate each matched fragment for substance:
+     - contains non-whitespace content,
+     - contains YAML front matter (`---` block) with `type:` field,
+     - contains at least one Markdown list item (`- `) in the body section.
+3. Update `diary-gate` in `.github/workflows/commitlint.yml` to:
+   - keep FR-number-based matching logic,
+   - validate matching diary file content for substance:
+     - contains non-whitespace content,
+     - contains at least one Markdown `##` header,
+     - contains `Seed:` marker,
+     - meets a minimum byte threshold (target: >100 bytes).
+4. Update tests to cover semantic behavior, not only path presence:
+   - extend/add tests proving invalid-empty/malformed artifacts fail,
+   - prove valid artifacts pass.
+5. Update traceability text for the affected capability/requirement records to reflect semantic gate behavior:
+   - `capabilities/CAP-50-ci-changelog-gate.yaml` (REQ-YG-148)
+   - `capabilities/CAP-54-ci-diary-existence-gate.yaml` (REQ-YG-152)
+   - `ARCHITECTURE.md` rows for REQ-YG-148 and REQ-YG-152.
+
+### Out of scope
+
+1. Rewriting historical diary/changelog files outside the current PR diff.
+2. Changing pre-commit hooks (`diary-reflection-check`, `changelog-required`) in this FR.
+3. Introducing a universal substance framework for all gates (can be a follow-up FR).
+
+## Acceptance Criteria
+
+- [x] **AC-01:** `changelog-gate` fails when a changed `changelog/unreleased/*.md` file is empty/whitespace-only.
+- [x] **AC-02:** `changelog-gate` fails when a changed fragment lacks valid front matter with `type:` and/or lacks a body list item (`- `).
+- [x] **AC-03:** `changelog-gate` passes when a changed fragment has non-empty content, valid front matter with `type:`, and at least one body list item.
+- [x] **AC-04:** `diary-gate` fails when the FR-matching diary file is empty, below minimum size, missing `##` header, or missing `Seed:` marker.
+- [x] **AC-05:** `diary-gate` passes when the FR-matching diary file satisfies all substance checks.
+- [x] **AC-06:** Gate scripts use shared semantic validation function(s) (no duplicated validation logic inline in workflow).
+- [x] **AC-07:** REQ/CAP architecture text for REQ-YG-148 and REQ-YG-152 describes substance validation semantics.
+
+## Failing Acceptance Tests (RED plan)
+
+RED test artifact:
+
+- `tests/unit/test_fr373_gate_substance_validation_red.py`
+
+Planned RED tests:
+
+1. `test_ac01_changelog_gate_rejects_empty_fragment_content`
+2. `test_ac02_changelog_gate_rejects_missing_type_or_body_list_item`
+3. `test_ac03_changelog_gate_accepts_valid_fragment_structure`
+4. `test_ac04_diary_gate_rejects_missing_header_seed_or_min_size`
+5. `test_ac05_diary_gate_accepts_valid_reflection_structure`
+6. `test_ac06_commitlint_gate_scripts_source_shared_semantics_module`
+7. `test_ac07_reqyg148_and_reqyg152_text_mentions_substance_validation`
+
+RED command:
+
+```bash
+pytest tests/unit/test_fr373_gate_substance_validation_red.py -q --no-cov
+```
+
+Targeted regression command (post-implementation):
+
+```bash
+pytest tests/unit/test_ci_changelog_gate.py tests/unit/test_ci_diary_gate.py -q --no-cov
+```
+
+## Alternatives Considered
+
+1. **Keep presence-only CI checks**
+   - Rejected: does not address the reported failure mode; empty files still pass.
+2. **Rely only on local pre-commit hooks**
+   - Rejected: server-side squash merge bypasses local hooks; CI must enforce merge boundary truth.
+3. **Build one universal “substance gate” for all artifacts now**
+   - Rejected for scope: useful direction, but broader than this issue’s single responsibility.
+
+## Related
+
+- Issue #373: <https://github.com/sheikkinen/yamlgraph/issues/373>
+- `.github/workflows/commitlint.yml`
+- `tests/unit/test_ci_changelog_gate.py`
+- `tests/unit/test_ci_diary_gate.py`
+- `scripts/demo_log_semantics.sh` (prior-art semantic validator pattern from FR-325)
+- `feature-requests/FR-325-demo-gate-log-content-validation.md`
+- `feature-requests/FR-149-ci-changelog-gate.md`
+- `feature-requests/FR-158-diary-existence-ci-gate.md`
+- `docs/diary/2026-04-08-inquisitor-audit-162.md`
+- `docs/diary/2026-04-08-inquisitor-audit-163.md`

--- a/scripts/gate_artifact_semantics.sh
+++ b/scripts/gate_artifact_semantics.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Shared semantic contract for CI artifact validation (FR-373).
+# shellcheck shell=bash
+
+validate_changelog_fragment_file() {
+  local fragment_file="$1"
+  local fragment_label="${2:-$fragment_file}"
+
+  if [ ! -f "$fragment_file" ]; then
+    echo "::error::changelog fragment missing from workspace: $fragment_label"
+    return 1
+  fi
+
+  if ! grep -q '[^[:space:]]' "$fragment_file"; then
+    echo "::error::changelog fragment is empty: $fragment_label"
+    return 1
+  fi
+
+  if ! awk '
+    NR == 1 && $0 == "---" { in_front_matter = 1; next }
+    in_front_matter && $0 == "---" { found_end = 1; exit }
+    END { exit(found_end ? 0 : 1) }
+  ' "$fragment_file"; then
+    echo "::error::changelog fragment must start with YAML front matter: $fragment_label"
+    return 1
+  fi
+
+  if ! awk '
+    NR == 1 && $0 == "---" { in_front_matter = 1; next }
+    in_front_matter && $0 == "---" { found_end = 1; exit }
+    in_front_matter && $0 ~ /^type:[[:space:]]*[^[:space:]]+/ { found_type = 1 }
+    END { exit(found_end && found_type ? 0 : 1) }
+  ' "$fragment_file"; then
+    echo "::error::changelog fragment front matter missing type: field: $fragment_label"
+    return 1
+  fi
+
+  if ! awk '
+    NR == 1 && $0 == "---" { in_front_matter = 1; next }
+    in_front_matter && $0 == "---" { in_front_matter = 0; in_body = 1; next }
+    in_body && $0 ~ /^[[:space:]]*-[[:space:]]+/ { found_list = 1; exit }
+    END { exit(in_body && found_list ? 0 : 1) }
+  ' "$fragment_file"; then
+    echo "::error::changelog fragment body missing markdown list item (- ): $fragment_label"
+    return 1
+  fi
+
+  echo "✅ Changelog fragment validated: $fragment_label"
+  return 0
+}
+
+validate_diary_reflection_file() {
+  local diary_file="$1"
+  local diary_label="${2:-$diary_file}"
+
+  if [ ! -f "$diary_file" ]; then
+    echo "::error::diary reflection missing from workspace: $diary_label"
+    return 1
+  fi
+
+  if ! grep -q '[^[:space:]]' "$diary_file"; then
+    echo "::error::diary reflection is empty: $diary_label"
+    return 1
+  fi
+
+  local byte_count
+  byte_count="$(wc -c < "$diary_file" | tr -d ' ')"
+  if [ "$byte_count" -le 100 ]; then
+    echo "::error::diary reflection must be >100 bytes: $diary_label"
+    return 1
+  fi
+
+  if ! grep -qE '^##[[:space:]]+' "$diary_file"; then
+    echo "::error::diary reflection missing markdown ## header: $diary_label"
+    return 1
+  fi
+
+  if ! grep -q 'Seed:' "$diary_file"; then
+    echo "::error::diary reflection missing Seed: marker: $diary_label"
+    return 1
+  fi
+
+  echo "✅ Diary reflection validated: $diary_label"
+  return 0
+}

--- a/tests/unit/test_ci_changelog_gate.py
+++ b/tests/unit/test_ci_changelog_gate.py
@@ -1,174 +1,203 @@
-"""Tests for CI changelog gate in commitlint.yml (FR-149, updated by FR-179).
+"""Tests for CI changelog gate in commitlint.yml (FR-149 + FR-373)."""
 
-Validates that the `changelog-gate` job in `.github/workflows/commitlint.yml`
-correctly blocks feat/fix PRs without changelog fragments in the diff and skips
-for other PR types.
+from __future__ import annotations
 
-Two test layers:
-1. YAML structure — parse the workflow and verify job config, conditions, steps.
-2. Shell logic — run the verification script with mocked git diff output.
-"""
-
+import os
 import subprocess
+import tempfile
+from pathlib import Path
 
 import pytest
 import yaml
 
-WORKFLOW_PATH = ".github/workflows/commitlint.yml"
-
-# The shell script from the changelog-gate step, extracted for unit testing.
-# Mirrors the `run:` block in commitlint.yml; uses env vars BASE_SHA/HEAD_SHA.
-# FR-179: Updated to check for changelog fragments instead of CHANGELOG.md
-CHANGELOG_GATE_SCRIPT = """\
-if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE '^changelog/unreleased/'; then
-  echo "✅ Changelog fragment found"
-else
-  echo "::error::feat/fix PRs must include a changelog fragment in changelog/unreleased/"
-  exit 1
-fi
-"""
+WORKFLOW_PATH = Path(".github/workflows/commitlint.yml")
+SEMANTICS_SCRIPT_PATH = Path("scripts/gate_artifact_semantics.sh")
 
 
 def _load_workflow() -> dict:
-    """Load and parse the commitlint workflow YAML."""
-    with open(WORKFLOW_PATH) as f:
+    with WORKFLOW_PATH.open() as f:
         return yaml.safe_load(f)
 
 
-def _run_gate_script(diff_output: str) -> subprocess.CompletedProcess:
-    """Run the changelog gate script with mocked git diff output.
+def _changelog_gate_run_script() -> str:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["changelog-gate"]["steps"]
+    verify_steps = [
+        step
+        for step in steps
+        if "run" in step and "changelog fragment" in step.get("name", "").lower()
+    ]
+    assert verify_steps, "changelog-gate must include a verification step"
+    return str(verify_steps[0]["run"])
 
-    Replaces `git diff --name-only "$BASE_SHA" "$HEAD_SHA"` with an echo
-    of the provided diff output to test the grep logic in isolation.
-    """
-    script = CHANGELOG_GATE_SCRIPT.replace(
-        'git diff --name-only "$BASE_SHA" "$HEAD_SHA"',
-        f"echo '{diff_output}'",
+
+def _setup_git_repo(tmpdir: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmpdir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=tmpdir, check=True
     )
-    return subprocess.run(
-        ["bash", "-c", script],
-        capture_output=True,
-        text=True,
-    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmpdir, check=True)
 
 
-# ── YAML Structure Tests ───────────────────────────────────────────────────
+def _run_ci_changelog_gate_check(
+    changed_files: dict[str, str],
+) -> subprocess.CompletedProcess:
+    run_script = _changelog_gate_run_script()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_git_repo(tmpdir)
+        tmppath = Path(tmpdir)
+
+        semantics_dest = tmppath / "scripts" / "gate_artifact_semantics.sh"
+        semantics_dest.parent.mkdir(parents=True, exist_ok=True)
+        semantics_dest.write_text(SEMANTICS_SCRIPT_PATH.read_text())
+        semantics_dest.chmod(0o755)
+
+        (tmppath / "README.md").write_text("base\n")
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=tmpdir, check=True)
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        for relpath, content in changed_files.items():
+            fpath = tmppath / relpath
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=tmpdir, check=True)
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        env = os.environ.copy()
+        env["BASE_SHA"] = base_sha
+        env["HEAD_SHA"] = head_sha
+        return subprocess.run(
+            ["bash", "-lc", run_script],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            env=env,
+        )
 
 
 @pytest.mark.req("REQ-YG-148")
 class TestChangelogGateJobStructure:
-    """Verify the changelog-gate job exists with correct configuration."""
+    """Verify changelog-gate wiring in commitlint.yml."""
 
     def test_job_exists(self) -> None:
-        """The commitlint workflow must contain a 'changelog-gate' job."""
         wf = _load_workflow()
-        assert (
-            "changelog-gate" in wf["jobs"]
-        ), "Missing 'changelog-gate' job in commitlint.yml"
+        assert "changelog-gate" in wf["jobs"]
 
-    def test_job_name(self) -> None:
-        """The job display name indicates changelog fragment is required."""
+    def test_job_name_mentions_changelog_and_feat_fix(self) -> None:
         wf = _load_workflow()
-        job = wf["jobs"]["changelog-gate"]
-        assert "hangelog" in job["name"], "Job name must mention changelog"
-        assert (
-            "feat" in job["name"] or "fix" in job["name"]
-        ), "Job name must mention feat or fix"
+        name = wf["jobs"]["changelog-gate"]["name"].lower()
+        assert "changelog" in name
+        assert "feat" in name or "fix" in name
 
-    def test_job_condition_checks_feat(self) -> None:
-        """The job-level `if` condition must check for 'feat' PR titles."""
+    def test_job_condition_checks_feat_and_fix_titles(self) -> None:
         wf = _load_workflow()
-        job = wf["jobs"]["changelog-gate"]
-        condition = job.get("if", "")
-        assert (
-            "startsWith(github.event.pull_request.title, 'feat')" in condition
-        ), "Job must check for feat PR titles"
+        condition = wf["jobs"]["changelog-gate"].get("if", "")
+        assert "startsWith(github.event.pull_request.title, 'feat')" in condition
+        assert "startsWith(github.event.pull_request.title, 'fix')" in condition
 
-    def test_job_condition_checks_fix(self) -> None:
-        """The job-level `if` condition must check for 'fix' PR titles."""
-        wf = _load_workflow()
-        job = wf["jobs"]["changelog-gate"]
-        condition = job.get("if", "")
-        assert (
-            "startsWith(github.event.pull_request.title, 'fix')" in condition
-        ), "Job must check for fix PR titles"
-
-    def test_checkout_with_full_history(self) -> None:
-        """The checkout step must use fetch-depth: 0 for full git history."""
+    def test_checkout_uses_fetch_depth_zero(self) -> None:
         wf = _load_workflow()
         steps = wf["jobs"]["changelog-gate"]["steps"]
         checkout_steps = [
-            s for s in steps if s.get("uses", "").startswith("actions/checkout")
+            step
+            for step in steps
+            if step.get("uses", "").startswith("actions/checkout")
         ]
-        assert checkout_steps, "Must have an actions/checkout step"
-        checkout = checkout_steps[0]
-        assert (
-            checkout.get("with", {}).get("fetch-depth") == 0
-        ), "Checkout must use fetch-depth: 0"
+        assert checkout_steps
+        assert checkout_steps[0].get("with", {}).get("fetch-depth") == 0
 
-    def test_verify_step_uses_git_diff(self) -> None:
-        """The verification step must use git diff to check for fragments."""
+    def test_verify_step_has_required_sha_env_vars(self) -> None:
         wf = _load_workflow()
         steps = wf["jobs"]["changelog-gate"]["steps"]
-        verify_steps = [s for s in steps if "run" in s and "changelog" in s["run"]]
-        assert verify_steps, "Must have a step that checks changelog fragments"
-        run_script = verify_steps[0]["run"]
-        assert "git diff --name-only" in run_script
-        assert "changelog/unreleased/" in run_script
-
-    def test_verify_step_has_sha_env_vars(self) -> None:
-        """The verification step must receive BASE_SHA and HEAD_SHA from GitHub context."""
-        wf = _load_workflow()
-        steps = wf["jobs"]["changelog-gate"]["steps"]
-        verify_steps = [s for s in steps if "run" in s and "changelog" in s["run"]]
-        assert verify_steps, "Must have a verification step"
+        verify_steps = [
+            step
+            for step in steps
+            if "run" in step and "changelog fragment" in step.get("name", "").lower()
+        ]
+        assert verify_steps
         env = verify_steps[0].get("env", {})
-        assert "BASE_SHA" in env, "Must pass BASE_SHA env var"
-        assert "HEAD_SHA" in env, "Must pass HEAD_SHA env var"
+        assert "BASE_SHA" in env
+        assert "HEAD_SHA" in env
 
-
-# ── Shell Script Logic Tests ───────────────────────────────────────────────
+    def test_verify_step_sources_shared_semantics_script(self) -> None:
+        run_script = _changelog_gate_run_script()
+        assert "source scripts/gate_artifact_semantics.sh" in run_script
+        assert "validate_changelog_fragment_file" in run_script
 
 
 @pytest.mark.req("REQ-YG-148")
 class TestChangelogGateShellLogic:
-    """Test the bash script that verifies changelog fragments in diff."""
+    """Validate semantic behavior of the changelog gate script."""
 
-    def test_fragment_in_diff_passes(self) -> None:
-        """When a changelog fragment is in the diff, the gate passes."""
-        result = _run_gate_script("changelog/unreleased/FR-179-test.md")
-        assert result.returncode == 0, f"Should pass: {result.stderr}"
-        assert "fragment found" in result.stdout
+    def test_valid_fragment_in_diff_passes(self) -> None:
+        result = _run_ci_changelog_gate_check(
+            {
+                "changelog/unreleased/fr-373-valid.md": (
+                    "---\n"
+                    "type: feat\n"
+                    "scope: ci\n"
+                    "---\n"
+                    "- Added robust changelog substance checks.\n"
+                )
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_empty_fragment_fails(self) -> None:
+        result = _run_ci_changelog_gate_check(
+            {"changelog/unreleased/fr-373-empty.md": "  \n\t\n"}
+        )
+        assert result.returncode == 1
+        assert "empty" in (result.stdout + result.stderr).lower()
+
+    def test_missing_type_in_front_matter_fails(self) -> None:
+        result = _run_ci_changelog_gate_check(
+            {
+                "changelog/unreleased/fr-373-no-type.md": (
+                    "---\nscope: ci\n---\n- Body item exists but type is missing.\n"
+                )
+            }
+        )
+        assert result.returncode == 1
+        assert "type" in (result.stdout + result.stderr).lower()
+
+    def test_missing_body_list_item_fails(self) -> None:
+        result = _run_ci_changelog_gate_check(
+            {
+                "changelog/unreleased/fr-373-no-list.md": (
+                    "---\n"
+                    "type: feat\n"
+                    "scope: ci\n"
+                    "---\n"
+                    "Body exists but not as a markdown bullet.\n"
+                )
+            }
+        )
+        assert result.returncode == 1
+        assert "list item" in (result.stdout + result.stderr).lower()
 
     def test_fragment_absent_from_diff_fails(self) -> None:
-        """When no changelog fragment is in the diff, the gate fails."""
-        result = _run_gate_script("src/main.py\nREADME.md")
-        assert result.returncode == 1, "Should fail without changelog fragment"
-        assert (
-            "must include a changelog fragment" in result.stderr
-            or "must include a changelog fragment" in result.stdout
+        result = _run_ci_changelog_gate_check({"src/main.py": "print('x')\n"})
+        assert result.returncode == 1
+        assert "must include a changelog fragment" in (result.stdout + result.stderr)
+
+    def test_versioned_changelog_paths_do_not_satisfy_gate(self) -> None:
+        result = _run_ci_changelog_gate_check(
+            {"changelog/0.5.0/fr-373-old.md": "---\ntype: feat\n---\n- old\n"}
         )
-
-    def test_empty_diff_fails(self) -> None:
-        """An empty diff (no changed files) fails the gate."""
-        result = _run_gate_script("")
-        assert result.returncode == 1, "Empty diff should fail"
-
-    def test_fragment_among_many_files_passes(self) -> None:
-        """A changelog fragment among other files still passes."""
-        result = _run_gate_script(
-            "src/main.py\nchangelog/unreleased/FR-179-test.md\ntests/test_foo.py"
-        )
-        assert result.returncode == 0, "Should pass with fragment in file list"
-
-    def test_versioned_changelog_not_accepted(self) -> None:
-        """A file in changelog/0.5.0/ should NOT satisfy the gate."""
-        result = _run_gate_script("changelog/0.5.0/FR-100-old.md")
-        assert (
-            result.returncode == 1
-        ), "Versioned changelog fragment should not satisfy unreleased check"
-
-    def test_old_changelog_md_not_accepted(self) -> None:
-        """CHANGELOG.md alone should NOT satisfy the gate."""
-        result = _run_gate_script("CHANGELOG.md")
-        assert result.returncode == 1, "CHANGELOG.md should not satisfy the check"
+        assert result.returncode == 1

--- a/tests/unit/test_ci_diary_gate.py
+++ b/tests/unit/test_ci_diary_gate.py
@@ -1,249 +1,231 @@
-"""Tests for CI diary reflection gate in commitlint.yml (FR-158).
+"""Tests for CI diary gate in commitlint.yml (FR-158 + FR-373)."""
 
-Validates that the `diary-gate` job in `.github/workflows/commitlint.yml`
-correctly blocks feat/fix PRs without a diary reflection file for the
-referenced FR number, and skips for PRs without an FR reference.
+from __future__ import annotations
 
-Two test layers:
-1. YAML structure — parse the workflow and verify job config, conditions, steps.
-2. Shell logic — run the verification script with mocked git diff output.
-"""
-
+import os
 import subprocess
+import tempfile
+from pathlib import Path
 
 import pytest
 import yaml
 
-WORKFLOW_PATH = ".github/workflows/commitlint.yml"
-
-# The shell script from the diary-gate step, extracted for unit testing.
-# Mirrors the `run:` block in commitlint.yml; uses env vars BASE_SHA/HEAD_SHA/PR_TITLE.
-DIARY_GATE_SCRIPT = """\
-FR_NUM=$(echo "$PR_TITLE" | grep -oE 'FR-[0-9]+' | head -1 | sed 's/FR-//')
-
-if [ -z "$FR_NUM" ]; then
-  echo "⏭️ No FR-XXX reference in title — diary gate skipped"
-  exit 0
-fi
-
-echo "🔍 Checking for diary reflection for FR-$FR_NUM..."
-
-if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE "docs/diary/.*reflection.*fr-${FR_NUM}[^0-9]"; then
-  echo "✅ Diary reflection found for FR-$FR_NUM"
-else
-  echo "::error::feat/fix PRs referencing FR-$FR_NUM must include a diary reflection in docs/diary/"
-  echo ""
-  echo "Expected: docs/diary/YYYY-MM-DD-reflection-fr-${FR_NUM}.md"
-  echo ""
-  echo "The diary reflection should document:"
-  echo "  - Cognitive traps encountered"
-  echo "  - Heuristics learned"
-  echo "  - A Seed question for future work"
-  echo ""
-  echo "See docs/diary/ for examples."
-  exit 1
-fi
-"""
+WORKFLOW_PATH = Path(".github/workflows/commitlint.yml")
+SEMANTICS_SCRIPT_PATH = Path("scripts/gate_artifact_semantics.sh")
 
 
 def _load_workflow() -> dict:
-    """Load and parse the commitlint workflow YAML."""
-    with open(WORKFLOW_PATH) as f:
+    with WORKFLOW_PATH.open() as f:
         return yaml.safe_load(f)
 
 
-def _run_gate_script(
-    diff_output: str, pr_title: str = "feat(core): FR-158 add diary gate"
+def _diary_gate_run_script() -> str:
+    workflow = _load_workflow()
+    steps = workflow["jobs"]["diary-gate"]["steps"]
+    verify_steps = [
+        step
+        for step in steps
+        if "run" in step and "diary reflection" in step.get("name", "").lower()
+    ]
+    assert verify_steps, "diary-gate must include a verification step"
+    return str(verify_steps[0]["run"])
+
+
+def _setup_git_repo(tmpdir: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmpdir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=tmpdir, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmpdir, check=True)
+
+
+def _run_ci_diary_gate_check(
+    changed_files: dict[str, str],
+    pr_title: str = "feat(ci): FR-158 diary gate semantics",
 ) -> subprocess.CompletedProcess:
-    """Run the diary gate script with mocked git diff output.
+    run_script = _diary_gate_run_script()
 
-    Replaces `git diff --name-only "$BASE_SHA" "$HEAD_SHA"` with an echo
-    of the provided diff output to test the grep logic in isolation.
-    """
-    script = DIARY_GATE_SCRIPT.replace(
-        'git diff --name-only "$BASE_SHA" "$HEAD_SHA"',
-        f"echo '{diff_output}'",
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_git_repo(tmpdir)
+        tmppath = Path(tmpdir)
+
+        semantics_dest = tmppath / "scripts" / "gate_artifact_semantics.sh"
+        semantics_dest.parent.mkdir(parents=True, exist_ok=True)
+        semantics_dest.write_text(SEMANTICS_SCRIPT_PATH.read_text())
+        semantics_dest.chmod(0o755)
+
+        (tmppath / "README.md").write_text("base\n")
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=tmpdir, check=True)
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        for relpath, content in changed_files.items():
+            fpath = tmppath / relpath
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=tmpdir, check=True)
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        env = os.environ.copy()
+        env["BASE_SHA"] = base_sha
+        env["HEAD_SHA"] = head_sha
+        env["PR_TITLE"] = pr_title
+        env["PATH"] = "/usr/bin:/bin"
+        return subprocess.run(
+            ["bash", "-lc", run_script],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            env=env,
+        )
+
+
+def _valid_diary_body() -> str:
+    return (
+        "# Reflection FR-158\n\n"
+        "## Trap\n"
+        "Assuming file presence equals meaningful reflection caused a false green.\n\n"
+        "## Heuristic\n"
+        "Require structural evidence before passing merge-time compliance gates.\n\n"
+        "## Seed\n"
+        "Seed: How can we standardize substance checks across all merge gates?\n"
     )
-    return subprocess.run(
-        ["bash", "-c", script],
-        capture_output=True,
-        text=True,
-        env={"PR_TITLE": pr_title, "PATH": "/usr/bin:/bin"},
-    )
-
-
-# ── YAML Structure Tests ───────────────────────────────────────────────────
 
 
 @pytest.mark.req("REQ-YG-152")
 class TestDiaryGateJobStructure:
-    """Verify the diary-gate job exists with correct configuration."""
+    """Verify diary-gate wiring in commitlint.yml."""
 
     def test_job_exists(self) -> None:
-        """The commitlint workflow must contain a 'diary-gate' job."""
         wf = _load_workflow()
-        assert "diary-gate" in wf["jobs"], "Missing 'diary-gate' job in commitlint.yml"
+        assert "diary-gate" in wf["jobs"]
 
-    def test_job_name(self) -> None:
-        """The job display name indicates diary is required for feat/fix."""
+    def test_job_name_mentions_diary_and_feat_fix(self) -> None:
         wf = _load_workflow()
-        job = wf["jobs"]["diary-gate"]
-        name = job["name"].lower()
-        assert "diary" in name, "Job name must mention diary"
-        assert "feat" in name or "fix" in name, "Job name must mention feat or fix"
+        name = wf["jobs"]["diary-gate"]["name"].lower()
+        assert "diary" in name
+        assert "feat" in name or "fix" in name
 
-    def test_job_condition_checks_feat(self) -> None:
-        """The job-level `if` condition must check for 'feat' PR titles."""
+    def test_job_condition_checks_feat_and_fix_titles(self) -> None:
         wf = _load_workflow()
-        job = wf["jobs"]["diary-gate"]
-        condition = job.get("if", "")
-        assert (
-            "startsWith(github.event.pull_request.title, 'feat')" in condition
-        ), "Job must check for feat PR titles"
+        condition = wf["jobs"]["diary-gate"].get("if", "")
+        assert "startsWith(github.event.pull_request.title, 'feat')" in condition
+        assert "startsWith(github.event.pull_request.title, 'fix')" in condition
 
-    def test_job_condition_checks_fix(self) -> None:
-        """The job-level `if` condition must check for 'fix' PR titles."""
-        wf = _load_workflow()
-        job = wf["jobs"]["diary-gate"]
-        condition = job.get("if", "")
-        assert (
-            "startsWith(github.event.pull_request.title, 'fix')" in condition
-        ), "Job must check for fix PR titles"
-
-    def test_checkout_with_full_history(self) -> None:
-        """The checkout step must use fetch-depth: 0 for full git history."""
+    def test_checkout_uses_fetch_depth_zero(self) -> None:
         wf = _load_workflow()
         steps = wf["jobs"]["diary-gate"]["steps"]
         checkout_steps = [
-            s for s in steps if s.get("uses", "").startswith("actions/checkout")
+            step
+            for step in steps
+            if step.get("uses", "").startswith("actions/checkout")
         ]
-        assert checkout_steps, "Must have an actions/checkout step"
-        checkout = checkout_steps[0]
-        assert (
-            checkout.get("with", {}).get("fetch-depth") == 0
-        ), "Checkout must use fetch-depth: 0"
-
-    def test_verify_step_uses_git_diff(self) -> None:
-        """The verification step must use git diff with base/head SHAs."""
-        wf = _load_workflow()
-        steps = wf["jobs"]["diary-gate"]["steps"]
-        verify_steps = [s for s in steps if "run" in s and "diary" in s["run"].lower()]
-        assert verify_steps, "Must have a step that checks diary reflection"
-        run_script = verify_steps[0]["run"]
-        assert "git diff --name-only" in run_script
-        assert "diary" in run_script.lower()
+        assert checkout_steps
+        assert checkout_steps[0].get("with", {}).get("fetch-depth") == 0
 
     def test_verify_step_has_required_env_vars(self) -> None:
-        """The verification step must receive BASE_SHA, HEAD_SHA, and PR_TITLE."""
         wf = _load_workflow()
         steps = wf["jobs"]["diary-gate"]["steps"]
-        verify_steps = [s for s in steps if "run" in s and "diary" in s["run"].lower()]
-        assert verify_steps, "Must have a verification step"
+        verify_steps = [
+            step
+            for step in steps
+            if "run" in step and "diary reflection" in step.get("name", "").lower()
+        ]
+        assert verify_steps
         env = verify_steps[0].get("env", {})
-        assert "BASE_SHA" in env, "Must pass BASE_SHA env var"
-        assert "HEAD_SHA" in env, "Must pass HEAD_SHA env var"
-        assert "PR_TITLE" in env, "Must pass PR_TITLE env var"
+        assert "BASE_SHA" in env
+        assert "HEAD_SHA" in env
+        assert "PR_TITLE" in env
 
-    def test_error_message_includes_guidance(self) -> None:
-        """The error message must include expected path pattern and content guidance."""
-        wf = _load_workflow()
-        steps = wf["jobs"]["diary-gate"]["steps"]
-        verify_steps = [s for s in steps if "run" in s and "diary" in s["run"].lower()]
-        assert verify_steps, "Must have a verification step"
-        run_script = verify_steps[0]["run"]
-        assert "reflection" in run_script, "Error must mention reflection"
-        assert "Seed" in run_script, "Error must mention Seed question"
-        assert (
-            "Cognitive traps" in run_script or "traps" in run_script.lower()
-        ), "Error must mention cognitive traps"
-
-
-# ── Shell Script Logic Tests ───────────────────────────────────────────────
+    def test_verify_step_sources_shared_semantics_script(self) -> None:
+        run_script = _diary_gate_run_script()
+        assert "source scripts/gate_artifact_semantics.sh" in run_script
+        assert "validate_diary_reflection_file" in run_script
 
 
 @pytest.mark.req("REQ-YG-152")
 class TestDiaryGateShellLogic:
-    """Test the actual bash script that verifies diary reflection in diff."""
+    """Validate semantic behavior of the diary gate script."""
 
-    def test_diary_reflection_in_diff_passes(self) -> None:
-        """When a matching diary reflection is in the diff, the gate passes."""
-        result = _run_gate_script(
-            "docs/diary/2026-03-08-reflection-fr-158.md",
-            pr_title="feat(ci): FR-158 add diary gate",
+    def test_matching_valid_diary_reflection_passes(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {"docs/diary/2026-05-13-reflection-fr-158.md": _valid_diary_body()},
+            pr_title="feat(ci): FR-158 enforce diary semantics",
         )
-        assert result.returncode == 0, f"Should pass: {result.stderr}"
-        assert "Diary reflection found" in result.stdout
+        assert result.returncode == 0, result.stdout + result.stderr
 
     def test_diary_reflection_absent_from_diff_fails(self) -> None:
-        """When no diary reflection is in the diff, the gate fails."""
-        result = _run_gate_script(
-            "src/main.py\nREADME.md",
-            pr_title="feat(ci): FR-158 add diary gate",
+        result = _run_ci_diary_gate_check(
+            {"src/main.py": "print('x')\n"},
+            pr_title="feat(ci): FR-158 enforce diary semantics",
         )
-        assert result.returncode == 1, "Should fail without diary reflection"
-        assert "must include a diary reflection" in result.stdout
+        assert result.returncode == 1
+        assert "must include a diary reflection" in (result.stdout + result.stderr)
 
-    def test_empty_diff_fails(self) -> None:
-        """An empty diff (no changed files) fails the gate."""
-        result = _run_gate_script(
-            "",
-            pr_title="feat(ci): FR-158 add diary gate",
+    def test_empty_diary_reflection_fails(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {"docs/diary/2026-05-13-reflection-fr-158.md": "\n \t\n"},
+            pr_title="feat(ci): FR-158 enforce diary semantics",
         )
-        assert result.returncode == 1, "Empty diff should fail"
+        assert result.returncode == 1
+        assert "empty" in (result.stdout + result.stderr).lower()
 
-    def test_diary_among_many_files_passes(self) -> None:
-        """A matching diary file among other changed files still passes."""
-        result = _run_gate_script(
-            "src/main.py\ndocs/diary/2026-03-08-reflection-fr-158.md\ntests/test_foo.py",
-            pr_title="feat(ci): FR-158 add diary gate",
+    def test_diary_reflection_below_minimum_size_fails(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {"docs/diary/2026-05-13-reflection-fr-158.md": "## Trap\nSeed: x\n"},
+            pr_title="feat(ci): FR-158 enforce diary semantics",
         )
-        assert result.returncode == 0, "Should pass with diary in file list"
+        assert result.returncode == 1
+        assert ">100 bytes" in (result.stdout + result.stderr)
 
-    def test_wrong_fr_number_rejected(self) -> None:
-        """A diary file for a different FR number should NOT satisfy the gate."""
-        result = _run_gate_script(
-            "docs/diary/2026-03-08-reflection-fr-999.md",
-            pr_title="feat(ci): FR-158 add diary gate",
+    def test_diary_reflection_missing_header_fails(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {
+                "docs/diary/2026-05-13-reflection-fr-158.md": (
+                    "Trap section without markdown headers. " * 8 + "Seed: yes\n"
+                )
+            },
+            pr_title="feat(ci): FR-158 enforce diary semantics",
         )
-        assert result.returncode == 1, "Wrong FR number should not satisfy the check"
+        assert result.returncode == 1
+        assert "## header" in (result.stdout + result.stderr)
 
-    def test_no_fr_reference_skips(self) -> None:
-        """A PR without FR-XXX reference skips the gate (passes)."""
-        result = _run_gate_script(
-            "src/main.py",
-            pr_title="fix(typo): correct spelling in README",
+    def test_diary_reflection_missing_seed_fails(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {
+                "docs/diary/2026-05-13-reflection-fr-158.md": (
+                    "## Trap\n" + ("Content line for size.\n" * 12)
+                )
+            },
+            pr_title="feat(ci): FR-158 enforce diary semantics",
         )
-        assert result.returncode == 0, "No FR reference should skip"
+        assert result.returncode == 1
+        assert "seed:" in (result.stdout + result.stderr).lower()
+
+    def test_wrong_fr_number_does_not_satisfy_gate(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {"docs/diary/2026-05-13-reflection-fr-999.md": _valid_diary_body()},
+            pr_title="feat(ci): FR-158 enforce diary semantics",
+        )
+        assert result.returncode == 1
+
+    def test_no_fr_reference_skips_gate(self) -> None:
+        result = _run_ci_diary_gate_check(
+            {"src/main.py": "print('x')\n"},
+            pr_title="fix(readme): correct typo",
+        )
+        assert result.returncode == 0
         assert "diary gate skipped" in result.stdout
-
-    def test_fix_pr_with_fr_enforced(self) -> None:
-        """A fix PR with FR reference must also include diary reflection."""
-        result = _run_gate_script(
-            "src/main.py",
-            pr_title="fix(core): FR-042 resolve edge case",
-        )
-        assert result.returncode == 1, "fix PR with FR reference should enforce diary"
-
-    def test_fix_pr_with_fr_and_diary_passes(self) -> None:
-        """A fix PR with FR reference and matching diary file passes."""
-        result = _run_gate_script(
-            "src/main.py\ndocs/diary/2026-03-08-reflection-fr-042.md",
-            pr_title="fix(core): FR-042 resolve edge case",
-        )
-        assert result.returncode == 0, "fix PR with FR and diary should pass"
-
-    def test_substring_fr_number_not_matched(self) -> None:
-        """FR-15 should NOT match a diary file for FR-158."""
-        result = _run_gate_script(
-            "docs/diary/2026-03-08-reflection-fr-158.md",
-            pr_title="feat(ci): FR-15 some feature",
-        )
-        assert result.returncode == 1, "FR-15 should not match fr-158 diary file"
-
-    def test_diary_file_with_extra_suffix_passes(self) -> None:
-        """Diary files with extra descriptive suffixes should still match."""
-        result = _run_gate_script(
-            "docs/diary/2026-03-08-reflection-fr-158-diary-gate.md",
-            pr_title="feat(ci): FR-158 add diary gate",
-        )
-        assert result.returncode == 0, "Descriptive suffix should still match"

--- a/tests/unit/test_fr373_gate_substance_validation_red.py
+++ b/tests/unit/test_fr373_gate_substance_validation_red.py
@@ -1,0 +1,240 @@
+"""Acceptance tests for FR-373 gate substance validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(".github/workflows/commitlint.yml")
+SEMANTICS_SCRIPT_PATH = Path("scripts/gate_artifact_semantics.sh")
+CAP_50_PATH = Path("capabilities/CAP-50-ci-changelog-gate.yaml")
+CAP_54_PATH = Path("capabilities/CAP-54-ci-diary-existence-gate.yaml")
+ARCHITECTURE_PATH = Path("ARCHITECTURE.md")
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open() as f:
+        return yaml.safe_load(f)
+
+
+def _gate_run_script(job_name: str, step_name_substring: str) -> str:
+    steps = _load_workflow()["jobs"][job_name]["steps"]
+    verify_steps = [
+        step
+        for step in steps
+        if "run" in step and step_name_substring in step.get("name", "").lower()
+    ]
+    assert verify_steps, f"{job_name} must include a '{step_name_substring}' step"
+    return str(verify_steps[0]["run"])
+
+
+def _setup_git_repo(tmpdir: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmpdir, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=tmpdir, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmpdir, check=True)
+
+
+def _run_gate(
+    *,
+    job_name: str,
+    step_name_substring: str,
+    changed_files: dict[str, str],
+    pr_title: str = "feat(ci): FR-373 enforce gate substance checks",
+) -> subprocess.CompletedProcess:
+    run_script = _gate_run_script(job_name, step_name_substring)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_git_repo(tmpdir)
+        tmppath = Path(tmpdir)
+
+        semantics_dest = tmppath / "scripts" / "gate_artifact_semantics.sh"
+        semantics_dest.parent.mkdir(parents=True, exist_ok=True)
+        semantics_dest.write_text(SEMANTICS_SCRIPT_PATH.read_text())
+        semantics_dest.chmod(0o755)
+
+        (tmppath / "README.md").write_text("base\n")
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=tmpdir, check=True)
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        for relpath, content in changed_files.items():
+            fpath = tmppath / relpath
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+        subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "head"], cwd=tmpdir, check=True)
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        env = os.environ.copy()
+        env["BASE_SHA"] = base_sha
+        env["HEAD_SHA"] = head_sha
+        env["PR_TITLE"] = pr_title
+        env["PATH"] = "/usr/bin:/bin"
+        return subprocess.run(
+            ["bash", "-lc", run_script],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            env=env,
+        )
+
+
+def _valid_diary_body() -> str:
+    return (
+        "# Reflection FR-373\n\n"
+        "## Trap\n"
+        "Presence-only checks caused compliance theatre in CI gates.\n\n"
+        "## Heuristic\n"
+        "Check semantic structure and minimum content before passing a merge gate.\n\n"
+        "## Seed\n"
+        "Seed: Should gate-semantic checks be standardized across all CI contracts?\n"
+    )
+
+
+@pytest.mark.req("REQ-YG-148")
+def test_ac01_changelog_gate_rejects_empty_fragment_content() -> None:
+    result = _run_gate(
+        job_name="changelog-gate",
+        step_name_substring="changelog fragment",
+        changed_files={"changelog/unreleased/fr-373-empty.md": " \n\t\n"},
+    )
+    assert result.returncode == 1
+    assert "empty" in (result.stdout + result.stderr).lower()
+
+
+@pytest.mark.req("REQ-YG-148")
+def test_ac02_changelog_gate_rejects_missing_type_or_body_list_item() -> None:
+    missing_type = _run_gate(
+        job_name="changelog-gate",
+        step_name_substring="changelog fragment",
+        changed_files={
+            "changelog/unreleased/fr-373-no-type.md": (
+                "---\nscope: ci\n---\n- body item exists\n"
+            )
+        },
+    )
+    assert missing_type.returncode == 1
+    assert "type" in (missing_type.stdout + missing_type.stderr).lower()
+
+    missing_body_list = _run_gate(
+        job_name="changelog-gate",
+        step_name_substring="changelog fragment",
+        changed_files={
+            "changelog/unreleased/fr-373-no-list.md": (
+                "---\ntype: feat\nscope: ci\n---\nbody line without markdown bullet\n"
+            )
+        },
+    )
+    assert missing_body_list.returncode == 1
+    assert "list item" in (missing_body_list.stdout + missing_body_list.stderr).lower()
+
+
+@pytest.mark.req("REQ-YG-148")
+def test_ac03_changelog_gate_accepts_valid_fragment_structure() -> None:
+    result = _run_gate(
+        job_name="changelog-gate",
+        step_name_substring="changelog fragment",
+        changed_files={
+            "changelog/unreleased/fr-373-valid.md": (
+                "---\ntype: feat\nscope: ci\n---\n"
+                "- **FR-373**: Added changelog/diary substance validation.\n"
+            )
+        },
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.req("REQ-YG-152")
+def test_ac04_diary_gate_rejects_missing_header_seed_or_min_size() -> None:
+    missing_header = _run_gate(
+        job_name="diary-gate",
+        step_name_substring="diary reflection",
+        changed_files={
+            "docs/diary/2026-05-13-reflection-fr-373.md": (
+                "No markdown header present. " * 8 + "Seed: present\n"
+            )
+        },
+    )
+    assert missing_header.returncode == 1
+    assert "## header" in (missing_header.stdout + missing_header.stderr)
+
+    missing_seed = _run_gate(
+        job_name="diary-gate",
+        step_name_substring="diary reflection",
+        changed_files={
+            "docs/diary/2026-05-13-reflection-fr-373.md": (
+                "## Trap\n" + ("Long enough content line.\n" * 12)
+            )
+        },
+    )
+    assert missing_seed.returncode == 1
+    assert "seed:" in (missing_seed.stdout + missing_seed.stderr).lower()
+
+    too_small = _run_gate(
+        job_name="diary-gate",
+        step_name_substring="diary reflection",
+        changed_files={
+            "docs/diary/2026-05-13-reflection-fr-373.md": "## Trap\nSeed: x\n"
+        },
+    )
+    assert too_small.returncode == 1
+    assert ">100 bytes" in (too_small.stdout + too_small.stderr)
+
+
+@pytest.mark.req("REQ-YG-152")
+def test_ac05_diary_gate_accepts_valid_reflection_structure() -> None:
+    result = _run_gate(
+        job_name="diary-gate",
+        step_name_substring="diary reflection",
+        changed_files={
+            "docs/diary/2026-05-13-reflection-fr-373.md": _valid_diary_body()
+        },
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.req("REQ-YG-148", "REQ-YG-152")
+def test_ac06_commitlint_gate_scripts_source_shared_semantics_module() -> None:
+    changelog_script = _gate_run_script("changelog-gate", "changelog fragment")
+    diary_script = _gate_run_script("diary-gate", "diary reflection")
+    semantics = SEMANTICS_SCRIPT_PATH.read_text()
+
+    assert "source scripts/gate_artifact_semantics.sh" in changelog_script
+    assert "source scripts/gate_artifact_semantics.sh" in diary_script
+    assert "validate_changelog_fragment_file" in changelog_script
+    assert "validate_diary_reflection_file" in diary_script
+    assert "validate_changelog_fragment_file()" in semantics
+    assert "validate_diary_reflection_file()" in semantics
+
+
+@pytest.mark.req("REQ-YG-148", "REQ-YG-152")
+def test_ac07_reqyg148_and_reqyg152_text_mentions_substance_validation() -> None:
+    cap_50 = CAP_50_PATH.read_text().lower()
+    cap_54 = CAP_54_PATH.read_text().lower()
+    architecture = ARCHITECTURE_PATH.read_text().lower()
+
+    assert "substance" in cap_50
+    assert "front matter" in cap_50
+    assert "substance" in cap_54
+    assert "seed:" in cap_54
+    assert "req-yg-148" in architecture and "substance" in architecture
+    assert "req-yg-152" in architecture and "seed:" in architecture


### PR DESCRIPTION
## Summary

Harden `diary-gate` and `changelog-gate` so they validate artifact substance (not just filename presence) before allowing feat/fix PRs to merge.

Closes #373

## FR

feature-requests/FR-373-substance-validation-diary-changelog-gates.md