### PR TITLE
feat(fsm): FR-392 add on_launch lifecycle hook

### DIFF
--- a/changelog/unreleased/fr-392-fsm-on-launch-hook.md
+++ b/changelog/unreleased/fr-392-fsm-on-launch-hook.md
@@ -1,0 +1,5 @@
+---
+type: feat
+scope: fsm
+---
+- **FR-392**: Add `on_launch` lifecycle hook to `YamlgraphAsyncAction` between snapshot creation and async task launch.

--- a/docs/diary/2026-05-15-reflection-fr-392-fsm-on-launch-hook.md
+++ b/docs/diary/2026-05-15-reflection-fr-392-fsm-on-launch-hook.md
@@ -1,0 +1,40 @@
+# Reflection: FR-392 FSM on_launch Lifecycle Hook
+
+**Date:** 2026-05-15
+**FR:** FR-392 — add `on_launch` hook to `YamlgraphAsyncAction`
+**Reviewer:** watcher2 validate pass
+
+## Trap
+
+`working_system_inertia` — The existing lifecycle hook surface (`pre_snapshot`,
+`pre_dispatch`, `on_success`, `on_error`) worked. That very fact made it easy to
+overlook the gap at the exact boundary where snapshot resolution completes but the
+background task has not yet been scheduled. The hook was absent not from neglect but
+because the system worked without it.
+
+## What Happened
+
+Adding `on_launch` required only four lines to `action.py`: the method definition (a
+typed no-op) and the call site between `snapshot_params()` and `asyncio.create_task()`.
+The position contract — snapshot resolves, hook fires, task launches — is now enforced
+by AC-02's position assertions directly against source text. Tests confirm the hook is
+not called when `snapshot_params()` raises `ValueError`, preserving fail-closed
+semantics.
+
+The AST-based `test_ac02` check (position in source) is a structural guard that
+survives refactors that preserve line ordering but not one that reorders the three
+operations. This is a deliberate choice: the constraint is about sequencing, and source
+position is the cheapest proxy that doesn't require runtime instrumentation.
+
+## Heuristic
+
+When a lifecycle hook chain has *n* defined boundaries, check whether every meaningful
+state transition inside the method has a corresponding hook. Missing hooks force
+subclasses to override the entire method, which creates drift risk.
+
+## Seed
+
+**Seed:** Could an introspective test walk the call graph of `execute()` automatically
+and emit a list of "hookable" transition points — positions where the internal state
+changes materially — so that hook coverage becomes measurable rather than discovered
+ad-hoc?

--- a/feature-requests/FR-392-fsm-on-launch-hook.md
+++ b/feature-requests/FR-392-fsm-on-launch-hook.md
@@ -1,0 +1,124 @@
+# Feature Request: FR-392 on_launch lifecycle hook for YamlgraphAsyncAction
+
+**Priority:** HIGH
+**Type:** Enhancement
+**Status:** Implemented
+**Effort:** 0.5 days
+**Requested:** 2026-05-15
+
+## Summary
+
+Add an `on_launch(snap, context)` lifecycle hook to `yamlgraph.utils.fsm.action.YamlgraphAsyncAction`, invoked after `snapshot_params()` succeeds and before `asyncio.create_task(...)`.
+
+## Value Statement
+
+FSM bridge subclasses can observe fully resolved launch metadata (graph path, phase, success/failure events) without duplicating snapshot derivation logic or overriding `execute()`.
+
+## Problem
+
+`YamlgraphAsyncAction` currently exposes:
+
+1. `pre_snapshot(params, context)` before snapshot materialization
+2. `pre_dispatch(...)`, `on_success(...)`, and `on_error(...)` during/after runner dispatch
+
+There is no hook at the boundary immediately after `SnapshotParams` is created and validated, but before background task launch. Subclasses that need resolved launch telemetry must currently:
+
+1. Reconstruct resolved values in `pre_snapshot` from raw params (duplicates `snapshot_params()` behavior), or
+2. Override `execute()` to inject one line of custom logic (copies core orchestration and increases drift risk).
+
+## Research: Existing Patterns, Prior Art, and Gaps
+
+1. **Existing hook surface confirms a gap.**
+   - `yamlgraph/utils/fsm/action.py` has `pre_snapshot`, `pre_dispatch`, `on_success`, `on_error`; no launch-time hook between snapshot and task scheduling.
+
+2. **Snapshot contract already provides the needed typed payload.**
+   - `yamlgraph/utils/fsm/snapshot.py` defines `SnapshotParams` with resolved fields (`graph_path`, `phase`, `success_event`, `failure_event`, etc.), making this boundary ideal for a launch hook.
+
+3. **Architecture alignment exists under current capability.**
+   - `ARCHITECTURE.md` Capability 146 (`REQ-YG-347`) already tracks FSM snapshot + lifecycle hook behavior. This FR extends that same lifecycle contract with one additional hook.
+
+4. **Feature source discrepancy in this worktree.**
+   - Requested source `.chaplain/processing/feat-fsm-on-launch-hook.md` is not present; planning source used: GitHub issue #394 (`feat(fsm): add on_launch hook to YamlgraphAsyncAction`).
+
+## Objectives
+
+1. Add a launch-time extension seam with resolved snapshot values.
+2. Keep default behavior unchanged for callers that do not override the hook.
+3. Preserve fail-closed behavior when snapshot creation fails.
+
+## Constraints
+
+1. Single responsibility: lifecycle hook addition only.
+2. No changes to event resolution, dispatch transport, or guard semantics.
+3. No Chaplain subprocess bridge changes under `.chaplain/actions/`.
+4. Preserve existing `ValueError` handling path in `execute()`.
+
+## Proposed Solution
+
+### In Scope
+
+1. Add base no-op hook:
+   - `def on_launch(self, _snap: SnapshotParams, _context: dict[str, Any]) -> None: ...`
+2. In `YamlgraphAsyncAction.execute()`:
+   - call `self.on_launch(snapshot, context)` immediately after `snapshot_params(...)` returns
+   - call occurs before `asyncio.create_task(...)`
+3. Keep existing behavior unchanged when `snapshot_params(...)` raises `ValueError`:
+   - return failure event and do not invoke `on_launch`.
+4. Extend REQ-aligned tests for lifecycle contract.
+
+### Out of Scope
+
+1. New telemetry/output payload formats.
+2. Any changes in `yamlgraph.utils.fsm.graph_runner` hook sequence.
+3. Migration changes in downstream domain repositories.
+
+## Acceptance Criteria
+
+- [x] **AC-01:** `YamlgraphAsyncAction` exposes `on_launch(snap, context)` with a default no-op implementation.
+- [x] **AC-02:** `execute()` invokes `on_launch` after `snapshot_params()` succeeds and before `asyncio.create_task(...)`.
+- [x] **AC-03:** `on_launch` receives the resolved `SnapshotParams` instance produced by `snapshot_params()`.
+- [x] **AC-04:** `on_launch` is not called when `snapshot_params()` raises `ValueError`.
+- [x] **AC-05:** Existing lifecycle behavior (`pre_snapshot`, `pre_dispatch`, `on_success`, `on_error`) remains unchanged.
+
+## Failing Acceptance Tests (RED plan)
+
+RED test artifact:
+
+- `tests/unit/test_fr392_fsm_on_launch_hook_red.py`
+
+Planned RED tests:
+
+1. `test_ac01_action_exposes_on_launch_hook_method`
+2. `test_ac02_execute_calls_on_launch_between_snapshot_and_create_task`
+3. `test_ac03_subclass_receives_resolved_snapshot_in_on_launch`
+4. `test_ac04_on_launch_not_called_when_snapshot_params_raises`
+
+RED command:
+
+```bash
+pytest tests/unit/test_fr392_fsm_on_launch_hook_red.py -q --no-cov
+```
+
+Targeted regression command after implementation:
+
+```bash
+pytest tests/unit/test_fr369_fsm_snapshot_hooks_red.py -q --no-cov
+pytest tests/unit/test_fsm_bridge_shared.py -q --no-cov
+```
+
+## Alternatives Considered
+
+1. **Use `pre_snapshot` only and reconstruct resolved values**
+   - Rejected: duplicates `snapshot_params()` logic and invites drift.
+2. **Override `execute()` in every subclass**
+   - Rejected: recreates orchestration code and weakens shared-bridge guarantees.
+3. **Emit launch telemetry from `run_and_dispatch`**
+   - Rejected: too late; launch metadata should be available before background scheduling.
+
+## Related
+
+- Issue #394: <https://github.com/sheikkinen/yamlgraph/issues/394>
+- `yamlgraph/utils/fsm/action.py`
+- `yamlgraph/utils/fsm/snapshot.py`
+- `feature-requests/FR-369-fsm-snapshot-hooks-phase2-subclassing.md`
+- `ARCHITECTURE.md` (`REQ-YG-347`, Capability 146)

--- a/reference/module-map.md
+++ b/reference/module-map.md
@@ -185,7 +185,7 @@
   - import dependencies: `yamlgraph.utils.parsing`
 - `yamlgraph/utils/fsm/__init__.py` - 14 lines; exports: _none_
   - import dependencies: `yamlgraph.utils.fsm.action`, `yamlgraph.utils.fsm.helpers`, `yamlgraph.utils.fsm.snapshot`
-- `yamlgraph/utils/fsm/action.py` - 140 lines; exports: `class YamlgraphAsyncAction`
+- `yamlgraph/utils/fsm/action.py` - 144 lines; exports: `class YamlgraphAsyncAction`
   - import dependencies: `yamlgraph.utils.fsm.graph_runner`, `yamlgraph.utils.fsm.snapshot`
 - `yamlgraph/utils/fsm/event_sender.py` - 41 lines; exports: `send_event(machine_name, event_type, payload)`
   - import dependencies: _none_

--- a/tests/unit/test_fr392_fsm_on_launch_hook_red.py
+++ b/tests/unit/test_fr392_fsm_on_launch_hook_red.py
@@ -1,0 +1,138 @@
+"""RED acceptance tests for FR-392 on_launch hook in shared FSM action."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import yamlgraph.utils.fsm.action as action_module
+from yamlgraph.utils.fsm.action import YamlgraphAsyncAction
+from yamlgraph.utils.fsm.snapshot import SnapshotParams
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION_PATH = ROOT / "yamlgraph" / "utils" / "fsm" / "action.py"
+
+
+def _class_method_names(path: Path, class_name: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {
+                item.name
+                for item in node.body
+                if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef)
+            }
+    return set()
+
+
+@pytest.mark.req("REQ-YG-347")
+class TestFR392OnLaunchHookRed:
+    def test_ac01_action_exposes_on_launch_hook_method(self) -> None:
+        methods = _class_method_names(ACTION_PATH, "YamlgraphAsyncAction")
+        assert "on_launch" in methods
+
+    def test_ac02_execute_calls_on_launch_between_snapshot_and_create_task(
+        self,
+    ) -> None:
+        source = ACTION_PATH.read_text(encoding="utf-8")
+        snapshot_pos = source.find("snapshot = snapshot_params(")
+        launch_hook_pos = source.find("self.on_launch(")
+        create_task_pos = source.find("asyncio.create_task(")
+
+        assert snapshot_pos != -1, "Expected snapshot materialization in execute()"
+        assert launch_hook_pos != -1, "Expected execute() to call self.on_launch(...)"
+        assert (
+            create_task_pos != -1
+        ), "Expected execute() to schedule run_and_dispatch task"
+        assert snapshot_pos < launch_hook_pos < create_task_pos
+
+    @pytest.mark.asyncio
+    async def test_ac03_subclass_receives_resolved_snapshot_in_on_launch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class ProbeAction(YamlgraphAsyncAction):
+            def on_launch(
+                self, snap: SnapshotParams, context: dict[str, Any]
+            ) -> None:  # pragma: no cover - RED path until feature exists
+                self.launch_calls.append((snap, dict(context)))
+
+        action = ProbeAction.__new__(ProbeAction)
+        action.config = {"params": {"graph": "graphs/demo.yaml", "failure": "failed"}}
+        action.launch_calls = []
+
+        snapshot = SnapshotParams(
+            graph_path="graphs/demo.yaml",
+            initial_state={"input": "hello"},
+            input_key="input",
+            output_key="result",
+            event_key="result",
+            event_map={},
+            success_event="completed",
+            failure_event="failed",
+            thread_id=None,
+            phase="graph",
+            payload_keys=None,
+        )
+
+        def fake_snapshot_params(
+            _params: dict[str, Any],
+            _context: dict[str, Any],
+            *,
+            project_root: str | Path | None = None,
+        ) -> SnapshotParams:
+            assert project_root is None
+            return snapshot
+
+        async def fake_run_and_dispatch(**_kwargs: Any) -> None:
+            return None
+
+        created: list[Any] = []
+
+        def fake_create_task(coro: Any) -> SimpleNamespace:
+            created.append(coro)
+            coro.close()
+            return SimpleNamespace()
+
+        monkeypatch.setattr(action_module, "snapshot_params", fake_snapshot_params)
+        monkeypatch.setattr(action_module, "run_and_dispatch", fake_run_and_dispatch)
+        monkeypatch.setattr(action_module.asyncio, "create_task", fake_create_task)
+
+        context: dict[str, Any] = {"current_state": "judge", "machine_name": "watcher"}
+        await action.execute(context)
+
+        assert len(created) == 1
+        assert action.launch_calls == [
+            (snapshot, {"current_state": "judge", "machine_name": "watcher"})
+        ]
+
+    @pytest.mark.asyncio
+    async def test_ac04_on_launch_not_called_when_snapshot_params_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class ProbeAction(YamlgraphAsyncAction):
+            def on_launch(
+                self, _snap: SnapshotParams, _context: dict[str, Any]
+            ) -> None:  # pragma: no cover - RED path until feature exists
+                self.launch_called = True
+
+        action = ProbeAction.__new__(ProbeAction)
+        action.config = {"params": {"failure": "launch_failed"}}
+        action.launch_called = False
+
+        def fake_snapshot_params(
+            _params: dict[str, Any],
+            _context: dict[str, Any],
+            *,
+            project_root: str | Path | None = None,
+        ) -> SnapshotParams:
+            raise ValueError("yamlgraph_async: no graph specified in params")
+
+        monkeypatch.setattr(action_module, "snapshot_params", fake_snapshot_params)
+
+        result = await action.execute({"current_state": "judge"})
+        assert result == "launch_failed"
+        assert action.launch_called is False

--- a/yamlgraph/utils/fsm/action.py
+++ b/yamlgraph/utils/fsm/action.py
@@ -71,6 +71,9 @@ class YamlgraphAsyncAction(BaseAction):
     ) -> None:
         """Lifecycle hook called when graph execution fails."""
 
+    def on_launch(self, _snap: SnapshotParams, _context: dict[str, Any]) -> None:
+        """Lifecycle hook called after snapshot resolution and before task launch."""
+
     def pre_dispatch(
         self,
         _snap: SnapshotParams | None,
@@ -114,6 +117,7 @@ class YamlgraphAsyncAction(BaseAction):
             snapshot.graph_path,
             current_state,
         )
+        self.on_launch(snapshot, context)
 
         asyncio.create_task(
             run_and_dispatch(


### PR DESCRIPTION
## FR-392: on_launch lifecycle hook for YamlgraphAsyncAction

Adds `on_launch(snap, context)` hook called after `snapshot_params()` succeeds and before `asyncio.create_task()`. Enables subclasses to observe resolved launch metadata without overriding `execute()`.

### Changes
- `yamlgraph/utils/fsm/action.py` — add `on_launch()` no-op default + call site
- `tests/unit/test_fr392_fsm_on_launch_hook_red.py` — 4 RED tests
- `feature-requests/FR-392-fsm-on-launch-hook.md`
- `docs/diary/2026-05-15-reflection-fr-392-fsm-on-launch-hook.md`
- `changelog/unreleased/fr-392-fsm-on-launch-hook.md`

Closes #394