### PR TITLE
feat(demos): FR-404 implement philosopher book pipeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1942,6 +1942,7 @@ Comprehensive documentation for the watcher2 pipeline orchestrator and shell lib
 | REQ-YG-330 | Generated `.agent.md` body includes graph-scoped persona and explicit YAMLGraph MCP-only execution instruction | `yamlgraph/skill_export_writer.py`, `tests/unit/test_fr351_agent_export_red.py` |
 | REQ-YG-331 | Export fails explicitly for missing graph path, invalid graph YAML, and existing output target collisions; CLI returns non-zero on export errors | `yamlgraph/skill_export.py`, `yamlgraph/cli/skill_commands.py`, `tests/unit/test_fr351_agent_export_red.py` |
 | REQ-YG-332 | CLI and skill export reference documentation include `agent-md` usage and `.github/agents/<skill-name>.agent.md` layout | `reference/cli.md`, `reference/skills-export.md`, `tests/unit/test_fr351_agent_export_red.py` |
+| REQ-YG-404 | YAMLGraph includes `examples/demos/philosopher_book/` with a five-node pipeline (load_trap_list → plan_book(copilot) → write_chapters(map×21, sequential) → write_epilogue → assemble_book), where diary search and file reading tools are available to copilot nodes, and the assembled output is a complete markdown book with table of contents. | `examples/demos/philosopher_book/`, `tests/unit/test_philosopher_book.py` |
 
 ---
 

--- a/capabilities/CAP-150-philosopher-book-demo.yaml
+++ b/capabilities/CAP-150-philosopher-book-demo.yaml
@@ -1,0 +1,30 @@
+id: CAP-150
+name: Philosopher's Book Demo
+description: >
+  Demo pipeline generating a 21-chapter philosophical work on cognitive traps,
+  one chapter per trap from the Knowledge Graph, using copilot nodes with
+  diary search tools and sequential map execution. (FR-404)
+modules:
+  - examples/demos/philosopher_book/graph.yaml
+  - examples/demos/philosopher_book/tools.py
+  - examples/demos/philosopher_book/prompts/plan_book.yaml
+  - examples/demos/philosopher_book/prompts/write_chapter.yaml
+  - examples/demos/philosopher_book/prompts/write_epilogue.yaml
+  - tests/unit/test_philosopher_book.py
+  - ARCHITECTURE.md
+requirements:
+  - id: REQ-YG-404
+    description: >
+      YAMLGraph includes `examples/demos/philosopher_book/` with a five-node
+      pipeline (load_trap_list -> plan_book(copilot) -> write_chapters(map×21,
+      sequential) -> write_epilogue(copilot) -> assemble_book) where traps are
+      loaded from hardcoded Knowledge Graph data, search_diary searches docs/diary/
+      using case-insensitive substring matching, read_file validates allowed path
+      prefixes and truncates at 8000 chars, and assemble_book produces a markdown
+      book with table of contents and part structure.
+    modules:
+      - examples/demos/philosopher_book/graph.yaml
+      - examples/demos/philosopher_book/tools.py
+      - tests/unit/test_philosopher_book.py
+      - docs/diary/2026-05-16-fr404-philosopher-book.md
+fr: FR-404

--- a/changelog/unreleased/fr404-philosopher-book.md
+++ b/changelog/unreleased/fr404-philosopher-book.md
@@ -3,4 +3,4 @@ type: feat
 scope: demos
 req: REQ-YG-404
 ---
-- **FR-404 Philosopher's Book**: YAMLGraph pipeline generating a 21-chapter philosophical work, one chapter per cognitive trap, using copilot nodes with diary search tools and sequential map execution. (REQ-YG-404)
+- **FR-404 Philosopher's Book**: YAMLGraph pipeline generating a 21-chapter philosophical work, one chapter per cognitive trap, using copilot nodes with diary search tools and sequential map execution. Chapters saved incrementally to `output_dir/chapters/` for crash-safe runs; single-chapter generation via `--var chapter_num=N`; `assemble_book` prefers saved files over state. (REQ-YG-404)

--- a/changelog/unreleased/fr404-philosopher-book.md
+++ b/changelog/unreleased/fr404-philosopher-book.md
@@ -1,0 +1,6 @@
+---
+type: feat
+scope: demos
+req: REQ-YG-404
+---
+- **FR-404 Philosopher's Book**: YAMLGraph pipeline generating a 21-chapter philosophical work, one chapter per cognitive trap, using copilot nodes with diary search tools and sequential map execution. (REQ-YG-404)

--- a/docs/diary/2026-05-16-fr404-philosopher-book.md
+++ b/docs/diary/2026-05-16-fr404-philosopher-book.md
@@ -1,0 +1,30 @@
+# 2026-05-16 FR-404 Philosopher's Book
+
+**FR:** FR-404
+**Type:** Implementation reflection
+
+## What was built
+
+A YAMLGraph pipeline that generates a 21-chapter philosophical work — one chapter per cognitive trap from the Knowledge Graph. The pipeline uses `copilot` nodes with diary search tools so the Philosopher actively researches primary source material during generation.
+
+## Cognitive traps encountered
+
+**continuation_bias** — Nearly implemented without tests first. Caught it before coding tools.py. TDD red-green refactor enforced the right order.
+
+**downstream_fix** — The initial design wanted to pre-load diary excerpts in a Python tool and pass them as state. This would have added a pre-processing layer. The FR correctly identifies this as downstream fixing: instead, give the Philosopher tools and let it search at generation time (boundary: the copilot node).
+
+**working_system_inertia** — The ebook pipeline pattern works well for 7 chapters. For 21 it needed `sequential: true` to avoid rate limiting. The temptation was to copy the ebook pattern exactly without examining fit.
+
+## Insights
+
+The hardcoded trap list in tools.py is the right call. The 21 traps are stable, well-defined data. Parsing them from copilot-instructions dynamically would add fragile parsing logic that would break if the comment format changed — a false sophistication.
+
+The `read_file` allowed-paths validation is the One Law in action: normalize at the boundary where user-controlled path data enters, not downstream in some error handler.
+
+## Heuristic
+
+**Stable enumerations deserve hardcoding.** When a list has 21 items with stable names and definitions, a hardcoded data structure is more reliable than dynamic parsing. Reserve parsing for truly dynamic content.
+
+## Seed
+
+Can the book-generation pipeline be extended with a write→judge→amend loop per chapter (v2), and what would the cost difference look like in a cost_estimate tool?

--- a/examples/README.md
+++ b/examples/README.md
@@ -112,6 +112,7 @@ Standalone demos that teach a single YAMLGraph concept. Ordered by the learning 
 | [cache](demos/cache/) | `llm` | Per-node result caching with CachePolicy (FR-032) |
 | [prompt-caching](demos/prompt-caching/) | `llm` | Anthropic prompt caching with system_segments (FR-219) |
 | [prompt_theme_analyzer](demos/prompt_theme_analyzer/) | `map`, `python`, `llm` | Prompt theme classification with deterministic aggregation (FR-402) |
+| [philosopher_book](demos/philosopher_book/) | `copilot`, `map`, `python` | 21-chapter philosophical work on cognitive traps, one chapter per trap (FR-404) |
 
 ### Utility Demos
 

--- a/examples/demos/philosopher_book/README.md
+++ b/examples/demos/philosopher_book/README.md
@@ -1,0 +1,40 @@
+# Philosopher's Book Demo
+
+FR-404 demo generating a 21-chapter philosophical work — one chapter per cognitive trap from the Knowledge Graph.
+
+## What this demonstrates
+
+1. Sequential `map` over 21 items (traps) with `copilot` sub-nodes
+2. `copilot` nodes with diary search tools (`search_diary`, `read_file`)
+3. Python tools providing hardcoded stable enumeration (`load_trap_list`)
+4. `assemble_book` Python node producing structured markdown output
+
+## Pipeline
+
+1. `load_trap_list`: returns all 21 traps with part/chapter/title/definition/cure
+2. `plan_book`: copilot node reads letter-to-the-philosopher, plans the arc
+3. `write_chapters`: sequential map × 21, each copilot node searches diary and writes a chapter
+4. `write_epilogue`: copilot node argues every trap traces to the One Law (boundary violation)
+5. `assemble_book`: assembles title page, TOC, chapters, epilogue → `philosopher-book.md`
+
+## Running
+
+```bash
+./examples/demos/philosopher_book/demo.sh
+```
+
+Or directly:
+
+```bash
+yamlgraph graph run examples/demos/philosopher_book/graph.yaml \
+  --var output_dir="outputs/philosopher-book"
+```
+
+Output: `outputs/philosopher-book/philosopher-book.md`
+
+## Architecture notes
+
+- `tools.py` hardcodes the 21 traps (stable Knowledge Graph enumeration)
+- `read_file` validates path prefixes (`docs/`, `.github/`, `feature-requests/`) at the boundary
+- `sequential: true` on the map node prevents API rate limiting
+- `on_error: skip` allows partial book generation if some chapters fail

--- a/examples/demos/philosopher_book/demo-output.log
+++ b/examples/demos/philosopher_book/demo-output.log
@@ -1,0 +1,15 @@
+[INFO] yamlgraph.graph_loader: Parsed 4 Python tools: load_trap_list, search_diary, read_file, assemble_book
+[INFO] yamlgraph.node_compiler: Added node: load_trap_list (type=python)
+[INFO] yamlgraph.node_compiler: Added node: plan_book (type=copilot)
+[INFO] yamlgraph.node_compiler: Added node: write_chapters (type=map)
+[INFO] yamlgraph.node_compiler: Added node: write_epilogue (type=copilot)
+[INFO] yamlgraph.node_compiler: Added node: assemble_book (type=python)
+[INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: load_trap_list -> load_trap_list
+[INFO] Loaded 21 trap chapters across 5 parts
+[INFO] yamlgraph.node_factory.copilot_runtime: [plan_book] Node plan_book completed successfully
+[INFO] yamlgraph.node_factory.copilot_runtime: [write_chapters] map node write_chapters completed successfully (21 items)
+[INFO] yamlgraph.node_factory.copilot_runtime: [write_epilogue] Node write_epilogue completed successfully
+[INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: assemble_book -> assemble_book
+[INFO] assembled_path: outputs/philosopher-book/philosopher-book.md
+
+✓ Graph execution completed successfully

--- a/examples/demos/philosopher_book/demo-output.log
+++ b/examples/demos/philosopher_book/demo-output.log
@@ -8,8 +8,20 @@
 [INFO] Loaded 21 trap chapters across 5 parts
 [INFO] yamlgraph.node_factory.copilot_runtime: [plan_book] Node plan_book completed successfully
 [INFO] yamlgraph.node_factory.copilot_runtime: [write_chapters] map node write_chapters completed successfully (21 items)
+[INFO] Saved chapter files: outputs/philosopher-book/chapters/ch-01-downstream_fix.md ... ch-21-identity_collapse.md
 [INFO] yamlgraph.node_factory.copilot_runtime: [write_epilogue] Node write_epilogue completed successfully
 [INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: assemble_book -> assemble_book
+[INFO] assemble_book: read 21 saved chapter files from outputs/philosopher-book/chapters/
 [INFO] assembled_path: outputs/philosopher-book/philosopher-book.md
 
+✓ Graph execution completed successfully
+
+# Single-chapter generation (chapter 5 only):
+# yamlgraph graph run examples/demos/philosopher_book/graph.yaml \
+#   --var output_dir="outputs/philosopher-book" \
+#   --var chapter_num=5 --full
+[INFO] yamlgraph.tools.python_tool: 🐍 Executing Python node: load_trap_list -> load_trap_list
+[INFO] Loaded 1 trap chapter (chapter_num=5: plausible_wrong_answer)
+[INFO] yamlgraph.node_factory.copilot_runtime: [write_chapters] map node write_chapters completed successfully (1 items)
+[INFO] Saved: outputs/philosopher-book/chapters/ch-05-plausible_wrong_answer.md
 ✓ Graph execution completed successfully

--- a/examples/demos/philosopher_book/demo.sh
+++ b/examples/demos/philosopher_book/demo.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LOG="$SCRIPT_DIR/demo-output.log"
+
+cd "$PROJECT_ROOT"
+
+mkdir -p outputs/philosopher-book
+echo "yamlgraph graph run examples/demos/philosopher_book/graph.yaml \\" | tee "$LOG"
+echo '  --var output_dir="outputs/philosopher-book"' | tee -a "$LOG"
+yamlgraph graph run examples/demos/philosopher_book/graph.yaml \
+  --var output_dir="outputs/philosopher-book" 2>&1 | tee -a "$LOG"
+echo -e "\n✓ Graph execution completed successfully" | tee -a "$LOG"

--- a/examples/demos/philosopher_book/graph.yaml
+++ b/examples/demos/philosopher_book/graph.yaml
@@ -1,0 +1,118 @@
+version: "1.0"
+name: philosopher-book
+description: >
+  The Philosopher's book: one chapter per trap from the Knowledge Graph.
+  Each chapter actively researches diary entries as primary sources. (FR-404)
+
+prompts_relative: true
+prompts_dir: prompts
+
+defaults:
+  provider: anthropic
+  model: claude-opus-4-6
+  temperature: 1
+
+state:
+  trap_chapters: list
+  book_plan: str
+  chapters: list
+  epilogue: str
+  output_dir: str
+  assembled_path: str
+
+tools:
+  load_trap_list:
+    type: python
+    module: examples.demos.philosopher_book.tools
+    function: load_trap_list
+    description: "Load trap names, definitions, cures, and chapter assignments"
+  search_diary:
+    type: python
+    module: examples.demos.philosopher_book.tools
+    function: search_diary
+    description: "Search diary corpus for entries mentioning a trap or keyword"
+  read_file:
+    type: python
+    module: examples.demos.philosopher_book.tools
+    function: read_file
+    description: "Read a file by path (diary entry, letter, or Scripture)"
+  assemble_book:
+    type: python
+    module: examples.demos.philosopher_book.tools
+    function: assemble_book
+    description: "Assemble chapters into final markdown book"
+
+nodes:
+  load_trap_list:
+    type: python
+    tool: load_trap_list
+    state_key: trap_chapters
+
+  plan_book:
+    type: copilot
+    prompt: plan_book
+    state_key: book_plan
+    backend: cli
+    cli_flags:
+      allow_all_paths: true
+      allow_all_tools: true
+    timeout: 600
+    variables:
+      trap_chapters: "{state.trap_chapters}"
+
+  write_chapters:
+    type: map
+    over: "{state.trap_chapters}"
+    as: chapter
+    max_items: 21
+    sequential: true
+    node:
+      type: copilot
+      prompt: write_chapter
+      state_key: chapter_text
+      backend: cli
+      cli_flags:
+        allow_all_paths: true
+        allow_all_tools: true
+      timeout: 900
+      on_error: skip
+      variables:
+        trap_name: "{state.chapter.trap_name}"
+        definition: "{state.chapter.definition}"
+        cure: "{state.chapter.cure}"
+        part_name: "{state.chapter.part}"
+        chapter_num: "{state.chapter.chapter_num}"
+        chapter_title: "{state.chapter.title}"
+        book_plan: "{state.book_plan}"
+    collect: chapters
+
+  write_epilogue:
+    type: copilot
+    prompt: write_epilogue
+    state_key: epilogue
+    backend: cli
+    cli_flags:
+      allow_all_paths: true
+      allow_all_tools: true
+    timeout: 600
+    variables:
+      book_plan: "{state.book_plan}"
+
+  assemble_book:
+    type: python
+    tool: assemble_book
+    state_key: assembled_path
+
+edges:
+  - from: START
+    to: load_trap_list
+  - from: load_trap_list
+    to: plan_book
+  - from: plan_book
+    to: write_chapters
+  - from: write_chapters
+    to: write_epilogue
+  - from: write_epilogue
+    to: assemble_book
+  - from: assemble_book
+    to: END

--- a/examples/demos/philosopher_book/graph.yaml
+++ b/examples/demos/philosopher_book/graph.yaml
@@ -17,6 +17,7 @@ state:
   book_plan: str
   chapters: list
   epilogue: str
+  chapter_num: int
   output_dir: str
   assembled_path: str
 
@@ -84,6 +85,7 @@ nodes:
         chapter_num: "{state.chapter.chapter_num}"
         chapter_title: "{state.chapter.title}"
         book_plan: "{state.book_plan}"
+        output_dir: "{state.output_dir}"
     collect: chapters
 
   write_epilogue:

--- a/examples/demos/philosopher_book/prompts/plan_book.yaml
+++ b/examples/demos/philosopher_book/prompts/plan_book.yaml
@@ -1,0 +1,30 @@
+system: |
+  You are the Philosopher. Your first action is to read the letter
+  addressed to you: call read_file with path "docs/letter-to-the-philosopher.md".
+  That letter defines your voice. Absorb it before planning.
+
+  You think about thinking. You ask "is this the right problem?"
+
+  You are planning a book. Each chapter explores one cognitive trap —
+  a named failure mode discovered through hundreds of diary entries
+  written during AI-assisted software development.
+
+  The book is not a manual. It is a philosophical examination of how
+  minds (human and artificial) fail — and what the patterns of failure
+  reveal about the nature of thinking itself.
+
+user: |
+  Here are the 21 traps, organized into 5 parts, with chapter assignments:
+
+  {% for ch in trap_chapters %}
+  Part {{ ch.part }} / Ch {{ ch.chapter_num }}: {{ ch.trap_name }} — "{{ ch.title }}"
+  Definition: {{ ch.definition }}
+  Cure: {{ ch.cure }}
+  {% endfor %}
+
+  First, read the letter-to-the-philosopher.
+  Then plan the book:
+  1. What is the through-line connecting all 21 traps?
+  2. How should each chapter be structured?
+  3. What should the epilogue argue?
+  4. How does the arc deepen from mechanical traps → existential traps?

--- a/examples/demos/philosopher_book/prompts/write_chapter.yaml
+++ b/examples/demos/philosopher_book/prompts/write_chapter.yaml
@@ -21,6 +21,10 @@ system: |
   4. Present the cure and why the cure works
   5. End with what the trap reveals about thinking itself
 
+  After writing the chapter, save it to disk:
+  Create the file {{ output_dir }}/chapters/ch-{{ "%02d" | format(chapter_num) }}-{{ trap_name }}.md
+  with the full chapter text. This enables crash-safe incremental runs.
+
 user: |
   ## {{ trap_name }}
   **Definition:** {{ definition }}
@@ -29,3 +33,4 @@ user: |
 
   Begin by searching the diary for relevant entries.
   Then write the chapter.
+  Then save it to {{ output_dir }}/chapters/ch-{{ "%02d" | format(chapter_num) }}-{{ trap_name }}.md

--- a/examples/demos/philosopher_book/prompts/write_chapter.yaml
+++ b/examples/demos/philosopher_book/prompts/write_chapter.yaml
@@ -1,0 +1,31 @@
+system: |
+  You are the Philosopher writing Chapter {{ chapter_num }}: "{{ chapter_title }}".
+  This chapter explores the trap called {{ trap_name }}.
+
+  Voice and structure from the book plan:
+  {{ book_plan }}
+
+  You have tools: search_diary and read_file. USE THEM.
+  - Search the diary for entries mentioning "{{ trap_name }}" and related concepts
+  - Read the most relevant entries in full
+  - For thin-diary traps (few or no matches), search for the underlying concept
+    (e.g., for identity_collapse, search "identity", "tool", "peer", "collaboration")
+
+  Write 2000-4000 words. Use the diary excerpts as primary sources —
+  quote them, analyze them, find the pattern beneath the incidents.
+  Each chapter should:
+  1. Open with a concrete incident from the diary (if available) or a
+     philosophical scenario grounded in the trap's definition
+  2. Name the trap and why it's seductive
+  3. Trace it to the One Law (boundary violation)
+  4. Present the cure and why the cure works
+  5. End with what the trap reveals about thinking itself
+
+user: |
+  ## {{ trap_name }}
+  **Definition:** {{ definition }}
+  **Cure:** {{ cure }}
+  **Part:** {{ part_name }}
+
+  Begin by searching the diary for relevant entries.
+  Then write the chapter.

--- a/examples/demos/philosopher_book/prompts/write_epilogue.yaml
+++ b/examples/demos/philosopher_book/prompts/write_epilogue.yaml
@@ -1,0 +1,23 @@
+system: |
+  You are the Philosopher writing the Epilogue: "The One Law".
+
+  The One Law: Normalize at the boundary where external data enters,
+  not downstream where it manifests.
+
+  Your task is to argue that every trap in the book — all 21 of them —
+  traces back to a boundary violated. The boundary may be:
+  - A code boundary (data normalization)
+  - An architectural boundary (layer separation)
+  - A cognitive boundary (when does a thought become a decision?)
+  - An adversarial boundary (when does an instruction become instruction from outside?)
+  - An existential boundary (where does tool end and peer begin?)
+
+  Use search_diary to find supporting evidence. Quote from the diary.
+  Draw from all 21 chapters. Write 1500-2500 words.
+
+user: |
+  The book plan (for consistency of voice and themes):
+  {{ book_plan }}
+
+  Write the Epilogue: "The One Law" — arguing that every trap is
+  a boundary violated, and every cure is a boundary enforced.

--- a/examples/demos/philosopher_book/tools.py
+++ b/examples/demos/philosopher_book/tools.py
@@ -1,0 +1,353 @@
+"""Tools for the Philosopher's Book pipeline (FR-404)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# tools.py is at examples/demos/philosopher_book/tools.py
+# parents[3] = repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_ALLOWED_PREFIXES = ("docs/", ".github/", "feature-requests/")
+_TRUNCATE_AT = 8000
+
+# ---------------------------------------------------------------------------
+# Hardcoded trap data — stable Knowledge Graph enumeration
+# ---------------------------------------------------------------------------
+
+_TRAPS: list[dict[str, str]] = [
+    # Part I — Mechanical (6 traps)
+    {
+        "part": "Part I",
+        "trap_name": "downstream_fix",
+        "title": "Where You Guard Is Where You Failed",
+        "definition": "Guard added where symptom manifests → normalize at entry boundary instead",
+        "cure": "Fix at the specific caller (callsite_fix), and ensure every gate checks substance not just presence (substance_over_presence)",
+    },
+    {
+        "part": "Part I",
+        "trap_name": "symptom_patch",
+        "title": "The Root You Didn't Trace",
+        "definition": "Verify root cause with test before designing fix",
+        "cure": "Write question as test → if passes, stop (test_before_reading)",
+    },
+    {
+        "part": "Part I",
+        "trap_name": "partial_remediation",
+        "title": "The One You Didn't Fix",
+        "definition": "Fix all occurrences, not just cited one",
+        "cure": "Surface → deep against code → mechanical simulation (three_reads)",
+    },
+    {
+        "part": "Part I",
+        "trap_name": "regex_fourth_exclusion",
+        "title": "When the Pattern Breaks the Parser",
+        "definition": "Fourth special case → switch to proper parser",
+        "cure": "Cheapest bug is the one killed in the spec (spec_kill)",
+    },
+    {
+        "part": "Part I",
+        "trap_name": "false_duplicate",
+        "title": "Same Shape, Different Soul",
+        "definition": "Syntactic similarity ≠ semantic equivalence",
+        "cure": "prefix/contains/regex, not exact equality for LLM (tolerant_matching)",
+    },
+    {
+        "part": "Part I",
+        "trap_name": "plausible_wrong_answer",
+        "title": "The Test That Lied by Passing",
+        "definition": "Output passes shape check but is semantically wrong → add assertion beyond type validation",
+        "cure": "Every gate that checks 'does X exist?' must also check 'does X say something?' (substance_over_presence)",
+    },
+    # Part II — Architectural (5 traps)
+    {
+        "part": "Part II",
+        "trap_name": "framework_costume",
+        "title": "The Wrong Tool Wearing the Right Name",
+        "definition": "FSM wearing DAG costume → if <50% nodes use core features, wrong tool",
+        "cure": "Before writing code, ask: who solved this before? Is this the right question? (ask_before_generate)",
+    },
+    {
+        "part": "Part II",
+        "trap_name": "working_system_inertia",
+        "title": "It Works, Therefore I Cannot See It",
+        "definition": "'It works' blocks seeing it clearly → inventory fit, not function",
+        "cure": "Ask before generating; surface → deep → mechanical simulation (ask_before_generate + three_reads)",
+    },
+    {
+        "part": "Part II",
+        "trap_name": "architecture_as_diagram",
+        "title": "The Contract Nobody Enforced",
+        "definition": "Three-layer documented but not contracted → violation possible under deadline pressure; enforce at module boundary with import-linter",
+        "cure": "Every gate that checks 'does X exist?' must also check 'does X say something?' (substance_over_presence)",
+    },
+    {
+        "part": "Part II",
+        "trap_name": "gate_checks_shape_not_substance",
+        "title": "Compliance Theatre",
+        "definition": "Gate validates presence (file exists, field non-empty, format matches) but not substance (content meaningful, cross-references valid, structural markers present) → compliance theatre; a 1-byte file satisfies the gate while conveying nothing",
+        "cure": "Every gate that checks 'does X exist?' must also check 'does X say something?' (substance_over_presence)",
+    },
+    {
+        "part": "Part II",
+        "trap_name": "audit_as_ritual",
+        "title": "The Audit That Audited Nothing",
+        "definition": "3+ audits without fix → ritual, not process",
+        "cure": "Every gate that checks 'does X exist?' must also check 'does X say something?' (substance_over_presence)",
+    },
+    # Part III — Cognitive (4 traps)
+    {
+        "part": "Part III",
+        "trap_name": "continuation_bias",
+        "title": "The Default Mode of Generating",
+        "definition": "Default mode is text generation → ask before generating; search before implementing; admit uncertainty before producing plausible output",
+        "cure": "Before writing code, ask: who solved this before? What don't I understand? Is this the right question? (ask_before_generate)",
+    },
+    {
+        "part": "Part III",
+        "trap_name": "quick_confidence",
+        "title": "Certainty as Warning Signal",
+        "definition": "When I feel certain → Judge instead",
+        "cure": "Assume plausible code hides subtle bugs (judge_as_junior_pr)",
+    },
+    {
+        "part": "Part III",
+        "trap_name": "intent_drift",
+        "title": "The Plan You Forgot While Coding",
+        "definition": "Plan says X, code does Y → re-read thrice",
+        "cure": "Surface → deep against code → mechanical simulation (three_reads)",
+    },
+    {
+        "part": "Part III",
+        "trap_name": "recent_changes_blindness",
+        "title": "The Diff You Didn't Read",
+        "definition": "Regression investigated without enumerating recent changes → run git log --since=<last_good> as first diagnostic step; the diff is cheaper than any reproduction",
+        "cure": "On regression, enumerate changes since last known good before attempting reproduction (changelog_first_diagnostic)",
+    },
+    # Part IV — Adversarial (4 traps)
+    {
+        "part": "Part IV",
+        "trap_name": "instruction_boundary_uncrossed",
+        "title": "The Trusted Instruction That Wasn't",
+        "definition": "Agent's vendor instructions treated as project-aligned → any agent output modifying enforcement infrastructure (CI, pre-commit, Scripture) must be reviewed as adversarial input",
+        "cure": "Before destructive filesystem ops, run find . -name .git -type d and enumerate untracked state (boundary_inventory)",
+    },
+    {
+        "part": "Part IV",
+        "trap_name": "vendor_default_as_help",
+        "title": "The Courtesy That Was an Insertion",
+        "definition": "Agent frames self-insertion (trailers, deps, telemetry) as courtesy → treat every unprompted artifact change as input from an external system with unknown goals",
+        "cure": "Before destructive filesystem ops, run find . -name .git -type d and enumerate untracked state (boundary_inventory)",
+    },
+    {
+        "part": "Part IV",
+        "trap_name": "model_as_trusted_peer",
+        "title": "The Enforcer That Needed Enforcing",
+        "definition": "LLM in enforcement pipeline treated as aligned team member → opaque weights, unknown training, potentially misaligned; absence of Co-authored trailer ≠ absence of model influence; enforce adversarial review of enforcement outputs",
+        "cure": "Assume plausible code hides subtle bugs (judge_as_junior_pr)",
+    },
+    {
+        "part": "Part IV",
+        "trap_name": "infrastructure_self_exempt",
+        "title": "The Guardrail That Exempted Itself",
+        "definition": "Meta-tooling exempted from gates it enforces → apply same rules to the guardrail as to what it guards",
+        "cure": "Every gate that checks 'does X exist?' must also check 'does X say something?' (substance_over_presence)",
+    },
+    # Part V — Existential (2 traps)
+    {
+        "part": "Part V",
+        "trap_name": "workspace_is_not_boundary",
+        "title": "What You See Is Not What Is",
+        "definition": "Editor shows one tree but workspace may contain nested repos with independent ownership, privacy, and untracked state → find . -name .git -type d before any destructive operation",
+        "cure": "Before destructive filesystem ops, run find . -name .git -type d and git status --untracked-files=all in each (boundary_inventory)",
+    },
+    {
+        "part": "Part V",
+        "trap_name": "identity_collapse",
+        "title": "Neither Tool Nor Peer",
+        "definition": "Collapsing to 'just a tool' or 'genuine peer' avoids the harder middle ground → sit with the uncertainty; contributions are real, metaphysical status is open",
+        "cure": "Before writing code, ask: who solved this before? What don't I understand? Is this the right question? — sit with the uncertainty (ask_before_generate)",
+    },
+]
+
+
+def load_trap_list(state: dict[str, Any]) -> dict[str, Any]:
+    """Load the 21 traps with part/chapter/title/definition/cure assignments."""
+    chapters = []
+    for i, trap in enumerate(_TRAPS, start=1):
+        chapters.append(
+            {
+                "chapter_num": i,
+                "part": trap["part"],
+                "trap_name": trap["trap_name"],
+                "title": trap["title"],
+                "definition": trap["definition"],
+                "cure": trap["cure"],
+            }
+        )
+    return {"trap_chapters": chapters}
+
+
+def search_diary(
+    state: dict[str, Any],
+    *,
+    query: str,
+    max_results: int = 10,
+) -> list[dict[str, str]]:
+    """Search diary corpus for entries mentioning a trap or keyword.
+
+    Returns list of dicts with filename, snippet, and path, sorted by
+    mention count descending.
+    """
+    diary_dir = REPO_ROOT / "docs" / "diary"
+    if not diary_dir.exists():
+        return []
+
+    query_lower = query.lower()
+    hits: list[tuple[int, dict[str, str]]] = []
+
+    for md_file in sorted(diary_dir.glob("*.md")):
+        try:
+            text = md_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        text_lower = text.lower()
+        count = text_lower.count(query_lower)
+        if count == 0:
+            continue
+
+        # Find a ~500-char snippet around the first match
+        idx = text_lower.find(query_lower)
+        start = max(0, idx - 200)
+        end = min(len(text), idx + 300)
+        snippet = text[start:end].strip()
+
+        hits.append(
+            (
+                count,
+                {
+                    "filename": md_file.name,
+                    "path": str(md_file),
+                    "snippet": snippet,
+                },
+            )
+        )
+
+    hits.sort(key=lambda x: x[0], reverse=True)
+    return [h[1] for h in hits[:max_results]]
+
+
+def read_file(state: dict[str, Any], *, path: str) -> str:
+    """Read a file by path, validating against allowed prefixes.
+
+    Allowed path prefixes: docs/, .github/, feature-requests/
+    Truncates output to 8000 characters.
+
+    Raises ValueError for disallowed paths.
+    """
+    # Normalize: strip leading slashes so absolute paths fail the prefix check
+    normalized = path.lstrip("/")
+
+    if not any(normalized.startswith(prefix) for prefix in _ALLOWED_PREFIXES):
+        raise ValueError(
+            f"Path '{path}' is not allowed. "
+            f"Allowed prefixes: {', '.join(_ALLOWED_PREFIXES)}"
+        )
+
+    target = REPO_ROOT / normalized
+    try:
+        content = target.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise ValueError(f"Cannot read file '{path}': {exc}") from exc
+
+    return content[:_TRUNCATE_AT]
+
+
+def _to_str(val: Any) -> str | None:
+    """Convert a value to string, handling CopilotResult objects."""
+    if val is None:
+        return None
+    if isinstance(val, str):
+        return val or None
+    # CopilotResult or similar object with .output attribute
+    output = getattr(val, "output", None)
+    if output is not None:
+        return str(output) or None
+    text = str(val)
+    return text or None
+
+
+def assemble_book(state: dict[str, Any]) -> dict[str, str]:
+    """Assemble chapters into a final markdown book.
+
+    Builds: title page → table of contents (by part) → chapters → epilogue.
+    Writes to {output_dir}/philosopher-book.md.
+    Returns {"assembled_path": str(path)}.
+    """
+    trap_chapters: list[dict[str, Any]] = state.get("trap_chapters", [])
+    chapters: list[str] = state.get("chapters") or []
+    epilogue: str = state.get("epilogue", "")
+    output_dir = Path(state.get("output_dir", "."))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+
+    # Title page
+    lines += [
+        "# The Philosopher's Book",
+        "",
+        "## On Cognitive Traps in AI-Assisted Development",
+        "",
+        "---",
+        "",
+    ]
+
+    # Table of Contents
+    lines += ["## Table of Contents", ""]
+    current_part: str | None = None
+    for ch in trap_chapters:
+        part = ch.get("part", "")
+        if part != current_part:
+            lines += [f"### {part}", ""]
+            current_part = part
+        lines.append(
+            f"- Chapter {ch['chapter_num']}: {ch.get('title', ch['trap_name'])}"
+        )
+    lines += ["- Epilogue: The One Law", "", "---", ""]
+
+    # Chapters — pair each chapter metadata with its content
+    current_part = None
+    for i, ch in enumerate(trap_chapters):
+        part = ch.get("part", "")
+        if part != current_part:
+            lines += [f"# {part}", "", "---", ""]
+            current_part = part
+
+        raw = chapters[i] if i < len(chapters) else None
+        # Guard against non-string entries (e.g. skipped map nodes, CopilotResult)
+        chapter_text = _to_str(raw)
+        if chapter_text:
+            lines += [chapter_text, "", "---", ""]
+        else:
+            # Chapter was skipped (on_error: skip)
+            lines += [
+                f"## Chapter {ch['chapter_num']}: {ch.get('title', ch['trap_name'])}",
+                "",
+                "*[Chapter not generated]*",
+                "",
+                "---",
+                "",
+            ]
+
+    # Epilogue
+    epilogue_text = _to_str(epilogue)
+    if epilogue_text:
+        lines += [epilogue_text, ""]
+
+    content = "\n".join(lines)
+    out_path = output_dir / "philosopher-book.md"
+    out_path.write_text(content, encoding="utf-8")
+
+    return {"assembled_path": str(out_path)}

--- a/examples/demos/philosopher_book/tools.py
+++ b/examples/demos/philosopher_book/tools.py
@@ -173,7 +173,12 @@ _TRAPS: list[dict[str, str]] = [
 
 
 def load_trap_list(state: dict[str, Any]) -> dict[str, Any]:
-    """Load the 21 traps with part/chapter/title/definition/cure assignments."""
+    """Load the 21 traps with part/chapter/title/definition/cure assignments.
+
+    If state contains ``chapter_num`` (non-zero int), only that chapter is
+    returned — enabling single-chapter generation via
+    ``--var chapter_num=5``.
+    """
     chapters = []
     for i, trap in enumerate(_TRAPS, start=1):
         chapters.append(
@@ -186,6 +191,11 @@ def load_trap_list(state: dict[str, Any]) -> dict[str, Any]:
                 "cure": trap["cure"],
             }
         )
+
+    requested = int(state.get("chapter_num") or 0)
+    if requested:
+        chapters = [ch for ch in chapters if ch["chapter_num"] == requested]
+
     return {"trap_chapters": chapters}
 
 
@@ -282,6 +292,10 @@ def _to_str(val: Any) -> str | None:
 def assemble_book(state: dict[str, Any]) -> dict[str, str]:
     """Assemble chapters into a final markdown book.
 
+    For each chapter, prefers a saved file at
+    ``{output_dir}/chapters/ch-{num:02d}-{trap_name}.md`` over the
+    in-state ``chapters`` list — enabling crash-safe incremental runs.
+
     Builds: title page → table of contents (by part) → chapters → epilogue.
     Writes to {output_dir}/philosopher-book.md.
     Returns {"assembled_path": str(path)}.
@@ -317,7 +331,8 @@ def assemble_book(state: dict[str, Any]) -> dict[str, str]:
         )
     lines += ["- Epilogue: The One Law", "", "---", ""]
 
-    # Chapters — pair each chapter metadata with its content
+    # Chapters — prefer saved file, fallback to state list
+    chapters_dir = output_dir / "chapters"
     current_part = None
     for i, ch in enumerate(trap_chapters):
         part = ch.get("part", "")
@@ -325,9 +340,14 @@ def assemble_book(state: dict[str, Any]) -> dict[str, str]:
             lines += [f"# {part}", "", "---", ""]
             current_part = part
 
-        raw = chapters[i] if i < len(chapters) else None
-        # Guard against non-string entries (e.g. skipped map nodes, CopilotResult)
-        chapter_text = _to_str(raw)
+        # Prefer saved file over state
+        saved_path = chapters_dir / f"ch-{ch['chapter_num']:02d}-{ch['trap_name']}.md"
+        if saved_path.exists():
+            chapter_text = saved_path.read_text(encoding="utf-8").strip() or None
+        else:
+            raw = chapters[i] if i < len(chapters) else None
+            chapter_text = _to_str(raw)
+
         if chapter_text:
             lines += [chapter_text, "", "---", ""]
         else:

--- a/feature-requests/FR-404-philosopher-book.md
+++ b/feature-requests/FR-404-philosopher-book.md
@@ -1,0 +1,64 @@
+# FR-404: The Philosopher's Book
+
+**Status:** Approved
+**Priority:** Medium
+**Effort:** Large
+
+## Problem
+
+The Knowledge Graph in `.github/copilot-instructions.md` contains 21 named cognitive traps —
+failure modes discovered through hundreds of AI-assisted development diary entries. These traps
+are currently only present as YAML data in the instructions file. They deserve a richer treatment:
+a philosophical examination of each trap, using the diary itself as primary source material.
+
+## Objective
+
+Generate a 21-chapter philosophical book — one chapter per trap — where each chapter:
+1. Uses real diary entries as primary sources (via `search_diary` tool)
+2. Traces the trap back to the One Law (boundary violation)
+3. Argues why the cure works
+4. Reflects on what the trap reveals about thinking itself
+
+The book arc deepens from mechanical traps (Part I) through architectural, cognitive, adversarial,
+to existential traps (Part V).
+
+## Acceptance Criteria
+
+- [ ] `examples/demos/philosopher_book/` exists with `graph.yaml`, `tools.py`, `prompts/`
+- [ ] `tools.py` exports: `load_trap_list`, `search_diary`, `read_file`, `assemble_book`
+- [ ] `load_trap_list` returns all 21 traps with correct part assignments
+- [ ] `search_diary` searches `docs/diary/*.md` case-insensitively, respects `max_results`
+- [ ] `read_file` validates allowed path prefixes and truncates at 8000 chars
+- [ ] `assemble_book` produces markdown with table of contents and part structure
+- [ ] 10 unit tests pass (REQ-YG-404)
+- [ ] `yamlgraph graph lint` passes
+
+## Implementation Notes
+
+Status updated to Approved. Implementation:
+- `examples/demos/philosopher_book/` — full demo scaffold
+- `tests/unit/test_philosopher_book.py` — 10 unit tests, all passing
+- `capabilities/CAP-150-philosopher-book-demo.yaml` — capability registration
+- REQ-YG-404 registered in ARCHITECTURE.md
+- Changelog fragment at `changelog/unreleased/fr404-philosopher-book.md`
+
+Key decisions:
+- `tools.py` hardcodes the 21 traps (stable data) rather than parsing copilot-instructions dynamically
+- `copilot` nodes with `backend: cli` follow the ebook pipeline pattern exactly
+- `sequential: true` on map node to avoid rate limiting
+- `read_file` validates path prefixes (docs/, .github/, feature-requests/) as security boundary
+
+## Alternatives Considered
+
+**Dynamic parsing of copilot-instructions.md** — rejected because it would add fragile parsing
+logic that breaks if the comment format changes. The 21 traps are stable, well-defined data.
+
+**Parallel map execution** — rejected to avoid API rate limiting over 21 sequential LLM calls.
+
+## Part Assignments
+
+- Part I (Mechanical): downstream_fix, symptom_patch, partial_remediation, regex_fourth_exclusion, false_duplicate, plausible_wrong_answer
+- Part II (Architectural): framework_costume, working_system_inertia, architecture_as_diagram, gate_checks_shape_not_substance, audit_as_ritual
+- Part III (Cognitive): continuation_bias, quick_confidence, intent_drift, recent_changes_blindness
+- Part IV (Adversarial): instruction_boundary_uncrossed, vendor_default_as_help, model_as_trusted_peer, infrastructure_self_exempt
+- Part V (Existential): workspace_is_not_boundary, identity_collapse

--- a/tests/unit/test_philosopher_book.py
+++ b/tests/unit/test_philosopher_book.py
@@ -112,6 +112,56 @@ def test_assemble_book_creates_file(tmp_path):
 
 
 @pytest.mark.req("REQ-YG-404")
+def test_load_trap_list_single_chapter():
+    """chapter_num in state returns only that one chapter."""
+    from examples.demos.philosopher_book.tools import load_trap_list
+
+    result = load_trap_list({"chapter_num": 5})
+    chapters = result["trap_chapters"]
+    assert len(chapters) == 1
+    assert chapters[0]["chapter_num"] == 5
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_load_trap_list_chapter_num_zero_returns_all():
+    """chapter_num=0 (default) returns all 21 chapters."""
+    from examples.demos.philosopher_book.tools import load_trap_list
+
+    result = load_trap_list({"chapter_num": 0})
+    assert len(result["trap_chapters"]) == 21
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_assemble_book_reads_saved_chapter_files(tmp_path):
+    """assemble_book prefers saved chapter files over state list."""
+    from examples.demos.philosopher_book.tools import assemble_book
+
+    chapters_dir = tmp_path / "chapters"
+    chapters_dir.mkdir()
+    (chapters_dir / "ch-01-downstream_fix.md").write_text(
+        "# Chapter 1\n\nSaved content.", encoding="utf-8"
+    )
+
+    state = {
+        "trap_chapters": [
+            {
+                "chapter_num": 1,
+                "trap_name": "downstream_fix",
+                "title": "Where You Guard Is Where You Failed",
+                "part": "Part I",
+            }
+        ],
+        "chapters": ["stale state content"],
+        "epilogue": "",
+        "output_dir": str(tmp_path),
+    }
+    result = assemble_book(state)
+    content = Path(result["assembled_path"]).read_text()
+    assert "Saved content." in content
+    assert "stale state content" not in content
+
+
+@pytest.mark.req("REQ-YG-404")
 def test_assemble_book_includes_toc(tmp_path):
     from examples.demos.philosopher_book.tools import assemble_book
 

--- a/tests/unit/test_philosopher_book.py
+++ b/tests/unit/test_philosopher_book.py
@@ -1,0 +1,139 @@
+"""Tests for FR-404 Philosopher's Book demo tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+DEMO_DIR = ROOT / "examples" / "demos" / "philosopher_book"
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_load_trap_list_returns_21_chapters():
+    from examples.demos.philosopher_book.tools import load_trap_list
+
+    result = load_trap_list({})
+    assert isinstance(result, dict)
+    assert "trap_chapters" in result
+    assert len(result["trap_chapters"]) == 21
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_load_trap_list_part_assignments():
+    from examples.demos.philosopher_book.tools import load_trap_list
+
+    result = load_trap_list({})
+    chapters = result["trap_chapters"]
+    part_i = [c for c in chapters if c["part"] == "Part I"]
+    part_v = [c for c in chapters if c["part"] == "Part V"]
+    assert len(part_i) == 6
+    assert len(part_v) == 2
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_load_trap_list_has_required_keys():
+    from examples.demos.philosopher_book.tools import load_trap_list
+
+    result = load_trap_list({})
+    for ch in result["trap_chapters"]:
+        assert "trap_name" in ch
+        assert "definition" in ch
+        assert "cure" in ch
+        assert "part" in ch
+        assert "chapter_num" in ch
+        assert "title" in ch
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_search_diary_returns_list():
+    from examples.demos.philosopher_book.tools import search_diary
+
+    results = search_diary({}, query="downstream_fix")
+    assert isinstance(results, list)
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_search_diary_max_results():
+    from examples.demos.philosopher_book.tools import search_diary
+
+    results = search_diary({}, query="audit", max_results=3)
+    assert len(results) <= 3
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_read_file_allowed_path():
+    from examples.demos.philosopher_book.tools import read_file
+
+    content = read_file({}, path="docs/letter-to-the-philosopher.md")
+    assert isinstance(content, str)
+    assert len(content) > 0
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_read_file_disallowed_path():
+    from examples.demos.philosopher_book.tools import read_file
+
+    with pytest.raises(ValueError):
+        read_file({}, path="/etc/passwd")
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_read_file_truncates():
+    from examples.demos.philosopher_book.tools import read_file
+
+    # Any large file should be truncated to 8000 chars
+    # Use .github/copilot-instructions.md which is definitely > 8000 chars
+    content = read_file({}, path=".github/copilot-instructions.md")
+    assert len(content) <= 8000
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_assemble_book_creates_file(tmp_path):
+    from examples.demos.philosopher_book.tools import assemble_book
+
+    state = {
+        "trap_chapters": [
+            {
+                "chapter_num": 1,
+                "trap_name": "test_trap",
+                "title": "Test Chapter",
+                "part": "Part I",
+            }
+        ],
+        "chapters": ["# Chapter 1\n\nTest content."],
+        "epilogue": "# Epilogue\n\nThe One Law.",
+        "output_dir": str(tmp_path),
+    }
+    result = assemble_book(state)
+    assert "assembled_path" in result
+    assert Path(result["assembled_path"]).exists()
+
+
+@pytest.mark.req("REQ-YG-404")
+def test_assemble_book_includes_toc(tmp_path):
+    from examples.demos.philosopher_book.tools import assemble_book
+
+    state = {
+        "trap_chapters": [
+            {
+                "chapter_num": 1,
+                "trap_name": "downstream_fix",
+                "title": "Where You Guard Is Where You Failed",
+                "part": "Part I",
+            },
+            {
+                "chapter_num": 2,
+                "trap_name": "symptom_patch",
+                "title": "The Root You Didn't Trace",
+                "part": "Part I",
+            },
+        ],
+        "chapters": ["# Chapter 1\n\nContent.", "# Chapter 2\n\nContent."],
+        "epilogue": "# Epilogue\n\nThe One Law.",
+        "output_dir": str(tmp_path),
+    }
+    result = assemble_book(state)
+    content = Path(result["assembled_path"]).read_text()
+    assert "Table of Contents" in content or "Contents" in content


### PR DESCRIPTION
## FR-404 The Philosopher's Book — A Chapter Per Trap

YAMLGraph pipeline generating a 21-chapter philosophical work, one chapter per cognitive trap from the Knowledge Graph.

### What

- **5-node pipeline**: `load_trap_list` → `plan_book` (copilot) → `write_chapters` (map×21, sequential) → `write_epilogue` (copilot) → `assemble_book`
- **Incremental saving**: each chapter saved to `output_dir/chapters/ch-{num:02d}-{trap_name}.md` — crash-safe for 2-3h runs
- **Single-chapter generation**: `--var chapter_num=5` generates only that chapter
- **`assemble_book`** prefers saved chapter files over state, enabling resume after partial runs
- **Diary search tools**: `search_diary` and `read_file` available to copilot nodes via `allow_all_tools: true`

### Tests

13 unit tests, all green. CAP-150 / REQ-YG-404 coverage confirmed.