### PR TITLE
fix(watcher): FR-410 enforce author identity gate

### DIFF
--- a/.chaplain/actions/git_commit_action.py
+++ b/.chaplain/actions/git_commit_action.py
@@ -13,6 +13,7 @@ Config keys:
 
 import asyncio
 import logging
+import os
 import re
 from typing import Any
 
@@ -23,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 class GitCommitAction(BaseAction):
     """Stage files, check diff, commit, optionally capture fr_path."""
+
+    BLOCKED_AUTHOR_NAME = "Test"
+    BLOCKED_AUTHOR_EMAIL = "test@test.com"
 
     async def execute(self, context: dict[str, Any]) -> str:
         add_paths = self.get_config_value("add_paths", ["."])
@@ -92,6 +96,11 @@ class GitCommitAction(BaseAction):
                         )
                     break
 
+        # Resolve and validate commit identity from repository git config.
+        commit_env = await self._build_commit_env(cwd, machine_name)
+        if commit_env is None:
+            return error_event
+
         # Commit with retry on hook auto-fixes (FR-311)
         for attempt in range(1, max_attempts + 1):
             proc = await asyncio.create_subprocess_exec(
@@ -100,6 +109,7 @@ class GitCommitAction(BaseAction):
                 "-m",
                 message,
                 cwd=cwd,
+                env=commit_env,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -153,3 +163,60 @@ class GitCommitAction(BaseAction):
                 )
 
         return error_event
+
+    async def _resolve_identity(self, cwd: str) -> tuple[str, str]:
+        name = await self._git_config_get(cwd, "user.name")
+        email = await self._git_config_get(cwd, "user.email")
+        return name, email
+
+    async def _build_commit_env(self, cwd: str, machine_name: str) -> dict | None:
+        author_name, author_email = await self._resolve_identity(cwd)
+        if not author_name:
+            logger.error(
+                f"[{machine_name}] Missing git user.name in {cwd}. "
+                'Run: git config user.name "Your Name"'
+            )
+            return None
+        if not author_email:
+            logger.error(
+                f"[{machine_name}] Missing git user.email in {cwd}. "
+                'Run: git config user.email "you@example.com"'
+            )
+            return None
+        if (
+            author_name == self.BLOCKED_AUTHOR_NAME
+            or author_email == self.BLOCKED_AUTHOR_EMAIL
+        ):
+            logger.error(
+                f"[{machine_name}] Blocked git identity detected: "
+                f"{author_name} <{author_email}>. "
+                'Run: git config user.name "Your Name" && '
+                'git config user.email "you@example.com"'
+            )
+            return None
+
+        commit_env = os.environ.copy()
+        commit_env.update(
+            {
+                "GIT_AUTHOR_NAME": author_name,
+                "GIT_AUTHOR_EMAIL": author_email,
+                "GIT_COMMITTER_NAME": author_name,
+                "GIT_COMMITTER_EMAIL": author_email,
+            }
+        )
+        return commit_env
+
+    async def _git_config_get(self, cwd: str, key: str) -> str:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "config",
+            "--get",
+            key,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            return ""
+        return stdout.decode().strip()

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -97,6 +97,33 @@ jobs:
 
           echo "✅ No Co-authored-by trailers found"
 
+  author-identity-gate:
+    name: Block placeholder commit authors
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify commit range for blocked author identity
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          BLOCKED_NAME='Test'
+          BLOCKED_EMAIL='test@test.com'
+
+          if git log --format='%an|%ae' "$BASE_SHA..$HEAD_SHA" \
+            | grep -Fxq "${BLOCKED_NAME}|${BLOCKED_EMAIL}"; then
+            echo "::error::Blocked author identity found in commit range: ${BLOCKED_NAME} <${BLOCKED_EMAIL}>"
+            exit 1
+          fi
+
+          echo "✅ No blocked author identities found"
+
   changelog-gate:
     name: Changelog fragment required for feat/fix
     runs-on: ubuntu-latest

--- a/changelog/unreleased/fr-410-watcher-author-identity-gate.md
+++ b/changelog/unreleased/fr-410-watcher-author-identity-gate.md
@@ -1,0 +1,5 @@
+---
+type: fix
+scope: watcher
+---
+- **FR-410 Watcher Author Identity Gate**: Enforced runtime git author identity in watcher commits and added CI `author-identity-gate` to block placeholder commit authors (`Test <test@test.com>`) in PR commit ranges.

--- a/docs/diary/2026-05-19-reflection-fr-410-watcher-author-identity-gate.md
+++ b/docs/diary/2026-05-19-reflection-fr-410-watcher-author-identity-gate.md
@@ -1,0 +1,26 @@
+# Reflection: FR-410 watcher author identity gate
+
+## Context
+
+FR-410 fixed a recurrent authorship defect where watcher-generated commits used placeholder identity (`Test <test@test.com>`). The implementation enforced identity at runtime and at merge boundary in CI.
+
+## Cognitive Process
+
+1. The first trap was file-name anchoring: FR number 407 already existed for an unrelated rejected topic, so creating a new FR file was required instead of mutating historical FR-407.
+2. The second trap was partial remediation: adding only the runtime fix would have left merge-boundary exposure. The dual-boundary design (runtime + CI) avoided that.
+3. The third trap was test illusion: existing retry tests silently assumed no extra subprocess calls. Identity enforcement introduced new `git config` calls, so existing fakes had to be upgraded before meaningful assertions.
+
+## What Worked
+
+1. Exact-match blocklist (`name == Test`, `email == test@test.com`) kept v1 deterministic and low-risk.
+2. Strict env propagation assertions (`GIT_AUTHOR_*` and `GIT_COMMITTER_*`) validated behavior rather than trusting intent.
+3. Running a focused regression slice (`test_commitlint_workflow.py`) after gate changes prevented accidental CI workflow drift.
+
+## Trap and Heuristic
+
+- Trap: `partial_remediation`.
+- Heuristic: "Identity policy must be enforced at both creation boundary and merge boundary; a single boundary is an advisory, not a guardrail."
+
+## Seed
+
+Seed: Can author identity blocking be driven by a single repository-owned policy file consumed by both watcher runtime and CI gates to eliminate drift between enforcement layers?

--- a/feature-requests/FR-410-watcher-author-identity-gate.md
+++ b/feature-requests/FR-410-watcher-author-identity-gate.md
@@ -1,0 +1,195 @@
+# Feature Request: FR-410 enforce watcher git author identity and CI author gate
+
+**Priority:** HIGH
+**Type:** Bug
+**Status:** Implemented
+**Effort:** 0.5 day
+**Requested:** 2026-05-19
+**Judged:** 2026-05-19
+
+## Summary
+
+Fix GitHub issue #407 by hardening watcher commit authorship at runtime and adding a CI gate that rejects PR commit ranges containing blocked placeholder identities (for example `Test <test@test.com>`).
+
+## Value Statement
+
+This closes a recurring provenance and auditability failure where automation-generated commits use placeholder identity and reach mainline history. The fix adds defense in depth:
+
+1. Runtime boundary enforcement in watcher commit action.
+2. Merge boundary enforcement in CI.
+
+## Problem
+
+Issue #407 reports that the watcher daemon commits with placeholder identity `Test <test@test.com>` instead of the operator's configured git identity.
+
+Current gaps:
+
+1. The watcher commit action does not explicitly source and enforce identity from repository git config before commit.
+2. CI has no dedicated gate to block PRs containing commits from known placeholder identities.
+
+## Objectives
+
+1. Ensure watcher commit subprocess always uses canonical git identity from repo/worktree git config.
+2. Fail fast when git identity is missing or blocklisted.
+3. Add CI `author-identity-gate` to reject blocked identities in PR commit range.
+4. Keep scope minimal and deterministic.
+
+## Constraints
+
+1. No fallback to synthetic/default identity.
+2. Deterministic checks only (git config, git log, shell matching).
+3. Preserve existing workflow topology; add one focused gate.
+4. Avoid unrelated watcher pipeline refactors.
+
+## Proposed Solution
+
+### Runtime fix: watcher commit action
+
+Update `.chaplain/actions/git_commit_action.py`:
+
+1. Resolve `user.name` and `user.email` via git config in the target `cwd`.
+2. Validate both values are present and non-empty.
+3. Reject blocklisted identities (minimum initial set: `Test`, `test@test.com`).
+4. Pass explicit environment to `git commit` subprocess:
+   - `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`
+   - `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`
+5. Return configured error event when validation fails.
+
+### Pipeline fix: CI author identity gate
+
+Update `.github/workflows/commitlint.yml`:
+
+1. Add job `author-identity-gate` for pull requests.
+2. Scan `BASE_SHA..HEAD_SHA` using `git log --format='%an|%ae'`.
+3. Fail when blocklisted author name/email is present.
+4. Keep gate separate from `copilot-trailer-gate` for clear diagnostics.
+
+## Acceptance Criteria
+
+- [x] **AC-01:** Watcher commit action fails when git `user.name` is missing.
+- [x] **AC-02:** Watcher commit action fails when git `user.email` is missing.
+- [x] **AC-03:** Watcher commit action fails on blocklisted identity (`Test` / `test@test.com`).
+- [x] **AC-04:** Valid identity is propagated to commit subprocess as author+committer env variables.
+- [x] **AC-05:** `author-identity-gate` exists in `commitlint.yml` and scans `BASE_SHA..HEAD_SHA`.
+- [x] **AC-06:** CI fails when PR commit range contains blocked author identity.
+- [x] **AC-07:** CI passes when commit range contains no blocked identities.
+- [x] **AC-08:** Unit tests cover AC-01 through AC-07.
+
+## Test Plan (TDD)
+
+### RED
+
+1. Extend `tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py` with identity validation and env-propagation tests.
+2. Add `tests/unit/test_fr410_ci_author_identity_gate_red.py` for workflow gate behavior.
+
+Planned RED tests:
+
+1. `test_ac01_missing_user_name_fails_before_commit`
+2. `test_ac02_missing_user_email_fails_before_commit`
+3. `test_ac03_blocklisted_identity_fails_before_commit`
+4. `test_ac04_valid_identity_sets_author_and_committer_env`
+5. `test_ac05_workflow_contains_author_identity_gate`
+6. `test_ac06_gate_rejects_blocklisted_identity_in_commit_range`
+7. `test_ac07_gate_allows_clean_commit_range`
+
+RED command:
+
+```bash
+pytest tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py tests/unit/test_fr410_ci_author_identity_gate_red.py -q --no-cov
+```
+
+### GREEN
+
+1. Implement watcher identity enforcement.
+2. Implement CI author identity gate.
+3. Update and pass tests.
+
+### Verification
+
+```bash
+pytest tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py tests/unit/test_fr410_ci_author_identity_gate_red.py -q --no-cov
+pytest tests/unit/test_commitlint_workflow.py -q --no-cov
+```
+
+## Files Expected to Change
+
+1. `.chaplain/actions/git_commit_action.py`
+2. `.github/workflows/commitlint.yml`
+3. `tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py`
+4. `tests/unit/test_fr410_ci_author_identity_gate_red.py` (new)
+5. `changelog/unreleased/*.md` fragment for this fix
+6. `docs/diary/*` reflection entry
+
+## Risks and Mitigations
+
+1. **Risk:** Overbroad matching blocks valid authors.
+   **Mitigation:** Start with exact blocked values and add tests for clean pass.
+2. **Risk:** Runtime checks fail on misconfigured local repos.
+   **Mitigation:** Fail fast with explicit error message and remediation hint.
+3. **Risk:** Policy overlap confusion with trailer gate.
+   **Mitigation:** Keep separate gate names and error reasons.
+
+## Alternatives Considered
+
+1. **Runtime-only fix**
+   Rejected: merge-boundary bypass remains possible.
+2. **CI-only fix**
+   Rejected: invalid commits still get created locally by watcher.
+3. **Fallback default identity**
+   Rejected: recreates the core defect pattern.
+
+## Implementation Checklist
+
+- [x] Add RED tests for runtime identity enforcement
+- [x] Add RED tests for CI author identity gate
+- [x] Implement runtime fix (GREEN)
+- [x] Implement CI gate (GREEN)
+- [x] Run targeted tests
+- [x] Add changelog fragment
+- [x] Add diary reflection with Seed
+
+## Related
+
+1. GitHub issue #407: <https://github.com/sheikkinen/yamlgraph/issues/407>
+2. Existing watcher commit retry tests: `tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py`
+3. CI workflow: `.github/workflows/commitlint.yml`
+4. Prior related gate work: `feature-requests/FR-409-ci-coauthored-by-gate-generalization.md`
+
+## Judgement
+
+**Verdict: APPROVED WITH AMENDMENTS**
+
+The problem is real, recurrent, and already evidenced in repository history. The proposed two-boundary design (runtime + CI) is minimal, deterministic, and aligned with doctrine.
+
+Required amendments before implementation:
+
+1. **Blocklist contract must be explicit and exact-match first.**
+   Define exact blocked values for this FR (`name == "Test"`, `email == "test@test.com"`) and avoid broad substring matching in v1.
+2. **Runtime failure must include actionable remediation text.**
+   When identity is missing/blocked, return error output that tells operator exactly which git config commands to run.
+3. **CI gate must validate commit range only, not PR body.**
+   This FR targets author identity in commit metadata; keep trailer/body policy in FR-409 scope.
+4. **Test assertion for env propagation must be strict.**
+   Validate both author and committer env vars are present and equal to resolved git config values.
+
+Scope freeze:
+
+1. In scope: `.chaplain/actions/git_commit_action.py`, `.github/workflows/commitlint.yml`, targeted tests, changelog fragment, diary reflection.
+2. Out of scope: generalized identity policy expansion, commit-msg hook redesign, unrelated watcher pipeline refactors.
+
+Authority granted to implement RED -> GREEN under this FR.
+
+## Implementation Notes
+
+Implemented in worktree `feat/watcher2-gh-407`:
+
+1. Added strict runtime identity resolution and validation in `.chaplain/actions/git_commit_action.py`.
+2. Added explicit author+committer env propagation on `git commit` subprocess calls.
+3. Added CI job `author-identity-gate` in `.github/workflows/commitlint.yml` using exact-match blocked identity check on `BASE_SHA..HEAD_SHA` commit range.
+4. Extended runtime tests in `tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py` for missing name/email, blocklisted identity, and env propagation.
+5. Added CI gate acceptance tests in `tests/unit/test_fr410_ci_author_identity_gate_red.py`.
+
+Verification evidence:
+
+1. `pytest tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py tests/unit/test_fr410_ci_author_identity_gate_red.py -q --no-cov` -> `10 passed`
+2. `pytest tests/unit/test_commitlint_workflow.py -q --no-cov` -> `13 passed`

--- a/tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py
+++ b/tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py
@@ -82,6 +82,10 @@ class TestFR311GitCommitHookRetry:
             argv = list(cmd)
             calls.append(argv)
 
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(0, stdout="Sheikki\n")
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(0, stdout="sheikki@example.com\n")
             if argv[:2] == ["git", "add"]:
                 return _FakeProcess(0)
             if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
@@ -120,6 +124,10 @@ class TestFR311GitCommitHookRetry:
             argv = list(cmd)
             calls.append(argv)
 
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(0, stdout="Sheikki\n")
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(0, stdout="sheikki@example.com\n")
             if argv[:2] == ["git", "add"]:
                 return _FakeProcess(0)
             if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
@@ -162,6 +170,10 @@ class TestFR311GitCommitHookRetry:
             argv = list(cmd)
             calls.append(argv)
 
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(0, stdout="Sheikki\n")
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(0, stdout="sheikki@example.com\n")
             if argv[:2] == ["git", "add"]:
                 return _FakeProcess(0)
             if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
@@ -182,3 +194,124 @@ class TestFR311GitCommitHookRetry:
         assert event == "error"
         assert len(commit_calls) == 1, "Genuine failures should not trigger retry loop"
         assert not any(c[:3] == ["git", "add", "-u"] for c in calls)
+
+    def test_ac05_missing_user_name_fails_before_commit(self, monkeypatch):
+        action = _build_action(monkeypatch)
+        calls: list[list[str]] = []
+
+        async def fake_create_subprocess_exec(*cmd, **_kwargs):
+            argv = list(cmd)
+            calls.append(argv)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(1)
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(0, stdout="sheikki@example.com\n")
+            if argv[:2] == ["git", "commit"]:
+                return _FakeProcess(0, stdout="unexpected commit\n")
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        assert event == "error"
+        assert not any(c[:2] == ["git", "commit"] for c in calls)
+
+    def test_ac06_missing_user_email_fails_before_commit(self, monkeypatch):
+        action = _build_action(monkeypatch)
+        calls: list[list[str]] = []
+
+        async def fake_create_subprocess_exec(*cmd, **_kwargs):
+            argv = list(cmd)
+            calls.append(argv)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(0, stdout="Sheikki\n")
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(1)
+            if argv[:2] == ["git", "commit"]:
+                return _FakeProcess(0, stdout="unexpected commit\n")
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        assert event == "error"
+        assert not any(c[:2] == ["git", "commit"] for c in calls)
+
+    def test_ac07_blocklisted_identity_fails_before_commit(self, monkeypatch):
+        action = _build_action(monkeypatch)
+        calls: list[list[str]] = []
+
+        async def fake_create_subprocess_exec(*cmd, **_kwargs):
+            argv = list(cmd)
+            calls.append(argv)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(0, stdout="Test\n")
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(0, stdout="test@test.com\n")
+            if argv[:2] == ["git", "commit"]:
+                return _FakeProcess(0, stdout="unexpected commit\n")
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        assert event == "error"
+        assert not any(c[:2] == ["git", "commit"] for c in calls)
+
+    def test_ac08_valid_identity_sets_author_and_committer_env(self, monkeypatch):
+        action = _build_action(monkeypatch)
+        commit_env: dict | None = None
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            nonlocal commit_env
+            argv = list(cmd)
+
+            if argv[:2] == ["git", "add"]:
+                return _FakeProcess(0)
+            if argv[:4] == ["git", "diff", "--cached", "--quiet"]:
+                return _FakeProcess(1)
+            if argv[:4] == ["git", "config", "--get", "user.name"]:
+                return _FakeProcess(0, stdout="Sheikki\n")
+            if argv[:4] == ["git", "config", "--get", "user.email"]:
+                return _FakeProcess(0, stdout="sheikki@example.com\n")
+            if argv[:2] == ["git", "commit"]:
+                commit_env = kwargs.get("env")
+                return _FakeProcess(0, stdout="[main abc123] commit ok\n")
+            return _FakeProcess(0)
+
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", fake_create_subprocess_exec
+        )
+
+        event = asyncio.run(action.execute({"wt_dir": "."}))
+
+        assert event == "committed"
+        assert commit_env is not None
+        assert commit_env.get("GIT_AUTHOR_NAME") == "Sheikki"
+        assert commit_env.get("GIT_AUTHOR_EMAIL") == "sheikki@example.com"
+        assert commit_env.get("GIT_COMMITTER_NAME") == "Sheikki"
+        assert commit_env.get("GIT_COMMITTER_EMAIL") == "sheikki@example.com"

--- a/tests/unit/test_fr410_ci_author_identity_gate_red.py
+++ b/tests/unit/test_fr410_ci_author_identity_gate_red.py
@@ -1,0 +1,134 @@
+"""Acceptance tests for FR-410 CI author identity gate."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(".github/workflows/commitlint.yml")
+
+
+def _load_workflow() -> dict:
+    with WORKFLOW_PATH.open() as f:
+        return yaml.safe_load(f)
+
+
+def _gate_run_script() -> str:
+    job = _load_workflow()["jobs"].get("author-identity-gate")
+    assert job is not None, "author-identity-gate job must exist"
+
+    verify_steps = [
+        step
+        for step in job.get("steps", [])
+        if "run" in step and "author identity" in step.get("name", "").lower()
+    ]
+    assert verify_steps, "author-identity-gate must include a verification step"
+    return str(verify_steps[0]["run"])
+
+
+def _setup_git_repo(tmpdir: str) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmpdir, check=True)
+
+
+def _commit_as(tmpdir: str, *, name: str, email: str, message: str, index: int) -> None:
+    tmppath = Path(tmpdir)
+    file_path = tmppath / f"src/file_{index}.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(f"change {index}\n")
+    subprocess.run(["git", "add", "."], cwd=tmpdir, check=True)
+
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = name
+    env["GIT_AUTHOR_EMAIL"] = email
+    env["GIT_COMMITTER_NAME"] = name
+    env["GIT_COMMITTER_EMAIL"] = email
+
+    msg_file = tmppath / f"msg_{index}.txt"
+    msg_file.write_text(message)
+    subprocess.run(
+        ["git", "commit", "-q", "-F", str(msg_file)], cwd=tmpdir, check=True, env=env
+    )
+
+
+def _run_author_identity_gate(
+    head_author: tuple[str, str],
+) -> subprocess.CompletedProcess:
+    run_script = _gate_run_script()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _setup_git_repo(tmpdir)
+
+        _commit_as(
+            tmpdir,
+            name="Valid User",
+            email="valid@example.com",
+            message="base",
+            index=0,
+        )
+        base_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        _commit_as(
+            tmpdir,
+            name=head_author[0],
+            email=head_author[1],
+            message="head",
+            index=1,
+        )
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=tmpdir,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+
+        env = os.environ.copy()
+        env["BASE_SHA"] = base_sha
+        env["HEAD_SHA"] = head_sha
+        env["PATH"] = "/usr/bin:/bin"
+
+        return subprocess.run(
+            ["bash", "-lc", run_script],
+            capture_output=True,
+            text=True,
+            cwd=tmpdir,
+            env=env,
+        )
+
+
+@pytest.mark.req("REQ-YG-002")
+def test_ac05_workflow_contains_author_identity_gate() -> None:
+    wf = _load_workflow()
+    assert "author-identity-gate" in wf["jobs"]
+
+    script = _gate_run_script()
+    assert "BASE_SHA" in script
+    assert "HEAD_SHA" in script
+    assert "git log" in script
+    assert "test@test.com" in script
+
+
+@pytest.mark.req("REQ-YG-002")
+def test_ac06_gate_rejects_blocklisted_identity_in_commit_range() -> None:
+    result = _run_author_identity_gate(("Test", "test@test.com"))
+    assert result.returncode == 1
+    output = (result.stdout + result.stderr).lower()
+    assert "blocked" in output or "author" in output
+
+
+@pytest.mark.req("REQ-YG-002")
+def test_ac07_gate_allows_clean_commit_range() -> None:
+    result = _run_author_identity_gate(("Another User", "another@example.com"))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no blocked author identities" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- enforce watcher commit identity from git config in GitCommitAction
- block placeholder identity Test <test@test.com> at runtime
- add author-identity-gate in commitlint workflow for PR commit ranges
- add FR-410 tests, changelog fragment, and diary reflection

## Validation
- /Users/sheikki/Documents/src/yamlgraph/.venv/bin/python -m pytest tests/unit/test_fr311_watcher2_git_commit_hook_fix_retry.py tests/unit/test_fr410_ci_author_identity_gate_red.py tests/unit/test_commitlint_workflow.py -q --no-cov

Closes #407